### PR TITLE
feat: v1.0.0 GitHub Actions gate with fail-closed authorization

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,42 @@
+# Release Notes — v1.0.0
+
+**Release date:** 2026-04-17
+
+## AtlaSent GitHub Actions Gate v1.0.0
+
+First stable release. Use as a required status check to gate deployments behind an AtlaSent authorization decision.
+
+### Usage
+
+```yaml
+- uses: AtlaSent-Systems-Inc/atlasent-action@v1
+  with:
+    atlasent_api_key: ${{ secrets.ATLASENT_API_KEY }}
+    atlasent_anon_key: ${{ vars.ATLASENT_ANON_KEY }}
+    agent: ${{ github.actor }}
+    action: deployment.production
+```
+
+### Inputs
+
+| Input | Required | Description |
+|---|---|---|
+| `atlasent_api_key` | Yes | Scoped API key (`evaluate` scope minimum) |
+| `atlasent_anon_key` | Yes | Supabase anonymous key |
+| `agent` | Yes | Agent identifier (typically `github.actor`) |
+| `action` | Yes | Action class being gated |
+| `context` | No | JSON object with additional context |
+| `fail_on_deny` | No | Default: `true`. Set to `false` for audit-only mode |
+
+### Outputs
+
+| Output | Description |
+|---|---|
+| `decision` | `allow`, `deny`, or `hold` |
+| `decision_id` | UUID for the decision record |
+| `audit_hash` | SHA-256 hash of the audit chain row |
+| `permit_token` | Single-use permit token (only on `allow`) |
+
+### Stability guarantees
+
+The `@v1` tag is maintained. Patch updates are applied automatically. Pin to `@v1.0.0` for pinned reproducibility.


### PR DESCRIPTION
## Summary\n\n- Ships `AtlaSent-Systems-Inc/atlasent-action@v1` composite action at v1.0.0\n- Evaluate-before-execute gate using `POST /v1-evaluate`\n- Outputs: `decision`, `decision_id`, `audit_hash`, `permit_token`\n- Fail-closed by default (`fail_on_deny: true`)\n- `RELEASE_NOTES.md` documents all inputs/outputs and the `@v1` tag stability guarantee\n\n## Test plan\n\n- [ ] Run included test workflow against staging API — expect `decision: allow`\n- [ ] Remove API key — confirm workflow fails with clear error message\n- [ ] Add as required status check on a test repo — blocks merge on deny\n- [ ] Verify `audit_hash` output appears in AtlaSent Console audit log\n\nhttps://claude.ai/code/session_014KsoGG1zDMih6Qu693xkL6