### PR TITLE
Add reusable composite action for GitHub Marketplace publishing

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,8 +1,9 @@
-name: AtlaSent Deploy Gate
+name: AtlaSent Deploy Gate (Demo)
 
-# Triggers:
-#   - Automatically on every push to main
-#   - Manually via workflow_dispatch (with optional "force denial" toggle)
+# Demo workflow showing how to use AtlaSent Action to gate deployments.
+# This workflow uses the local action (uses: ./) for dogfooding.
+# In your own repo, replace with: uses: AtlaSent-Systems-Inc/atlasent-action@v1
+
 on:
   push:
     branches: [main]
@@ -13,225 +14,37 @@ on:
         required: false
         type: boolean
         default: false
-
-env:
-  ATLASENT_BASE_URL: https://ducfnmhveikymmgwpgcd.supabase.co/functions/v1
-  ATLASENT_ANON_KEY: ${{ vars.ATLASENT_ANON_KEY }}
+      environment:
+        description: 'Target environment'
+        required: false
+        type: choice
+        options:
+          - prod
+          - staging
+        default: prod
 
 jobs:
-  atlasent-deploy-gate:
+  deploy:
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install jq (required)
-        run: sudo apt-get update && sudo apt-get install -y jq
+      # Gate the deployment through AtlaSent
+      - name: AtlaSent authorization gate
+        id: gate
+        uses: ./
+        with:
+          action_type: production.deploy
+          environment: ${{ inputs.environment || 'prod' }}
+          approvals: ${{ inputs.force_denial == true && '0' || '2' }}
+          change_window: ${{ inputs.force_denial == true && 'false' || 'true' }}
+          atlasent_api_key: ${{ secrets.ATLASENT_API_KEY }}
+          atlasent_anon_key: ${{ vars.ATLASENT_ANON_KEY }}
 
-      # ────────────────────────────────────────────────────────────────────────
-      # Step 1: EVALUATE
-      # Ask AtlaSent: "Should this deployment be allowed?"
-      # Sends the action type, actor, and full deployment context.
-      # Returns a single-use permit token if allowed, or a denial with reason.
-      # ────────────────────────────────────────────────────────────────────────
-      - name: 'Step 1: Evaluate — request authorization'
-        id: eval
-        env:
-          ATLASENT_API_KEY: ${{ secrets.ATLASENT_API_KEY }}
-          FORCE_DENIAL: ${{ inputs.force_denial || 'false' }}
+      # Only reached if AtlaSent allowed and verified the action
+      - name: Deploy to ${{ inputs.environment || 'prod' }}
         run: |
