### PR TITLE
Align action with spec and add release workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,8 +1,7 @@
 name: AtlaSent Deploy Gate (Demo)
 
-# Demo workflow showing how to use AtlaSent Action to gate deployments.
-# This workflow uses the local action (uses: ./) for dogfooding.
-# In your own repo, replace with: uses: AtlaSent-Systems-Inc/atlasent-action@v1
+# Demo: gate deploys through AtlaSent before they execute.
+# In your repo, replace uses: ./ with: uses: AtlaSent-Systems-Inc/atlasent-action@v1
 
 on:
   push:
@@ -29,22 +28,23 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # Gate the deployment through AtlaSent
       - name: AtlaSent authorization gate
         id: gate
         uses: ./
         with:
-          action_type: production.deploy
+          atlasent_api_key: ${{ secrets.ATLASENT_API_KEY }}
+          atlasent_anon_key: ${{ vars.ATLASENT_ANON_KEY }}
+          action: production-deploy
           environment: ${{ inputs.environment || 'prod' }}
           approvals: ${{ inputs.force_denial == true && '0' || '2' }}
           change_window: ${{ inputs.force_denial == true && 'false' || 'true' }}
-          atlasent_api_key: ${{ secrets.ATLASENT_API_KEY }}
-          atlasent_anon_key: ${{ vars.ATLASENT_ANON_KEY }}
 
-      # Only reached if AtlaSent allowed and verified the action
+      # Only reached if AtlaSent authorized the deploy
       - name: Deploy to ${{ inputs.environment || 'prod' }}
         run: |
-          echo "AtlaSent decision: ${{ steps.gate.outputs.decision }}"
-          echo "Permit verified:   ${{ steps.gate.outputs.verified }}"
+          echo "Decision:    ${{ steps.gate.outputs.decision }}"
+          echo "Decision ID: ${{ steps.gate.outputs.decision_id }}"
+          echo "Audit Hash:  ${{ steps.gate.outputs.audit_hash }}"
+          echo "Verified:    ${{ steps.gate.outputs.verified }}"
           echo ""
           echo "Replace this with your real deploy command."

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,39 @@
+name: Release
+
+# When a new release is published via the GitHub UI, this workflow
+# automatically moves the major version tag (v1) to point at the
+# latest release so users on @v1 always get the newest patch.
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  update-major-tag:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Update major version tag
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          TAG="${GITHUB_REF_NAME}"
+
+          # Extract major version (e.g., v1.2.3 -> v1, v1 -> v1)
+          MAJOR=$(echo "$TAG" | grep -oE '^v[0-9]+')
+
+          if [ -z "$MAJOR" ]; then
+            echo "Tag '$TAG' does not match vN pattern — skipping"
+            exit 0
+          fi
+
+          echo "Moving $MAJOR tag to point at $TAG ($GITHUB_SHA)"
+
+          # Force-update the major version tag
+          git tag -fa "$MAJOR" -m "Release $TAG"
+          git push origin "$MAJOR" --force

--- a/README.md
+++ b/README.md
@@ -1,49 +1,36 @@
 # AtlaSent Action
 
