### PR TITLE
chore: add standard hygiene files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Default owners for this repository.
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+*       @bettyc925

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,20 @@
+---
+name: Bug report
+about: Report a bug or unexpected behavior
+labels: bug
+---
+
+## What happened
+
+
+## What you expected
+
+
+## Steps to reproduce
+
+Share the relevant workflow snippet if possible.
+
+## Environment
+- Runner OS (ubuntu-latest / macos-latest / windows-latest):
+- atlasent-action version / tag:
+- Link to a failing Actions run (if public):

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,15 @@
+---
+name: Feature request
+about: Suggest an idea or improvement
+labels: enhancement
+---
+
+## Problem
+
+What are you trying to do?
+
+## Proposal
+
+What would solve this?
+
+## Alternatives considered

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      actions-minor-and-patch:
+        update-types:
+          - minor
+          - patch

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,5 @@
+## Summary
+
+
+## Test plan
+- [ ] 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,29 @@
+# Contributing to atlasent-action
+
+Thanks for your interest. This repo publishes the AtlaSent composite GitHub Action used as a required status check to gate deploys on a valid permit.
+
+## Ground rules
+
+1. **Fail-closed.** If evaluation cannot complete, the action must fail the check — never pass "because the network was slow."
+2. **No secret leakage.** Never `echo` the API key or any bearer token. Use `::add-mask::` for any dynamic value that could be sensitive.
+3. **Tag stability.** Published major tag is `v1`. Any change that's not backwards-compatible requires a deliberate tag bump and release notes.
+4. **Runner compatibility.** Keep the composite action working on ubuntu / macos / windows runners unless there's a documented reason not to.
+
+## Local testing
+
+Use [act](https://github.com/nektos/act) or a fork with a test workflow that references `uses: <your-fork>/atlasent-action@<your-branch>`.
+
+## Pull request checklist
+
+- [ ] `action.yml` still valid (composite steps parse)
+- [ ] `README.md` updated if inputs / outputs changed
+- [ ] No unmasked secrets in shell output
+- [ ] A smoke workflow run proves the action still fails closed on bad credentials
+
+## Reporting a security issue
+
+Email **security@atlasent.io**. We acknowledge within 2 business days. Do not open a public issue for security-sensitive reports.
+
+## License
+
+By contributing, you agree that your contributions are licensed under the same license as this repository (see [`LICENSE`](./LICENSE)).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,7 @@
+# Security Policy
+
+If you discover a security vulnerability in this repository, please email [security@atlasent.io](mailto:security@atlasent.io).
+
+We acknowledge all reports within **2 business days** and will coordinate disclosure on a timeline agreed with the reporter before any public writeup.
+
+Please do not open a public GitHub issue for security-sensitive reports.


### PR DESCRIPTION
## Summary

- `SECURITY.md`, `.github/CODEOWNERS` (`* @bettyc925`)
- `.github/dependabot.yml` — weekly `github-actions` only (composite action; no npm/pip/gomod)
- `.github/ISSUE_TEMPLATE/{bug_report,feature_request}.md`
- `.github/pull_request_template.md`
- `CONTRIBUTING.md` — action-specific (fail-closed, tag stability, no secret leakage)

## Test plan

- [ ] Issue picker shows Bug + Feature forms
- [ ] PR template renders
- [ ] Dependabot opens grouped updates for transitive actions in workflows