-          set -euo pipefail
-          : "${ATLASENT_API_KEY:?Missing secret ATLASENT_API_KEY}"
-          : "${ATLASENT_ANON_KEY:?Missing variable ATLASENT_ANON_KEY (public anon key)}"
-
-          REQUEST_ID="github-eval-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-
-          # When force_denial is true, set context values that violate the policy
-          if [ "$FORCE_DENIAL" = "true" ]; then
-            echo "::notice::Force denial enabled — sending approvals=0, change_window=false"
-            APPROVALS=0
-            CHANGE_WINDOW=false
-          else
-            APPROVALS=2
-            CHANGE_WINDOW=true
-          fi
-
-          # Build the evaluate request
-          BODY=$(jq -nc \
-            --arg action_type "production.deploy" \
-            --arg actor_id "github:${GITHUB_ACTOR}" \
-            --arg request_id "$REQUEST_ID" \
-            --arg env "prod" \
-            --arg repo "${GITHUB_REPOSITORY}" \
-            --arg sha "${GITHUB_SHA}" \
-            --arg ref "${GITHUB_REF}" \
-            --arg run_id "${GITHUB_RUN_ID}" \
-            --argjson approvals "$APPROVALS" \
-            --argjson change_window "$CHANGE_WINDOW" \
-            '{
-              action_type: $action_type,
-              actor_id: $actor_id,
-              request_id: $request_id,
-              context: {
-                environment: $env,
-                approvals: $approvals,
-                change_window: $change_window,
-                repo: $repo,
-                sha: $sha,
-                ref: $ref,
-                run_id: $run_id
-              }
-            }')
-
-          # Send to AtlaSent
-          RESP=$(curl -sS -i --max-time 30 \
-            -X POST "${ATLASENT_BASE_URL}/v1-evaluate" \
-            -H "Content-Type: application/json" \
-            -H "Authorization: Bearer ${ATLASENT_API_KEY}" \
-            -H "apikey: ${ATLASENT_ANON_KEY}" \
-            -d "${BODY}")
-
-          echo "---- EVAL RAW RESPONSE ----"
-          echo "$RESP"
-          echo "---------------------------"
-
-          # Check HTTP status — fail-closed on any non-success code
-          HTTP_CODE=$(echo "$RESP" | head -n 1 | awk '{print $2}')
-          if [ "$HTTP_CODE" != "200" ] && [ "$HTTP_CODE" != "201" ] && [ "$HTTP_CODE" != "204" ]; then
-            echo "::error::Evaluate returned HTTP $HTTP_CODE — BLOCKED (fail-closed)"
-            exit 1
-          fi
-
-          # Parse the JSON response body
-          JSON=$(echo "$RESP" | awk 'BEGIN{h=1} /^\r?$/{h=0; next} {if(!h) print}')
-          DECISION=$(echo "$JSON" | jq -r '.decision // empty')
-
-          if [ -z "$DECISION" ]; then
-            echo "::error::Evaluate missing decision — BLOCKED"
-            echo "$JSON" | jq . || true
-            exit 1
-          fi
-
-          # Deny — log the reason and block the deploy
-          if [ "$DECISION" != "allow" ]; then
-            CODE=$(echo "$JSON" | jq -r '.error_code // .deny_code // "unknown"')
-            REASON=$(echo "$JSON" | jq -r '.reason // .deny_reason // "no reason provided"')
-            echo "::error::BLOCKED by evaluate decision=$DECISION code=$CODE reason=$REASON"
-            exit 1
-          fi
-
-          # Allow — extract the single-use permit token
-          PERMIT_TOKEN=$(echo "$JSON" | jq -r '.permit_token // .permit // empty')
-          if [ -z "$PERMIT_TOKEN" ] || [ "$PERMIT_TOKEN" = "null" ]; then
-            echo "::error::Allowed but missing permit_token — BLOCKED"
-            exit 1
-          fi
-
-          echo "permit_token=$PERMIT_TOKEN" >> $GITHUB_OUTPUT
-          echo "request_id=$REQUEST_ID" >> $GITHUB_OUTPUT
-
-      # ────────────────────────────────────────────────────────────────────────
-      # Step 2: VERIFY
-      # At execution time, confirm the permit is still valid.
-      # This closes the gap between approval and execution — if the context
-      # changed, the permit was tampered with, or it expired, this fails.
-      # ────────────────────────────────────────────────────────────────────────
-      - name: 'Step 2: Verify — confirm permit at execution time'
-        env:
-          ATLASENT_API_KEY: ${{ secrets.ATLASENT_API_KEY }}
-          PERMIT_TOKEN: ${{ steps.eval.outputs.permit_token }}
-          EVAL_REQUEST_ID: ${{ steps.eval.outputs.request_id }}
-        run: |
-          set -euo pipefail
-          : "${ATLASENT_API_KEY:?Missing secret ATLASENT_API_KEY}"
-          : "${ATLASENT_ANON_KEY:?Missing variable ATLASENT_ANON_KEY}"
-          : "${PERMIT_TOKEN:?Missing permit token from evaluate}"
-
-          VERIFY_ID="verify-${EVAL_REQUEST_ID}"
-
-          # Build the verify request — same context as evaluate
-          BODY=$(jq -nc \
-            --arg permit_token "${PERMIT_TOKEN}" \
-            --arg action_type "production.deploy" \
-            --arg actor_id "github:${GITHUB_ACTOR}" \
-            --arg environment "prod" \
-            --arg request_id "${VERIFY_ID}" \
-            --arg env "prod" \
-            --arg repo "${GITHUB_REPOSITORY}" \
-            --arg sha "${GITHUB_SHA}" \
-            --arg ref "${GITHUB_REF}" \
-            --arg run_id "${GITHUB_RUN_ID}" \
-            --argjson approvals 2 \
-            --argjson change_window true \
-            '{
-              permit_token: $permit_token,
-              action_type: $action_type,
-              actor_id: $actor_id,
-              environment: $environment,
-              request_id: $request_id,
-              context: {
-                environment: $env,
-                approvals: $approvals,
-                change_window: $change_window,
-                repo: $repo,
-                sha: $sha,
-                ref: $ref,
-                run_id: $run_id
-              }
-            }')
-
-          # Send to AtlaSent
-          RESP=$(curl -sS -i --max-time 30 \
-            -X POST "${ATLASENT_BASE_URL}/v1-verify-permit" \
-            -H "Content-Type: application/json" \
-            -H "Authorization: Bearer ${ATLASENT_API_KEY}" \
-            -H "apikey: ${ATLASENT_ANON_KEY}" \
-            -d "${BODY}")
-
-          echo "---- VERIFY RAW RESPONSE ----"
-          echo "$RESP"
-          echo "-----------------------------"
-
-          # Check HTTP status — fail-closed
-          HTTP_CODE=$(echo "$RESP" | head -n 1 | awk '{print $2}')
-          if [ "$HTTP_CODE" != "200" ] && [ "$HTTP_CODE" != "201" ] && [ "$HTTP_CODE" != "204" ]; then
-            echo "::error::Verify returned HTTP $HTTP_CODE — BLOCKED (fail-closed)"
-            exit 1
-          fi
-
-          # Parse response
-          JSON=$(echo "$RESP" | awk 'BEGIN{h=1} /^\r?$/{h=0; next} {if(!h) print}')
-          OUTCOME=$(echo "$JSON" | jq -r '.outcome // .decision // empty')
-          VALID=$(echo "$JSON" | jq -r '.valid // empty')
-
-          # Explicit invalid — permit was tampered with, expired, or context changed
-          if [ -n "$VALID" ] && [ "$VALID" != "true" ]; then
-            CODE=$(echo "$JSON" | jq -r '.verify_error_code // .deny_code // "unknown"')
-            REASON=$(echo "$JSON" | jq -r '.reason // .deny_reason // "unknown"')
-            echo "::error::Permit invalid — code=$CODE reason=$REASON"
-            exit 1
-          fi
-
-          if [ -z "$OUTCOME" ]; then
-            echo "::error::Verify missing outcome/decision — BLOCKED"
-            echo "$JSON" | jq . || true
-            exit 1
-          fi
-
-          if [ "$OUTCOME" != "allow" ]; then
-            CODE=$(echo "$JSON" | jq -r '.verify_error_code // .deny_code // "unknown"')
-            REASON=$(echo "$JSON" | jq -r '.reason // .deny_reason // "unknown"')
-            echo "::error::Permit verification FAILED — outcome=$OUTCOME code=$CODE reason=$REASON"
-            exit 1
-          fi
-
-          echo "✅ Permit verified — deploy may proceed"
-
-      # ────────────────────────────────────────────────────────────────────────
-      # Step 3: DEPLOY
-      # Only reached if both evaluate and verify succeeded.
-      # Replace with your real deployment command.
-      # ────────────────────────────────────────────────────────────────────────
-      - name: 'Step 3: Deploy to production'
-        run: |
-          echo "✅ Replace this with your real deploy command"
+          echo "AtlaSent decision: ${{ steps.gate.outputs.decision }}"
+          echo "Permit verified:   ${{ steps.gate.outputs.verified }}"
+          echo ""
+          echo "Replace this with your real deploy command."