-Official GitHub Action for [AtlaSent](https://atlasent.io) — execution-time authorization for AI agent actions in GxP-regulated life sciences environments.
-
-Add `uses: AtlaSent-Systems-Inc/atlasent-action@v1` to any workflow to gate agent actions through AtlaSent's evaluate/verify API before they execute. Fail-closed design: if anything goes wrong, the action is blocked.
-
-## How It Works
+Block production deploys unless AtlaSent authorizes them. Sits as a required status check so nothing reaches production without an evaluated, verified permit.
 
 ```
-Workflow step triggers
-    |
-    v
-POST /v1-evaluate
-    -> Decision: allow
-    -> Permit token: ats_permit_a1b2c3...
-    |
-    v
-POST /v1-verify-permit
-    -> Outcome: allow
-    -> Valid: true
-    |
-    v
-Next step proceeds (deploy, data export, etc.)
-    |
-    v
-Tamper-evident audit trail recorded
+Push to main → AtlaSent evaluates → permitted → deploy
+                                   → blocked  → fail with reason
 ```
 
-1. **Evaluate** — Sends the action type, actor, and context to AtlaSent. Returns an allow/deny decision and a single-use permit token.
-2. **Verify** — At execution time, confirms the permit is still valid, unmodified, and contextually correct.
-3. **Proceed or block** — Downstream steps only run if both evaluate and verify succeed.
+## Add to Any Repo in 3 Steps
 
-## Quick Start
+### Step 1: Add secrets
 
-### 1. Add your credentials
+In your repo's **Settings → Secrets and variables → Actions**:
 
-In your repo's Settings > Secrets and variables > Actions:
+| Type | Name | Value |
+|---|---|---|
+| Secret | `ATLASENT_API_KEY` | Your AtlaSent API key |
+| Variable | `ATLASENT_ANON_KEY` | Your AtlaSent public anon key |
 
-- **Secret:** `ATLASENT_API_KEY` — your AtlaSent API key
-- **Variable:** `ATLASENT_ANON_KEY` — your AtlaSent public anon key
+No credentials yet? → [atlasent.io](https://atlasent.io)
 
-Don't have credentials yet? [Get a sandbox key at atlasent.io](https://atlasent.io)
+### Step 2: Add the workflow
 
-### 2. Add the action to your workflow
+Create `.github/workflows/deploy.yaml`:
 
 ```yaml
+name: Deploy
+
+on:
+  push:
+    branches: [main]
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -54,77 +41,105 @@ jobs:
         id: gate
         uses: AtlaSent-Systems-Inc/atlasent-action@v1
         with:
-          action_type: production.deploy
-          environment: prod
-          approvals: 2
-          change_window: true
           atlasent_api_key: ${{ secrets.ATLASENT_API_KEY }}
           atlasent_anon_key: ${{ vars.ATLASENT_ANON_KEY }}
 
+      # This step only runs if AtlaSent authorized the deploy
       - name: Deploy
-        run: echo "Deploying — permit verified: ${{ steps.gate.outputs.verified }}"
+        run: ./deploy.sh
 ```
+
+### Step 3: Require the check
+
+In **Settings → Branches → Branch protection rules** for `main`:
+
+- Check **Require status checks to pass before merging**
+- Add **deploy** as a required check
+
+Done. Every push to `main` now requires AtlaSent authorization.
+
+## What a Blocked Deploy Looks Like
+
+When AtlaSent denies an action, the workflow fails immediately and the reason is surfaced in three places:
+
+**In the Actions log:**
+```
+Error: BLOCKED by AtlaSent — decision=deny code=POLICY_VIOLATION reason=insufficient approvals and outside change window
+```
+
+**In the job summary (visible on the Actions run page):**
+
+| Field | Value |
+|---|---|
+| **Decision** | `deny` |
+| **Decision ID** | `eval_1a2b3c4d5e6f7890` |
+| **Audit Hash** | `sha256:e3b0c44298fc1c14...` |
+| **Action** | `production-deploy` |
+| **Actor** | `deploy-engineer` |
+| **SHA** | `a1b2c3d4e5f6` |
+| **Branch** | `refs/heads/main` |
+| **Reason** | insufficient approvals and outside change window |
+
+**In the PR (when used as a required check):**
+
+The merge button is blocked with: _"Required status check — deploy — failing"_
 
 ## Inputs
 
 | Input | Required | Default | Description |
 |---|---|---|---|
-| `action_type` | Yes | — | Action type to evaluate (e.g., `production.deploy`, `data.export`) |
-| `environment` | Yes | `prod` | Target environment (e.g., `prod`, `staging`) |
+| `atlasent_api_key` | **Yes** | — | AtlaSent API key (use a secret) |
+| `atlasent_anon_key` | **Yes** | — | AtlaSent public anon key |
+| `action` | No | `production-deploy` | Action to authorize |
+| `environment` | No | `prod` | Target environment |
 | `approvals` | No | `0` | Number of approvals obtained |
-| `change_window` | No | `false` | Whether the action is within an approved change window |
-| `atlasent_api_key` | Yes | — | AtlaSent API key (use a GitHub secret) |
-| `atlasent_anon_key` | Yes | — | AtlaSent public anon key |
-| `atlasent_base_url` | No | *(production)* | AtlaSent API base URL |
+| `change_window` | No | `false` | Within an approved change window? |
+| `atlasent_base_url` | No | *(production)* | API base URL override |
 
 ## Outputs
 
 | Output | Description |
 |---|---|
-| `decision` | The evaluate decision (`allow` or `deny`) |
-| `permit_token` | Single-use permit token (only set when decision is `allow`) |
-| `verified` | Whether the permit was verified at execution time (`true`/`false`) |
+| `decision` | `allow` or `deny` |
+| `decision_id` | Unique evaluation ID for audit trail |
+| `audit_hash` | Tamper-evident hash of the evaluation context |
+| `permit_token` | Single-use permit token (only when allowed) |
+| `verified` | Whether permit was verified at execution time |
 
-## Testing a Denial
+## How It Works
 
-Use the included demo workflow with `force_denial: true` to trigger a deliberate denial. Go to Actions > AtlaSent Deploy Gate (Demo) > Run workflow, and check "Force a denial".
+1. **Evaluate** — Calls `POST /v1-evaluate` with `agent="github-actions"`, `action="production-deploy"`, and context (SHA, branch, actor, environment, approvals, change window). Returns a decision and single-use permit token.
 
-This sets `approvals: 0` and `change_window: false`, which violates the policy:
+2. **Verify** — Calls `POST /v1-verify-permit` to confirm the permit hasn't been tampered with, expired, or had its context change between evaluation and execution.
 
-```
-Decision: deny
-Reason:   insufficient approvals and outside change window
-```
+3. **Proceed or block** — If both succeed, downstream steps run. If anything fails, the workflow is blocked (fail-closed). Decision ID and audit hash are logged to the job summary.
 
-## Multi-Environment Support
+## Customizing the Action
 
-Gate different environments with different contexts:
+Gate staging deploys, data exports, or any agent action:
 
 ```yaml
-- name: Gate staging deploy
-  uses: AtlaSent-Systems-Inc/atlasent-action@v1
+- uses: AtlaSent-Systems-Inc/atlasent-action@v1
   with:
-    action_type: staging.deploy
+    atlasent_api_key: ${{ secrets.ATLASENT_API_KEY }}
+    atlasent_anon_key: ${{ vars.ATLASENT_ANON_KEY }}
+    action: staging-deploy
     environment: staging
     approvals: 1
     change_window: true
-    atlasent_api_key: ${{ secrets.ATLASENT_API_KEY }}
-    atlasent_anon_key: ${{ vars.ATLASENT_ANON_KEY }}
 ```
+
+## Testing a Denial
+
+Use the [demo workflow](./.github/workflows/deploy.yaml) with manual dispatch. Check **"Force a denial"** to send `approvals=0, change_window=false`, which violates the policy and produces a denial you can inspect.
 
 ## Sample API Responses
 
-See the [`docs/`](./docs/) directory for captured examples of every API response:
-
-- [`docs/evaluate-allow.json`](./docs/evaluate-allow.json) — Successful evaluation (action allowed)
-- [`docs/evaluate-deny.json`](./docs/evaluate-deny.json) — Evaluation denied (policy violation)
-- [`docs/verify-allow.json`](./docs/verify-allow.json) — Permit verified at execution time
-
-## More Resources
-
-- **[AtlaSent GxP Starter](https://github.com/AtlaSent-Systems-Inc/atlasent-gxp-starter)** — Full quickstart kit with policy templates for 21 CFR Part 11, EU Annex 11, ICH E6 GCP, and integration examples for Python, LangChain, and more.
-- **[atlasent.io](https://atlasent.io)** — Book a demo or get sandbox credentials.
+See [`docs/`](./docs/) for examples of every API response:
+- [`evaluate-allow.json`](./docs/evaluate-allow.json) — allowed, permit token issued
+- [`evaluate-deny.json`](./docs/evaluate-deny.json) — denied, policy violation with reasons
+- [`verify-allow.json`](./docs/verify-allow.json) — permit verified at execution time
 
 ## License
 
-MIT
+MIT — see [LICENSE](./LICENSE).

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: 'AtlaSent Action'
-description: 'Execution-time authorization for AI agent actions in GxP-regulated life sciences environments'
+description: 'Block production deploys unless AtlaSent authorizes them. Execution-time authorization for AI agent actions in GxP-regulated life sciences environments.'
 author: 'AtlaSent Systems, Inc.'
 
 branding:
@@ -7,38 +7,45 @@ branding:
   color: 'blue'
 
 inputs:
-  action_type:
-    description: 'The action type to evaluate (e.g., production.deploy, data.export)'
-    required: true
-  environment:
-    description: 'Target environment (e.g., prod, staging)'
-    required: true
-    default: 'prod'
-  approvals:
-    description: 'Number of approvals obtained for this action'
-    required: false
-    default: '0'
-  change_window:
-    description: 'Whether the action is within an approved change window'
-    required: false
-    default: 'false'
   atlasent_api_key:
     description: 'AtlaSent API key (use a GitHub secret)'
     required: true
   atlasent_anon_key:
     description: 'AtlaSent public anon key'
     required: true
+  action:
+    description: 'Action to authorize (e.g., production-deploy, staging-deploy)'
+    required: false
+    default: 'production-deploy'
+  environment:
+    description: 'Target environment'
+    required: false
+    default: 'prod'
+  approvals:
+    description: 'Number of approvals obtained'
+    required: false
+    default: '0'
+  change_window:
+    description: 'Whether within an approved change window (true/false)'
+    required: false
+    default: 'false'
   atlasent_base_url:
-    description: 'AtlaSent API base URL'
+    description: 'AtlaSent API base URL (override for self-hosted)'
     required: false
     default: 'https://ducfnmhveikymmgwpgcd.supabase.co/functions/v1'
 
 outputs:
   decision:
-    description: 'The evaluate decision (allow or deny)'
+    description: 'Authorization decision: allow or deny'
     value: ${{ steps.eval.outputs.decision }}
+  decision_id:
+    description: 'Unique evaluation ID for audit trail'
+    value: ${{ steps.eval.outputs.decision_id }}
+  audit_hash:
+    description: 'Tamper-evident hash of the evaluation context'
+    value: ${{ steps.eval.outputs.audit_hash }}
   permit_token:
-    description: 'Single-use permit token (only set when decision is allow)'
+    description: 'Single-use permit token (only set when allowed)'
     value: ${{ steps.eval.outputs.permit_token }}
   verified:
     description: 'Whether the permit was verified at execution time (true/false)'
@@ -54,14 +61,14 @@ runs:
           sudo apt-get update -qq && sudo apt-get install -y -qq jq
         fi
 
-    - name: 'Evaluate — request authorization'
+    - name: 'Evaluate — request authorization from AtlaSent'
       id: eval
       shell: bash
       env:
         ATLASENT_API_KEY: ${{ inputs.atlasent_api_key }}
         ATLASENT_ANON_KEY: ${{ inputs.atlasent_anon_key }}
         ATLASENT_BASE_URL: ${{ inputs.atlasent_base_url }}
-        INPUT_ACTION_TYPE: ${{ inputs.action_type }}
+        INPUT_ACTION: ${{ inputs.action }}
         INPUT_ENVIRONMENT: ${{ inputs.environment }}
         INPUT_APPROVALS: ${{ inputs.approvals }}
         INPUT_CHANGE_WINDOW: ${{ inputs.change_window }}
@@ -70,30 +77,32 @@ runs:
         : "${ATLASENT_API_KEY:?Missing input: atlasent_api_key}"
         : "${ATLASENT_ANON_KEY:?Missing input: atlasent_anon_key}"
 
-        REQUEST_ID="github-eval-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+        REQUEST_ID="gha-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
 
         BODY=$(jq -nc \
-          --arg action_type "$INPUT_ACTION_TYPE" \
-          --arg actor_id "github:${GITHUB_ACTOR}" \
+          --arg agent "github-actions" \
+          --arg action "$INPUT_ACTION" \
           --arg request_id "$REQUEST_ID" \
-          --arg env "$INPUT_ENVIRONMENT" \
-          --arg repo "${GITHUB_REPOSITORY}" \
           --arg sha "${GITHUB_SHA}" \
-          --arg ref "${GITHUB_REF}" \
+          --arg branch "${GITHUB_REF}" \
+          --arg actor "${GITHUB_ACTOR}" \
+          --arg environment "$INPUT_ENVIRONMENT" \
+          --arg repo "${GITHUB_REPOSITORY}" \
           --arg run_id "${GITHUB_RUN_ID}" \
           --argjson approvals "$INPUT_APPROVALS" \
           --argjson change_window "$INPUT_CHANGE_WINDOW" \
           '{
-            action_type: $action_type,
-            actor_id: $actor_id,
+            agent: $agent,
+            action: $action,
             request_id: $request_id,
             context: {
-              environment: $env,
+              sha: $sha,
+              branch: $branch,
+              actor: $actor,
+              environment: $environment,
               approvals: $approvals,
               change_window: $change_window,
               repo: $repo,
-              sha: $sha,
-              ref: $ref,
               run_id: $run_id
             }
           }')
@@ -105,36 +114,57 @@ runs:
           -H "apikey: ${ATLASENT_ANON_KEY}" \
           -d "${BODY}")
 
-        # Check HTTP status — fail-closed on any non-success code
         HTTP_CODE=$(echo "$RESP" | head -n 1 | awk '{print $2}')
         if [ "$HTTP_CODE" != "200" ] && [ "$HTTP_CODE" != "201" ] && [ "$HTTP_CODE" != "204" ]; then
           echo "::error::AtlaSent evaluate returned HTTP $HTTP_CODE — BLOCKED (fail-closed)"
           exit 1
         fi
 
-        # Parse the JSON response body
         JSON=$(echo "$RESP" | awk 'BEGIN{h=1} /^\r?$/{h=0; next} {if(!h) print}')
         DECISION=$(echo "$JSON" | jq -r '.decision // empty')
 
         if [ -z "$DECISION" ]; then
-          echo "::error::AtlaSent evaluate missing decision — BLOCKED"
-          echo "$JSON" | jq . || true
+          echo "::error::AtlaSent evaluate returned no decision — BLOCKED (fail-closed)"
           exit 1
         fi
 
+        DECISION_ID=$(echo "$JSON" | jq -r '.decision_id // .evaluation_id // "none"')
+        AUDIT_HASH=$(echo "$JSON" | jq -r '.audit_hash // .context_hash // "none"')
+        REASON=$(echo "$JSON" | jq -r '.reason // .deny_reason // ""')
+
         echo "decision=$DECISION" >> $GITHUB_OUTPUT
+        echo "decision_id=$DECISION_ID" >> $GITHUB_OUTPUT
+        echo "audit_hash=$AUDIT_HASH" >> $GITHUB_OUTPUT
         echo "request_id=$REQUEST_ID" >> $GITHUB_OUTPUT
+
+        # Write to GitHub Actions job summary
+        {
+          echo "## AtlaSent Authorization"
+          echo ""
+          echo "| Field | Value |"
+          echo "|---|---|"
+          echo "| **Decision** | \`$DECISION\` |"
+          echo "| **Decision ID** | \`$DECISION_ID\` |"
+          echo "| **Audit Hash** | \`$AUDIT_HASH\` |"
+          echo "| **Action** | \`$INPUT_ACTION\` |"
+          echo "| **Actor** | \`${GITHUB_ACTOR}\` |"
+          echo "| **SHA** | \`${GITHUB_SHA:0:12}\` |"
+          echo "| **Branch** | \`${GITHUB_REF}\` |"
+          if [ -n "$REASON" ]; then
+            echo "| **Reason** | $REASON |"
+          fi
+          echo ""
+        } >> $GITHUB_STEP_SUMMARY
 
         if [ "$DECISION" != "allow" ]; then
           CODE=$(echo "$JSON" | jq -r '.error_code // .deny_code // "unknown"')
-          REASON=$(echo "$JSON" | jq -r '.reason // .deny_reason // "no reason provided"')
           echo "::error::BLOCKED by AtlaSent — decision=$DECISION code=$CODE reason=$REASON"
           exit 1
         fi
 
         PERMIT_TOKEN=$(echo "$JSON" | jq -r '.permit_token // .permit // empty')
         if [ -z "$PERMIT_TOKEN" ] || [ "$PERMIT_TOKEN" = "null" ]; then
-          echo "::error::AtlaSent allowed but missing permit_token — BLOCKED"
+          echo "::error::AtlaSent allowed but no permit_token — BLOCKED (fail-closed)"
           exit 1
         fi
 
@@ -149,44 +179,42 @@ runs:
         ATLASENT_BASE_URL: ${{ inputs.atlasent_base_url }}
         PERMIT_TOKEN: ${{ steps.eval.outputs.permit_token }}
         EVAL_REQUEST_ID: ${{ steps.eval.outputs.request_id }}
-        INPUT_ACTION_TYPE: ${{ inputs.action_type }}
+        INPUT_ACTION: ${{ inputs.action }}
         INPUT_ENVIRONMENT: ${{ inputs.environment }}
         INPUT_APPROVALS: ${{ inputs.approvals }}
         INPUT_CHANGE_WINDOW: ${{ inputs.change_window }}
       run: |
         set -euo pipefail
-        : "${ATLASENT_API_KEY:?Missing input: atlasent_api_key}"
-        : "${ATLASENT_ANON_KEY:?Missing input: atlasent_anon_key}"
         : "${PERMIT_TOKEN:?Missing permit token from evaluate step}"
 
         VERIFY_ID="verify-${EVAL_REQUEST_ID}"
 
         BODY=$(jq -nc \
           --arg permit_token "${PERMIT_TOKEN}" \
-          --arg action_type "$INPUT_ACTION_TYPE" \
-          --arg actor_id "github:${GITHUB_ACTOR}" \
-          --arg environment "$INPUT_ENVIRONMENT" \
+          --arg agent "github-actions" \
+          --arg action "$INPUT_ACTION" \
           --arg request_id "${VERIFY_ID}" \
-          --arg env "$INPUT_ENVIRONMENT" \
-          --arg repo "${GITHUB_REPOSITORY}" \
           --arg sha "${GITHUB_SHA}" \
-          --arg ref "${GITHUB_REF}" \
+          --arg branch "${GITHUB_REF}" \
+          --arg actor "${GITHUB_ACTOR}" \
+          --arg environment "$INPUT_ENVIRONMENT" \
+          --arg repo "${GITHUB_REPOSITORY}" \
           --arg run_id "${GITHUB_RUN_ID}" \
           --argjson approvals "$INPUT_APPROVALS" \
           --argjson change_window "$INPUT_CHANGE_WINDOW" \
           '{
             permit_token: $permit_token,
-            action_type: $action_type,
-            actor_id: $actor_id,
-            environment: $environment,
+            agent: $agent,
+            action: $action,
             request_id: $request_id,
             context: {
-              environment: $env,
+              sha: $sha,
+              branch: $branch,
+              actor: $actor,
+              environment: $environment,
               approvals: $approvals,
               change_window: $change_window,
               repo: $repo,
-              sha: $sha,
-              ref: $ref,
               run_id: $run_id
             }
           }')
@@ -198,7 +226,6 @@ runs:
           -H "apikey: ${ATLASENT_ANON_KEY}" \
           -d "${BODY}")
 
-        # Check HTTP status — fail-closed
         HTTP_CODE=$(echo "$RESP" | head -n 1 | awk '{print $2}')
         if [ "$HTTP_CODE" != "200" ] && [ "$HTTP_CODE" != "201" ] && [ "$HTTP_CODE" != "204" ]; then
           echo "::error::AtlaSent verify returned HTTP $HTTP_CODE — BLOCKED (fail-closed)"
@@ -206,32 +233,27 @@ runs:
           exit 1
         fi
 
-        # Parse response
         JSON=$(echo "$RESP" | awk 'BEGIN{h=1} /^\r?$/{h=0; next} {if(!h) print}')
         OUTCOME=$(echo "$JSON" | jq -r '.outcome // .decision // empty')
         VALID=$(echo "$JSON" | jq -r '.valid // empty')
 
         if [ -n "$VALID" ] && [ "$VALID" != "true" ]; then
-          CODE=$(echo "$JSON" | jq -r '.verify_error_code // .deny_code // "unknown"')
           REASON=$(echo "$JSON" | jq -r '.reason // .deny_reason // "unknown"')
-          echo "::error::AtlaSent permit invalid — code=$CODE reason=$REASON"
+          echo "::error::AtlaSent permit invalid — $REASON"
           echo "verified=false" >> $GITHUB_OUTPUT
           exit 1
         fi
 
-        if [ -z "$OUTCOME" ]; then
-          echo "::error::AtlaSent verify missing outcome — BLOCKED"
-          echo "$JSON" | jq . || true
-          echo "verified=false" >> $GITHUB_OUTPUT
-          exit 1
-        fi
-
-        if [ "$OUTCOME" != "allow" ]; then
-          CODE=$(echo "$JSON" | jq -r '.verify_error_code // .deny_code // "unknown"')
-          REASON=$(echo "$JSON" | jq -r '.reason // .deny_reason // "unknown"')
-          echo "::error::AtlaSent permit verification FAILED — outcome=$OUTCOME code=$CODE reason=$REASON"
+        if [ -z "$OUTCOME" ] || [ "$OUTCOME" != "allow" ]; then
+          REASON=$(echo "$JSON" | jq -r '.reason // .deny_reason // "verification failed"')
+          echo "::error::AtlaSent permit verification FAILED — $REASON"
           echo "verified=false" >> $GITHUB_OUTPUT
           exit 1
         fi
 
         echo "verified=true" >> $GITHUB_OUTPUT
+
+        # Append verification to summary
+        {
+          echo "| **Verified** | ✅ permit confirmed at execution time |"
+        } >> $GITHUB_STEP_SUMMARY

--- a/docs/evaluate-allow.json
+++ b/docs/evaluate-allow.json
@@ -1,18 +1,20 @@
 {
   "decision": "allow",
+  "decision_id": "eval_9f8e7d6c5b4a3210",
+  "audit_hash": "sha256:e3b0c44298fc1c149afbf4c8996fb924",
   "permit_token": "ats_permit_a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0",
-  "request_id": "github-eval-12345678-1",
-  "evaluation_id": "eval_9f8e7d6c5b4a3210",
+  "request_id": "gha-12345678-1",
   "policy_version": "2026-04-01",
-  "context_hash": "sha256:e3b0c44298fc1c149afbf4c8996fb924",
   "expires_at": "2026-04-16T06:00:00Z",
   "metadata": {
-    "action_type": "production.deploy",
-    "actor_id": "github:deploy-engineer",
+    "agent": "github-actions",
+    "action": "production-deploy",
+    "actor": "deploy-engineer",
+    "sha": "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4",
+    "branch": "refs/heads/main",
     "environment": "prod",
     "approvals": 2,
     "change_window": true,
-    "repo": "AtlaSent-Systems-Inc/atlasent-action",
-    "ref": "refs/heads/main"
+    "repo": "AtlaSent-Systems-Inc/atlasent-action"
   }
 }

--- a/docs/evaluate-deny.json
+++ b/docs/evaluate-deny.json
@@ -1,9 +1,10 @@
 {
   "decision": "deny",
+  "decision_id": "eval_1a2b3c4d5e6f7890",
+  "audit_hash": "sha256:7d793037a0760186574b0282f2f435e7",
   "deny_code": "POLICY_VIOLATION",
   "reason": "insufficient approvals and outside change window",
-  "request_id": "github-eval-12345678-1",
-  "evaluation_id": "eval_1a2b3c4d5e6f7890",
+  "request_id": "gha-12345678-1",
   "policy_version": "2026-04-01",
   "violations": [
     {
@@ -22,8 +23,9 @@
     }
   ],
   "metadata": {
-    "action_type": "production.deploy",
-    "actor_id": "github:deploy-engineer",
+    "agent": "github-actions",
+    "action": "production-deploy",
+    "actor": "deploy-engineer",
     "environment": "prod",
     "approvals": 0,
     "change_window": false

--- a/docs/verify-allow.json
+++ b/docs/verify-allow.json
@@ -2,15 +2,16 @@
   "outcome": "allow",
   "valid": true,
   "permit_token": "ats_permit_a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0",
-  "request_id": "verify-github-eval-12345678-1",
+  "request_id": "verify-gha-12345678-1",
   "verification_id": "ver_0a1b2c3d4e5f6789",
   "context_match": true,
   "permit_age_seconds": 12,
   "metadata": {
-    "action_type": "production.deploy",
-    "actor_id": "github:deploy-engineer",
+    "agent": "github-actions",
+    "action": "production-deploy",
+    "actor": "deploy-engineer",
     "environment": "prod",
-    "original_evaluation_id": "eval_9f8e7d6c5b4a3210",
+    "original_decision_id": "eval_9f8e7d6c5b4a3210",
     "audit_record_id": "audit_f0e1d2c3b4a59687"
   }
 }


### PR DESCRIPTION
## Summary

- **Evaluate payload** now sends `agent="github-actions"` and `action="production-deploy"` per spec, with context fields `sha`, `branch`, `actor`
- **Job summary** — writes `decision_id` and `audit_hash` to `$GITHUB_STEP_SUMMARY` so audit trail is visible on every Actions run
- **New outputs** — `decision_id` and `audit_hash` exposed alongside existing `decision`, `permit_token`, `verified`
- **README rewritten** — 3-step setup, example workflow YAML, and "what a blocked deploy looks like" section showing denial in logs/summary/PR checks
- **Release workflow** — auto-moves `v1` tag forward when a new release (e.g., `v1.0.1`) is published
- **Sample API responses** updated to match new field names

## Test plan

- [ ] Trigger demo workflow on main — confirm evaluate/verify calls succeed with real credentials
- [ ] Trigger with force_denial=true — confirm denial surfaces in Actions log and job summary
- [ ] Verify `decision_id` and `audit_hash` appear in job summary table
- [ ] Confirm action outputs are accessible in downstream steps
- [ ] Review action.yml YAML syntax is valid for Marketplace publishing