### PR TITLE
feat: v1.0.0 — CHANGELOG, test workflow, migration guide

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,39 @@
+name: Test Action
+
+on:
+  push:
+    branches: [main, 'claude/**']
+  pull_request:
+
+jobs:
+  test-action-syntax:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate action.yml
+        run: |
+          # Verify action.yml is valid YAML
+          python3 -c "
+import yaml, sys
+with open('action.yml') as f:
+    data = yaml.safe_load(f)
+required = ['name', 'description', 'inputs', 'outputs', 'runs']
+for key in required:
+    if key not in data:
+        print(f'Missing key: {key}', file=sys.stderr)
+        sys.exit(1)
+print('action.yml valid')
+"
+
+      - name: Check evaluate step present
+        run: |
+          grep -q 'v1-evaluate' action.yml && echo 'evaluate step found'
+
+      - name: Check verify step present
+        run: |
+          grep -q 'v1-verify-permit' action.yml && echo 'verify step found'
+
+      - name: Check fail-closed logic
+        run: |
+          grep -q 'fail-closed' action.yml && echo 'fail-closed logic found'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+All notable changes to `atlasent-action` are documented here.
+
+## [1.0.0] — 2026-04-17
+
+### Added
+- `evaluate` step: calls `/v1-evaluate` before any deployment step executes
+- `verify` step: calls `/v1-verify-permit` after execution to close the audit record
+- `permit_token` output: single-use token passed from evaluate to verify
+- `decision_id` output: UUID for audit trail correlation
+- `audit_hash` output: tamper-evident context hash
+- `verified` output: boolean confirming execution-time permit validation
+- Fail-closed behavior: any API error, network timeout, or missing decision blocks the workflow
+- GitHub Actions job summary table with decision, actor, SHA, branch, and reason
+- Support for `change_window` and `approvals` context inputs for GxP environments
+- `atlasent_base_url` input for self-hosted AtlaSent deployments
+
+### Security
+- Permit tokens are single-use and expire after 5 minutes
+- All API calls use `--max-time 30` to prevent indefinite hangs
+- Fail-closed: missing or malformed responses block the workflow
+
+## [0.x] — Pre-release
+
+Internal development and beta testing.

--- a/docs/v1-migration.md
+++ b/docs/v1-migration.md
@@ -1,0 +1,60 @@
+# Migrating to v1
+
+This guide covers changes when upgrading to `atlasent-action@v1`.
+
+## Breaking Changes from Pre-release
+
+### Input renames
+
+| Old | New | Notes |
+|-----|-----|-------|
+| `api_key` | `atlasent_api_key` | More explicit naming |
+| `anon_key` | `atlasent_anon_key` | More explicit naming |
+| `action_type` | `action` | Shortened |
+
+### Output additions
+
+v1 adds three new outputs:
+- `permit_token`: pass to verify step
+- `verified`: boolean from verify step  
+- `audit_hash`: tamper-evident context hash
+
+## Upgrade Example
+
+**Before (pre-release):**
+```yaml
+- uses: atlasent-systems-inc/atlasent-action@v0
+  with:
+    api_key: ${{ secrets.ATLASENT_API_KEY }}
+    action_type: deploy
+```
+
+**After (v1):**
+```yaml
+- name: Gate with AtlaSent
+  id: gate
+  uses: atlasent-systems-inc/atlasent-action@v1
+  with:
+    atlasent_api_key: ${{ secrets.ATLASENT_API_KEY }}
+    atlasent_anon_key: ${{ secrets.ATLASENT_ANON_KEY }}
+    action: production-deploy
+    environment: production
+
+# ... your deploy steps ...
+
+- name: Verify permit
+  if: always()
+  uses: atlasent-systems-inc/atlasent-action@v1
+  with:
+    atlasent_api_key: ${{ secrets.ATLASENT_API_KEY }}
+    atlasent_anon_key: ${{ secrets.ATLASENT_ANON_KEY }}
+    action: verify
+    permit_id: ${{ steps.gate.outputs.permit-id }}
+    outcome: ${{ job.status == 'success' && 'success' || 'failure' }}
+```
+
+## New: Verify Step
+
+v1 introduces a mandatory verify step that closes the audit record after execution. This satisfies 21 CFR Part 11 §11.10(e) audit trail requirements.
+
+Always add a verify step with `if: always()` so it runs even when deployment fails.


### PR DESCRIPTION
## Summary\n- Adds `CHANGELOG.md` for v1.0.0 (evaluate + verify steps, permit_token, fail-closed behavior, job summary, GxP inputs)\n- Adds `.github/workflows/test.yml`: validates `action.yml` syntax, confirms evaluate and verify steps are present\n- Adds `docs/v1-migration.md`: upgrade guide from pre-release inputs to v1 input names\n\n## Test plan\n- [ ] `action.yml` YAML is valid\n- [ ] Test workflow passes on push\n- [ ] Migration guide accurately reflects input renames\n- [ ] CHANGELOG matches shipped `action.yml` behavior