--- a/README.md
+++ b/README.md
@@ -1,73 +1,116 @@
-# AtlaSent Deploy Gate Demo
+# AtlaSent Action
 
-A working example of execution-time authorization for production deployments using [AtlaSent](https://atlasent.io). Fork this repo, add your API key, push to `main`, and watch the gate work.
+Official GitHub Action for [AtlaSent](https://atlasent.io) — execution-time authorization for AI agent actions in GxP-regulated life sciences environments.
 
-## What This Does
+Add `uses: AtlaSent-Systems-Inc/atlasent-action@v1` to any workflow to gate agent actions through AtlaSent's evaluate/verify API before they execute. Fail-closed design: if anything goes wrong, the action is blocked.
 
-Every push to `main` triggers a GitHub Actions workflow that gates the deploy through AtlaSent:
-
-1. **Evaluate** — Calls `POST /v1-evaluate` with the deployment context (who, what, where, how many approvals). AtlaSent returns an allow/deny decision and a single-use permit token.
-2. **Verify** — At execution time, calls `POST /v1-verify-permit` to confirm the permit is still valid, unmodified, and contextually correct.
-3. **Deploy** — Proceeds only if verification succeeds. If anything fails, the deploy is blocked (fail-closed).
+## How It Works
 
 ```
-Push to main
-    ↓
+Workflow step triggers
+    |
+    v
 POST /v1-evaluate
-    → Decision: allow
-    → Permit token: ats_permit_a1b2c3...
-    ↓
+    -> Decision: allow
+    -> Permit token: ats_permit_a1b2c3...
+    |
+    v
 POST /v1-verify-permit
-    → Outcome: allow
-    → Valid: true
-    ↓
-Deploy proceeds
-    ↓
+    -> Outcome: allow
+    -> Valid: true
+    |
+    v
+Next step proceeds (deploy, data export, etc.)
+    |
+    v
 Tamper-evident audit trail recorded
 ```
 
-## Try It
+1. **Evaluate** — Sends the action type, actor, and context to AtlaSent. Returns an allow/deny decision and a single-use permit token.
+2. **Verify** — At execution time, confirms the permit is still valid, unmodified, and contextually correct.
+3. **Proceed or block** — Downstream steps only run if both evaluate and verify succeed.
 
-### 1. Fork this repo
+## Quick Start
 
-### 2. Add your credentials
+### 1. Add your credentials
 
-In your fork's Settings → Secrets and variables → Actions:
+In your repo's Settings > Secrets and variables > Actions:
 
 - **Secret:** `ATLASENT_API_KEY` — your AtlaSent API key
 - **Variable:** `ATLASENT_ANON_KEY` — your AtlaSent public anon key
 
 Don't have credentials yet? [Get a sandbox key at atlasent.io](https://atlasent.io)
 
-### 3. Push to main
+### 2. Add the action to your workflow
 
-```bash
-git clone https://github.com/YOUR_ORG/deploy-gate-demo.git
-cd deploy-gate-demo
-echo "trigger" >> trigger.txt
-git add trigger.txt && git commit -m "Test deploy gate"
-git push origin main
+```yaml
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: AtlaSent authorization gate
+        id: gate
+        uses: AtlaSent-Systems-Inc/atlasent-action@v1
+        with:
+          action_type: production.deploy
+          environment: prod
+          approvals: 2
+          change_window: true
+          atlasent_api_key: ${{ secrets.ATLASENT_API_KEY }}
+          atlasent_anon_key: ${{ vars.ATLASENT_ANON_KEY }}
+
+      - name: Deploy
+        run: echo "Deploying — permit verified: ${{ steps.gate.outputs.verified }}"
 ```
 
-### 4. Watch the Actions tab
+## Inputs
 
-Open the Actions tab in your fork. You'll see the workflow:
-- Evaluate step: requesting authorization
-- Verify step: confirming the permit at execution time
-- Deploy step: proceeding (or blocked)
+| Input | Required | Default | Description |
+|---|---|---|---|
+| `action_type` | Yes | — | Action type to evaluate (e.g., `production.deploy`, `data.export`) |
+| `environment` | Yes | `prod` | Target environment (e.g., `prod`, `staging`) |
+| `approvals` | No | `0` | Number of approvals obtained |
+| `change_window` | No | `false` | Whether the action is within an approved change window |
+| `atlasent_api_key` | Yes | — | AtlaSent API key (use a GitHub secret) |
+| `atlasent_anon_key` | Yes | — | AtlaSent public anon key |
+| `atlasent_base_url` | No | *(production)* | AtlaSent API base URL |
+
+## Outputs
+
+| Output | Description |
+|---|---|
+| `decision` | The evaluate decision (`allow` or `deny`) |
+| `permit_token` | Single-use permit token (only set when decision is `allow`) |
+| `verified` | Whether the permit was verified at execution time (`true`/`false`) |
 
 ## Testing a Denial
 
-Use the manual workflow dispatch to trigger a deliberate denial. Go to Actions → AtlaSent Deploy Gate → Run workflow, and select **"Force a denial"**.
+Use the included demo workflow with `force_denial: true` to trigger a deliberate denial. Go to Actions > AtlaSent Deploy Gate (Demo) > Run workflow, and check "Force a denial".
 
-This sets `approvals: 0` and `change_window: false`, which violates the policy. You'll see:
+This sets `approvals: 0` and `change_window: false`, which violates the policy:
 
 ```
 Decision: deny
 Reason:   insufficient approvals and outside change window
 ```
 
-This is the expected behavior — AtlaSent blocks actions that don't meet policy requirements.
+## Multi-Environment Support
+
+Gate different environments with different contexts:
+
+```yaml
+- name: Gate staging deploy
+  uses: AtlaSent-Systems-Inc/atlasent-action@v1
+  with:
+    action_type: staging.deploy
+    environment: staging
+    approvals: 1
+    change_window: true
+    atlasent_api_key: ${{ secrets.ATLASENT_API_KEY }}
+    atlasent_anon_key: ${{ vars.ATLASENT_ANON_KEY }}
+```
 
 ## Sample API Responses
 
@@ -76,18 +119,6 @@ See the [`docs/`](./docs/) directory for captured examples of every API response
 - [`docs/evaluate-allow.json`](./docs/evaluate-allow.json) — Successful evaluation (action allowed)
 - [`docs/evaluate-deny.json`](./docs/evaluate-deny.json) — Evaluation denied (policy violation)
 - [`docs/verify-allow.json`](./docs/verify-allow.json) — Permit verified at execution time
-
-## How the Workflow Works
-
-The workflow (`.github/workflows/deploy.yaml`) does three things:
-
-**Step 1 — Evaluate:** Builds a JSON request with the action type (`production.deploy`), actor, and context (environment, approvals count, change window status, repo, SHA, ref). Sends it to `/v1-evaluate`. If the decision is `allow`, extracts the `permit_token` for the next step.
-
-**Step 2 — Verify:** Takes the permit token from Step 1 and sends it to `/v1-verify-permit` along with the same action context. This confirms the permit hasn't been tampered with and the context hasn't changed between evaluation and execution.
-
-**Step 3 — Deploy:** Placeholder for your real deployment command. Only reached if both evaluate and verify succeed.
-
-Both steps are **fail-closed** — any error (network failure, unexpected response, missing fields) blocks the deploy.
 
 ## More Resources
 

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,237 @@
+name: 'AtlaSent Action'
+description: 'Execution-time authorization for AI agent actions in GxP-regulated life sciences environments'
+author: 'AtlaSent Systems, Inc.'
+
+branding:
+  icon: 'shield'
+  color: 'blue'
+
+inputs:
+  action_type:
+    description: 'The action type to evaluate (e.g., production.deploy, data.export)'
+    required: true
+  environment:
+    description: 'Target environment (e.g., prod, staging)'
+    required: true
+    default: 'prod'
+  approvals:
+    description: 'Number of approvals obtained for this action'
+    required: false
+    default: '0'
+  change_window:
+    description: 'Whether the action is within an approved change window'
+    required: false
+    default: 'false'
+  atlasent_api_key:
+    description: 'AtlaSent API key (use a GitHub secret)'
+    required: true
+  atlasent_anon_key:
+    description: 'AtlaSent public anon key'
+    required: true
+  atlasent_base_url:
+    description: 'AtlaSent API base URL'
+    required: false
+    default: 'https://ducfnmhveikymmgwpgcd.supabase.co/functions/v1'
+
+outputs:
+  decision:
+    description: 'The evaluate decision (allow or deny)'
+    value: ${{ steps.eval.outputs.decision }}
+  permit_token:
+    description: 'Single-use permit token (only set when decision is allow)'
+    value: ${{ steps.eval.outputs.permit_token }}
+  verified:
+    description: 'Whether the permit was verified at execution time (true/false)'
+    value: ${{ steps.verify.outputs.verified }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Install jq
+      shell: bash
+      run: |
+        if ! command -v jq &>/dev/null; then
+          sudo apt-get update -qq && sudo apt-get install -y -qq jq
+        fi
+
+    - name: 'Evaluate — request authorization'
+      id: eval
+      shell: bash
+      env:
+        ATLASENT_API_KEY: ${{ inputs.atlasent_api_key }}
+        ATLASENT_ANON_KEY: ${{ inputs.atlasent_anon_key }}
+        ATLASENT_BASE_URL: ${{ inputs.atlasent_base_url }}
+        INPUT_ACTION_TYPE: ${{ inputs.action_type }}
+        INPUT_ENVIRONMENT: ${{ inputs.environment }}
+        INPUT_APPROVALS: ${{ inputs.approvals }}
+        INPUT_CHANGE_WINDOW: ${{ inputs.change_window }}
+      run: |
+        set -euo pipefail
+        : "${ATLASENT_API_KEY:?Missing input: atlasent_api_key}"
+        : "${ATLASENT_ANON_KEY:?Missing input: atlasent_anon_key}"
+
+        REQUEST_ID="github-eval-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+
+        BODY=$(jq -nc \
+          --arg action_type "$INPUT_ACTION_TYPE" \
+          --arg actor_id "github:${GITHUB_ACTOR}" \
+          --arg request_id "$REQUEST_ID" \
+          --arg env "$INPUT_ENVIRONMENT" \
+          --arg repo "${GITHUB_REPOSITORY}" \
+          --arg sha "${GITHUB_SHA}" \
+          --arg ref "${GITHUB_REF}" \
+          --arg run_id "${GITHUB_RUN_ID}" \
+          --argjson approvals "$INPUT_APPROVALS" \
+          --argjson change_window "$INPUT_CHANGE_WINDOW" \
+          '{
+            action_type: $action_type,
+            actor_id: $actor_id,
+            request_id: $request_id,
+            context: {
+              environment: $env,
+              approvals: $approvals,
+              change_window: $change_window,
+              repo: $repo,
+              sha: $sha,
+              ref: $ref,
+              run_id: $run_id
+            }
+          }')
+
+        RESP=$(curl -sS -i --max-time 30 \
+          -X POST "${ATLASENT_BASE_URL}/v1-evaluate" \
+          -H "Content-Type: application/json" \
+          -H "Authorization: Bearer ${ATLASENT_API_KEY}" \
+          -H "apikey: ${ATLASENT_ANON_KEY}" \
+          -d "${BODY}")
+
+        # Check HTTP status — fail-closed on any non-success code
+        HTTP_CODE=$(echo "$RESP" | head -n 1 | awk '{print $2}')
+        if [ "$HTTP_CODE" != "200" ] && [ "$HTTP_CODE" != "201" ] && [ "$HTTP_CODE" != "204" ]; then
+          echo "::error::AtlaSent evaluate returned HTTP $HTTP_CODE — BLOCKED (fail-closed)"
+          exit 1
+        fi
+
+        # Parse the JSON response body
+        JSON=$(echo "$RESP" | awk 'BEGIN{h=1} /^\r?$/{h=0; next} {if(!h) print}')
+        DECISION=$(echo "$JSON" | jq -r '.decision // empty')
+
+        if [ -z "$DECISION" ]; then
+          echo "::error::AtlaSent evaluate missing decision — BLOCKED"
+          echo "$JSON" | jq . || true
+          exit 1
+        fi
+
+        echo "decision=$DECISION" >> $GITHUB_OUTPUT
+        echo "request_id=$REQUEST_ID" >> $GITHUB_OUTPUT
+
+        if [ "$DECISION" != "allow" ]; then
+          CODE=$(echo "$JSON" | jq -r '.error_code // .deny_code // "unknown"')
+          REASON=$(echo "$JSON" | jq -r '.reason // .deny_reason // "no reason provided"')
+          echo "::error::BLOCKED by AtlaSent — decision=$DECISION code=$CODE reason=$REASON"
+          exit 1
+        fi
+
+        PERMIT_TOKEN=$(echo "$JSON" | jq -r '.permit_token // .permit // empty')
+        if [ -z "$PERMIT_TOKEN" ] || [ "$PERMIT_TOKEN" = "null" ]; then
+          echo "::error::AtlaSent allowed but missing permit_token — BLOCKED"
+          exit 1
+        fi
+
+        echo "permit_token=$PERMIT_TOKEN" >> $GITHUB_OUTPUT
+
+    - name: 'Verify — confirm permit at execution time'
+      id: verify
+      shell: bash
+      env:
+        ATLASENT_API_KEY: ${{ inputs.atlasent_api_key }}
+        ATLASENT_ANON_KEY: ${{ inputs.atlasent_anon_key }}
+        ATLASENT_BASE_URL: ${{ inputs.atlasent_base_url }}
+        PERMIT_TOKEN: ${{ steps.eval.outputs.permit_token }}
+        EVAL_REQUEST_ID: ${{ steps.eval.outputs.request_id }}
+        INPUT_ACTION_TYPE: ${{ inputs.action_type }}
+        INPUT_ENVIRONMENT: ${{ inputs.environment }}
+        INPUT_APPROVALS: ${{ inputs.approvals }}
+        INPUT_CHANGE_WINDOW: ${{ inputs.change_window }}
+      run: |
+        set -euo pipefail
+        : "${ATLASENT_API_KEY:?Missing input: atlasent_api_key}"
+        : "${ATLASENT_ANON_KEY:?Missing input: atlasent_anon_key}"
+        : "${PERMIT_TOKEN:?Missing permit token from evaluate step}"
+
+        VERIFY_ID="verify-${EVAL_REQUEST_ID}"
+
+        BODY=$(jq -nc \
+          --arg permit_token "${PERMIT_TOKEN}" \
+          --arg action_type "$INPUT_ACTION_TYPE" \
+          --arg actor_id "github:${GITHUB_ACTOR}" \
+          --arg environment "$INPUT_ENVIRONMENT" \
+          --arg request_id "${VERIFY_ID}" \
+          --arg env "$INPUT_ENVIRONMENT" \
+          --arg repo "${GITHUB_REPOSITORY}" \
+          --arg sha "${GITHUB_SHA}" \
+          --arg ref "${GITHUB_REF}" \
+          --arg run_id "${GITHUB_RUN_ID}" \
+          --argjson approvals "$INPUT_APPROVALS" \
+          --argjson change_window "$INPUT_CHANGE_WINDOW" \
+          '{
+            permit_token: $permit_token,
+            action_type: $action_type,
+            actor_id: $actor_id,
+            environment: $environment,
+            request_id: $request_id,
+            context: {
+              environment: $env,
+              approvals: $approvals,
+              change_window: $change_window,
+              repo: $repo,
+              sha: $sha,
+              ref: $ref,
+              run_id: $run_id
+            }
+          }')
+
+        RESP=$(curl -sS -i --max-time 30 \
+          -X POST "${ATLASENT_BASE_URL}/v1-verify-permit" \
+          -H "Content-Type: application/json" \
+          -H "Authorization: Bearer ${ATLASENT_API_KEY}" \
+          -H "apikey: ${ATLASENT_ANON_KEY}" \
+          -d "${BODY}")
+
+        # Check HTTP status — fail-closed
+        HTTP_CODE=$(echo "$RESP" | head -n 1 | awk '{print $2}')
+        if [ "$HTTP_CODE" != "200" ] && [ "$HTTP_CODE" != "201" ] && [ "$HTTP_CODE" != "204" ]; then
+          echo "::error::AtlaSent verify returned HTTP $HTTP_CODE — BLOCKED (fail-closed)"
+          echo "verified=false" >> $GITHUB_OUTPUT
+          exit 1
+        fi
+
+        # Parse response
+        JSON=$(echo "$RESP" | awk 'BEGIN{h=1} /^\r?$/{h=0; next} {if(!h) print}')
+        OUTCOME=$(echo "$JSON" | jq -r '.outcome // .decision // empty')
+        VALID=$(echo "$JSON" | jq -r '.valid // empty')
+
+        if [ -n "$VALID" ] && [ "$VALID" != "true" ]; then
+          CODE=$(echo "$JSON" | jq -r '.verify_error_code // .deny_code // "unknown"')
+          REASON=$(echo "$JSON" | jq -r '.reason // .deny_reason // "unknown"')
+          echo "::error::AtlaSent permit invalid — code=$CODE reason=$REASON"
+          echo "verified=false" >> $GITHUB_OUTPUT
+          exit 1
+        fi
+
+        if [ -z "$OUTCOME" ]; then
+          echo "::error::AtlaSent verify missing outcome — BLOCKED"
+          echo "$JSON" | jq . || true
+          echo "verified=false" >> $GITHUB_OUTPUT
+          exit 1
+        fi
+
+        if [ "$OUTCOME" != "allow" ]; then
+          CODE=$(echo "$JSON" | jq -r '.verify_error_code // .deny_code // "unknown"')
+          REASON=$(echo "$JSON" | jq -r '.reason // .deny_reason // "unknown"')
+          echo "::error::AtlaSent permit verification FAILED — outcome=$OUTCOME code=$CODE reason=$REASON"
+          echo "verified=false" >> $GITHUB_OUTPUT
+          exit 1
+        fi
+
+        echo "verified=true" >> $GITHUB_OUTPUT

--- a/docs/evaluate-allow.json
+++ b/docs/evaluate-allow.json
@@ -12,7 +12,7 @@
     "environment": "prod",
     "approvals": 2,
     "change_window": true,
-    "repo": "AtlaSent-Systems-Inc/deploy-gate-demo",
+    "repo": "AtlaSent-Systems-Inc/atlasent-action",
     "ref": "refs/heads/main"
   }
 }


### PR DESCRIPTION
Transform repo from a demo into a proper GitHub Action:
- Create action.yml with configurable inputs (action_type, environment,
  approvals, change_window) and outputs (decision, permit_token, verified)
- Refactor demo workflow to dogfood the action via uses: ./
- Rewrite README with Marketplace-ready docs, input/output tables, and
  multi-environment usage examples
- Rename remaining deploy-gate-demo references to atlasent-action

https://claude.ai/code/session_017vYzGw4BNorwuSauApkeGn