### PR TITLE
docs: V1 plan — Marketplace publish, SDK swap, job summary

### DIFF
--- a/docs/V1_PLAN.md
+++ b/docs/V1_PLAN.md
@@ -1,0 +1,52 @@
+# atlasent-action — V1 Plan
+
+**Role:** GitHub Action that gates deploys behind an AtlaSent permit.
+Drop-in CI step. Blocks merge / deploy if no permit issued.
+
+**ICP this round:** platform engineer at a biotech who needs to prove
+every production deploy was pre-authorized by a named approver — the
+21 CFR Part 11 "electronic signature on production change" story.
+
+---
+
+## V1 gates
+
+- [ ] Published to GitHub Marketplace under `atlasent-systems-inc/atlasent-action@v1`.
+- [ ] Uses the TypeScript SDK from `atlasent-sdk` instead of raw `fetch`.
+- [ ] Honors `ATLASENT_API_KEY` + `ATLASENT_ENV` inputs; fails closed
+      if either is missing.
+- [ ] Writes a GitHub Actions job summary with the evaluation result,
+      permit token, and a link to the console's proof page.
+- [ ] Test mode (`mode: advisory`) logs the decision without blocking;
+      enforced mode blocks on `deny` / `hold`.
+- [ ] README has a 3-line copy-paste for a production-deploy gate.
+- [ ] E2E test: the action runs against a staging atlasent-api org on
+      every PR.
+- [ ] Tag-based release: `v1.0.0`, plus a moving `v1` major tag.
+- [ ] SECURITY.md describes the threat model (action tampering via
+      PR from fork, secret exfiltration via log injection).
+
+## Sequencing
+
+1. Swap raw `fetch` for `@atlasent/sdk`.
+2. Add job-summary markdown output.
+3. Wire advisory vs. enforced modes.
+4. Marketplace publish (requires `uses:` compatibility testing on at
+   least `ubuntu-22.04` + `ubuntu-latest`).
+5. Write the README quickstart and a biotech-specific example
+   (`.github/workflows/prod-release.yml`).
+
+## Out of scope for V1
+
+- GitLab CI, CircleCI, Jenkins adapters (separate repos).
+- Dynamic approval requests inside the action (stays a pass/fail gate;
+  escalation lives in the console).
+
+## Risks
+
+- **Secret handling.** `ATLASENT_API_KEY` in `env:` leaks to logs on
+  `set -x`. Test for masking before publishing.
+- **Fork PRs.** A malicious PR from a fork should not be able to
+  exfiltrate `ATLASENT_API_KEY`. Use
+  `pull_request_target` + no secrets, or document the right pattern
+  prominently in the README.


### PR DESCRIPTION
## Summary

Seed `docs/V1_PLAN.md`. V1 for atlasent-action: swap raw `fetch` for `@atlasent/sdk`, publish to GitHub Marketplace under a moving `v1` tag, advisory vs. enforced modes, job-summary markdown output with a console proof-page link, fork-PR secret-leak threat model documented.

Paired with the cross-repo plan (`plan-all-repos-v1.md`) and the other Tier 1/2 PRs.

## Why

21 CFR Part 11 requires an "electronic signature on production change" story. The action is where a biotech platform team wires AtlaSent into their existing CI without changing code. Today it uses raw `fetch`; moving to `@atlasent/sdk` means typed shapes and automatic contract drift protection.

## Test plan

- [ ] Read-through: does the input schema match what the action actually exposes today?
- [ ] Read-through: are the fork-PR risks covered well enough?

No code changes. Docs-only.

https://claude.ai/code/session_01S5A3e4kUESzGNri6qZ381m