### PR TITLE
port: replace with working v1 gate implementation from atlasent-api (v1.1.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,144 +1,103 @@
-# AtlaSent Action
+# AtlaSent Gate Action
 
-Block production deploys unless AtlaSent authorizes them. Sits as a required status check so nothing reaches production without an evaluated, verified permit.
+Require execution-time authorization before critical CI/CD actions run. Drop AtlaSent into any GitHub Actions workflow with a single step.
 
 ```
-Push to main → AtlaSent evaluates → permitted → deploy
-                                   → blocked  → fail with reason
+Push to main → AtlaSent evaluates → permit issued → deploy
+                                  → denied       → fail with reason
 ```
 
-## Add to Any Repo in 3 Steps
-
-### Step 1: Add secrets
-
-In your repo's **Settings → Secrets and variables → Actions**:
-
-| Type | Name | Value |
-|---|---|---|
-| Secret | `ATLASENT_API_KEY` | Your AtlaSent API key |
-| Variable | `ATLASENT_ANON_KEY` | Your AtlaSent public anon key |
-
-No credentials yet? → [atlasent.io](https://atlasent.io)
-
-### Step 2: Add the workflow
-
-Create `.github/workflows/deploy.yaml`:
-
-```yaml
-name: Deploy
-
-on:
-  push:
-    branches: [main]
-
-jobs:
-  deploy:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: AtlaSent authorization gate
-        id: gate
-        uses: AtlaSent-Systems-Inc/atlasent-action@v1
-        with:
-          atlasent_api_key: ${{ secrets.ATLASENT_API_KEY }}
-          atlasent_anon_key: ${{ vars.ATLASENT_ANON_KEY }}
-
-      # This step only runs if AtlaSent authorized the deploy
-      - name: Deploy
-        run: ./deploy.sh
-```
-
-### Step 3: Require the check
-
-In **Settings → Branches → Branch protection rules** for `main`:
-
-- Check **Require status checks to pass before merging**
-- Add **deploy** as a required check
-
-Done. Every push to `main` now requires AtlaSent authorization.
-
-## What a Blocked Deploy Looks Like
-
-When AtlaSent denies an action, the workflow fails immediately and the reason is surfaced in three places:
-
-**In the Actions log:**
-```
-Error: BLOCKED by AtlaSent — decision=deny code=POLICY_VIOLATION reason=insufficient approvals and outside change window
-```
-
-**In the job summary (visible on the Actions run page):**
-
-| Field | Value |
-|---|---|
-| **Decision** | `deny` |
-| **Decision ID** | `eval_1a2b3c4d5e6f7890` |
-| **Audit Hash** | `sha256:e3b0c44298fc1c14...` |
-| **Action** | `production-deploy` |
-| **Actor** | `deploy-engineer` |
-| **SHA** | `a1b2c3d4e5f6` |
-| **Branch** | `refs/heads/main` |
-| **Reason** | insufficient approvals and outside change window |
-
-**In the PR (when used as a required check):**
-
-The merge button is blocked with: _"Required status check — deploy — failing"_
-
-## Inputs
-
-| Input | Required | Default | Description |
-|---|---|---|---|
-| `atlasent_api_key` | **Yes** | — | AtlaSent API key (use a secret) |
-| `atlasent_anon_key` | **Yes** | — | AtlaSent public anon key |
-| `action` | No | `production-deploy` | Action to authorize |
-| `environment` | No | `prod` | Target environment |
-| `approvals` | No | `0` | Number of approvals obtained |
-| `change_window` | No | `false` | Within an approved change window? |
-| `atlasent_base_url` | No | *(production)* | API base URL override |
-
-## Outputs
-
-| Output | Description |
-|---|---|
-| `decision` | `allow` or `deny` |
-| `decision_id` | Unique evaluation ID for audit trail |
-| `audit_hash` | Tamper-evident hash of the evaluation context |
-| `permit_token` | Single-use permit token (only when allowed) |
-| `verified` | Whether permit was verified at execution time |
-
-## How It Works
-
-1. **Evaluate** — Calls `POST /v1-evaluate` with `agent="github-actions"`, `action="production-deploy"`, and context (SHA, branch, actor, environment, approvals, change window). Returns a decision and single-use permit token.
-
-2. **Verify** — Calls `POST /v1-verify-permit` to confirm the permit hasn't been tampered with, expired, or had its context change between evaluation and execution.
-
-3. **Proceed or block** — If both succeed, downstream steps run. If anything fails, the workflow is blocked (fail-closed). Decision ID and audit hash are logged to the job summary.
-
-## Customizing the Action
-
-Gate staging deploys, data exports, or any agent action:
+## Quick Start
 
 ```yaml
 - uses: AtlaSent-Systems-Inc/atlasent-action@v1
   with:
-    atlasent_api_key: ${{ secrets.ATLASENT_API_KEY }}
-    atlasent_anon_key: ${{ vars.ATLASENT_ANON_KEY }}
-    action: staging-deploy
-    environment: staging
-    approvals: 1
-    change_window: true
+    api-key: ${{ secrets.ATLASENT_API_KEY }}
+    action: production_deploy
 ```
 
-## Testing a Denial
+## Full Configuration
 
-Use the [demo workflow](./.github/workflows/deploy.yaml) with manual dispatch. Check **"Force a denial"** to send `approvals=0, change_window=false`, which violates the policy and produces a denial you can inspect.
+```yaml
+- name: Authorization Gate
+  id: gate
+  uses: AtlaSent-Systems-Inc/atlasent-action@v1
+  with:
+    api-key: ${{ secrets.ATLASENT_API_KEY }}
+    action: production_deploy
+    actor: ${{ github.actor }}
+    environment: live
+    fail-on-deny: 'true'
+    context: '{"team": "platform", "service": "api"}'
+```
 
-## Sample API Responses
+## Using Outputs
 
-See [`docs/`](./docs/) for examples of every API response:
-- [`evaluate-allow.json`](./docs/evaluate-allow.json) — allowed, permit token issued
-- [`evaluate-deny.json`](./docs/evaluate-deny.json) — denied, policy violation with reasons
-- [`verify-allow.json`](./docs/verify-allow.json) — permit verified at execution time
+The action sets several outputs you can reference in subsequent steps:
+
+```yaml
+- name: Authorization Gate
+  id: gate
+  uses: AtlaSent-Systems-Inc/atlasent-action@v1
+  with:
+    api-key: ${{ secrets.ATLASENT_API_KEY }}
+    action: production_deploy
+
+- name: Deploy
+  if: steps.gate.outputs.decision == 'allow'
+  run: |
+    echo "Deploying with permit: ${{ steps.gate.outputs.permit-token }}"
+    echo "Proof hash: ${{ steps.gate.outputs.proof-hash }}"
+    ./deploy.sh --permit "${{ steps.gate.outputs.permit-token }}"
+```
+
+### Outputs
+
+| Output          | Description                                                       |
+|-----------------|-------------------------------------------------------------------|
+| `decision`      | The evaluation result: `allow`, `deny`, `hold`, or `escalate`     |
+| `permit-token`  | The permit token for authorized actions (`pt_*` prefix)           |
+| `evaluation-id` | Unique evaluation ID for the audit trail                          |
+| `proof-hash`    | Cryptographic proof hash for tamper detection                     |
+
+## Inputs
+
+| Input          | Required | Default                | Description                                             |
+|----------------|----------|------------------------|---------------------------------------------------------|
+| `api-key`      | Yes      | —                      | AtlaSent API key (`ask_live_*` or `ask_test_*`)         |
+| `action`       | Yes      | —                      | Action type to evaluate (e.g. `production_deploy`)      |
+| `actor`        | No       | `${{ github.actor }}`  | Actor identity                                          |
+| `environment`  | No       | Auto-detected          | `live` for `main`/`master`, `test` otherwise            |
+| `api-url`      | No       | Production URL         | AtlaSent API endpoint                                   |
+| `fail-on-deny` | No       | `true`                 | Fail the step if denied                                 |
+| `context`      | No       | `{}`                   | Additional JSON context for evaluation                  |
+
+## How It Works
+
+1. **Evaluate** — POST `/v1-evaluate` with `action_type`, `actor_id`, and a context object populated from GitHub workflow metadata (repo, ref, sha, workflow, run id, PR number, optional user-supplied `context`).
+2. **Decide** — Server returns `allow` / `deny` / `hold` / `escalate` plus a single-use `permit_token` (only when `allow`).
+3. **Proceed or block** — `fail-on-deny: true` (default) surfaces deny/hold/escalate as a failing step. `false` demotes them to a workflow `::warning`.
+4. **Audit** — Every evaluation writes to the AtlaSent append-only, hash-chained audit log. The `evaluation-id` and `proof-hash` outputs reference the record.
+
+## Protecting `main`
+
+Add the action as a required check:
+
+1. Add secret `ATLASENT_API_KEY` in **Settings → Secrets and variables → Actions**
+2. Wire the step into `.github/workflows/deploy.yaml`
+3. Enable **Settings → Branches → Branch protection rules** and mark the workflow as required
+
+## Fail-open on network error (by design)
+
+If the action cannot reach the AtlaSent API (DNS, timeout, 5xx), it emits a `::warning::` and lets the workflow proceed. This is **intentional** — an outage at AtlaSent should not block every production deploy across every customer.
+
+If you want strict fail-closed behaviour on network errors, set `fail-on-deny: true` and wrap the step so a `decision=error` output also fails the job. See the FAQ in the AtlaSent docs.
+
+## Documentation
+
+- Full docs: <https://atlasent.io/docs>
+- API key guide: [docs/api-keys.md](https://github.com/AtlaSent-Systems-Inc/atlasent-api/blob/main/docs/api-keys.md)
+- Examples: <https://github.com/AtlaSent-Systems-Inc/atlasent-examples>
 
 ## License
 

--- a/action.yml
+++ b/action.yml
@@ -1,43 +1,43 @@
-name: AtlaSent Policy Gate
-description: Evaluate an action request against AtlaSent policies before proceeding
-author: AtlaSent Systems Inc
-
+name: 'AtlaSent Gate'
+description: 'Enforce real-time authorization gates on deployments and critical CI/CD actions with cryptographic audit trails'
+branding:
+  icon: 'shield'
+  color: 'green'
 inputs:
-  atlasent-api-url:
-    description: Base URL of your AtlaSent API
+  api-key:
+    description: 'AtlaSent API key (ask_live_* or ask_test_*)'
     required: true
-  atlasent-api-key:
-    description: Org-scoped API key with evaluation:execute scope
+  action:
+    description: 'Action type to evaluate (e.g., production_deploy)'
     required: true
-  action-id:
-    description: Action identifier to evaluate (e.g. ci.production-deploy)
-    required: true
+  actor:
+    description: 'Actor identity (defaults to github.actor)'
+    required: false
+    default: '${{ github.actor }}'
   environment:
-    description: Target environment
+    description: 'Environment (defaults to live for main branch, test otherwise)'
     required: false
-    default: production
-  actor-id:
-    description: Actor identifier (defaults to github.actor)
+  api-url:
+    description: 'AtlaSent API URL (defaults to production)'
     required: false
-  context:
-    description: JSON string of additional context
-    required: false
-    default: '{}'
+    default: 'https://ihghhasvxtltlbizvkqy.supabase.co/functions/v1'
   fail-on-deny:
-    description: Fail the step if decision is deny
+    description: 'Fail the workflow step if the action is denied (default: true)'
     required: false
     default: 'true'
-
+  context:
+    description: 'JSON context to include in the evaluation (optional)'
+    required: false
+    default: '{}'
 outputs:
   decision:
-    description: allow, deny, or require_approval
-  permit-id:
-    description: Permit ID if decision is allow
-  risk-level:
-    description: low, medium, high, or critical
+    description: 'The evaluation decision (allow/deny/hold/escalate)'
+  permit-token:
+    description: 'The permit token (if allowed)'
   evaluation-id:
-    description: Evaluation ID for audit trail
-
+    description: 'The evaluation ID for audit trail'
+  proof-hash:
+    description: 'The cryptographic proof hash'
 runs:
-  using: node20
-  main: dist/index.js
+  using: 'node20'
+  main: 'dist/index.js'

--- a/package.json
+++ b/package.json
@@ -1,21 +1,15 @@
 {
   "name": "atlasent-action",
-  "version": "2.0.0",
-  "description": "AtlaSent GitHub Actions gate — calls /v1/evaluate to enforce policy on every workflow run",
-  "private": true,
+  "version": "1.1.0",
+  "description": "GitHub Action for AtlaSent authorization gates — require a permit before critical CI/CD actions execute",
+  "main": "dist/index.js",
   "scripts": {
-    "build": "ncc build src/index.ts -o dist --source-map --license licenses.txt",
-    "typecheck": "tsc --noEmit",
-    "test": "vitest run"
-  },
-  "dependencies": {
-    "@actions/core": "^1.10.1",
-    "@actions/github": "^6.0.0"
+    "build": "esbuild src/index.ts --bundle --platform=node --target=node20 --outfile=dist/index.js",
+    "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
-    "@types/node": "^20.12.7",
-    "@vercel/ncc": "^0.38.1",
-    "typescript": "^5.4.5",
-    "vitest": "^1.5.0"
-  }
+    "esbuild": "^0.20.0",
+    "typescript": "^5.4.0"
+  },
+  "license": "MIT"
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,61 +1,285 @@
-import * as core from '@actions/core';
+// AtlaSent Gate Action — Zero-dependency GitHub Action entry point
+// Reads GitHub Actions inputs via INPUT_* env vars and calls the AtlaSent evaluate endpoint.
+
+import https from "node:https";
+import http from "node:http";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function getInput(name: string, required = false): string {
+  // GitHub Actions sets inputs as env vars: INPUT_<UPPER_NAME> with hyphens replaced by underscores
+  const envKey = `INPUT_${name.replace(/-/g, "_").toUpperCase()}`;
+  const val = (process.env[envKey] ?? "").trim();
+  if (required && !val) {
+    setFailed(`Input required and not supplied: ${name}`);
+  }
+  return val;
+}
+
+function setOutput(name: string, value: string): void {
+  const outputFile = process.env["GITHUB_OUTPUT"];
+  if (outputFile) {
+    const fs = require("node:fs");
+    fs.appendFileSync(outputFile, `${name}=${value}\n`);
+  }
+  // Also log for older runners
+  console.log(`::set-output name=${name}::${value}`);
+}
+
+function setFailed(message: string): never {
+  console.log(`::error::${message}`);
+  process.exit(1);
+}
+
+function warning(message: string): void {
+  console.log(`::warning::${message}`);
+}
+
+function info(message: string): void {
+  console.log(message);
+}
+
+function maskValue(value: string): void {
+  console.log(`::add-mask::${value}`);
+}
+
+// ---------------------------------------------------------------------------
+// HTTP helper — zero-dependency POST using Node built-ins
+// ---------------------------------------------------------------------------
+
+interface HttpResponse {
+  status: number;
+  body: string;
+}
+
+function post(url: string, body: string, headers: Record<string, string>): Promise<HttpResponse> {
+  return new Promise((resolve, reject) => {
+    const parsed = new URL(url);
+    const transport = parsed.protocol === "https:" ? https : http;
+
+    const req = transport.request(
+      {
+        hostname: parsed.hostname,
+        port: parsed.port || (parsed.protocol === "https:" ? 443 : 80),
+        path: parsed.pathname + parsed.search,
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Content-Length": Buffer.byteLength(body),
+          ...headers,
+        },
+        timeout: 30_000,
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (chunk: Buffer) => chunks.push(chunk));
+        res.on("end", () => {
+          resolve({
+            status: res.statusCode ?? 0,
+            body: Buffer.concat(chunks).toString("utf-8"),
+          });
+        });
+      },
+    );
+
+    req.on("error", reject);
+    req.on("timeout", () => {
+      req.destroy();
+      reject(new Error("Request timed out after 30 seconds"));
+    });
+
+    req.write(body);
+    req.end();
+  });
+}
+
+// ---------------------------------------------------------------------------
+// GitHub context from environment
+// ---------------------------------------------------------------------------
+
+interface GitHubContext {
+  repository: string;
+  ref: string;
+  sha: string;
+  run_id: string;
+  run_number: string;
+  workflow: string;
+  event_name: string;
+  pr_number: string | undefined;
+  server_url: string;
+}
+
+function getGitHubContext(): GitHubContext {
+  return {
+    repository: process.env["GITHUB_REPOSITORY"] ?? "",
+    ref: process.env["GITHUB_REF"] ?? "",
+    sha: process.env["GITHUB_SHA"] ?? "",
+    run_id: process.env["GITHUB_RUN_ID"] ?? "",
+    run_number: process.env["GITHUB_RUN_NUMBER"] ?? "",
+    workflow: process.env["GITHUB_WORKFLOW"] ?? "",
+    event_name: process.env["GITHUB_EVENT_NAME"] ?? "",
+    pr_number: process.env["GITHUB_REF"]?.match(/^refs\/pull\/(\d+)\//)?.[1],
+    server_url: process.env["GITHUB_SERVER_URL"] ?? "https://github.com",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Determine environment
+// ---------------------------------------------------------------------------
+
+function resolveEnvironment(explicit: string, ref: string, apiKey: string): string {
+  if (explicit) return explicit;
+  // Infer from API key prefix
+  if (apiKey.startsWith("ask_test_")) return "test";
+  if (apiKey.startsWith("ask_live_")) return "live";
+  // Infer from branch
+  const branch = ref.replace("refs/heads/", "");
+  return branch === "main" || branch === "master" ? "live" : "test";
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
 
 async function run(): Promise<void> {
-  const apiUrl = core.getInput('atlasent-api-url', { required: true });
-  const apiKey = core.getInput('atlasent-api-key', { required: true });
-  const actionId = core.getInput('action-id', { required: true });
-  const actorId = core.getInput('actor-id') || process.env.GITHUB_ACTOR || 'unknown';
-  const targetId = core.getInput('target-id') || process.env.GITHUB_REPOSITORY || 'unknown';
-  const failOnDeny = core.getBooleanInput('fail-on-deny');
+  // 1. Read inputs
+  const apiKey = getInput("api-key", true);
+  const actionType = getInput("action", true);
+  const actor = getInput("actor") || "unknown";
+  const explicitEnv = getInput("environment");
+  const apiUrl = getInput("api-url") || "https://ihghhasvxtltlbizvkqy.supabase.co/functions/v1";
+  const failOnDeny = getInput("fail-on-deny") !== "false";
+  let extraContext: Record<string, unknown> = {};
+  try {
+    extraContext = JSON.parse(getInput("context") || "{}");
+  } catch {
+    warning("Could not parse 'context' input as JSON — ignoring");
+  }
 
-  core.info(`AtlaSent: evaluating action "${actionId}" for actor "${actorId}"`);
+  // Mask the API key so it never appears in logs
+  maskValue(apiKey);
+
+  // 2. Build context
+  const gh = getGitHubContext();
+  const environment = resolveEnvironment(explicitEnv, gh.ref, apiKey);
 
   const payload = {
-    actor: { id: actorId, type: 'service', metadata: { workflow: process.env.GITHUB_WORKFLOW, run_id: process.env.GITHUB_RUN_ID } },
-    action: { id: crypto.randomUUID(), type: actionId },
-    target: { id: targetId, type: 'repository', environment: process.env.GITHUB_REF?.includes('main') ? 'production' : 'staging' },
+    action_type: actionType,
+    actor_id: `github:${actor}`,
+    context: {
+      environment,
+      source: "github-action",
+      repository: gh.repository,
+      ref: gh.ref,
+      sha: gh.sha,
+      workflow: gh.workflow,
+      run_id: gh.run_id,
+      run_number: gh.run_number,
+      event_name: gh.event_name,
+      pr_number: gh.pr_number ?? null,
+      run_url: `${gh.server_url}/${gh.repository}/actions/runs/${gh.run_id}`,
+      ...extraContext,
+    },
   };
 
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), 15_000);
-  let result: { decision: string; risk?: { level: string; score: number }; id?: string; permitId?: string };
+  info(`AtlaSent Gate: evaluating "${actionType}" for actor "${actor}" in ${environment} environment`);
 
+  // 3. Call the evaluate endpoint
+  let response: HttpResponse;
   try {
-    const res = await fetch(`${apiUrl.replace(/\/$/, '')}/v1/evaluate`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', 'X-AtlaSent-Key': apiKey },
-      body: JSON.stringify(payload),
-      signal: controller.signal,
+    response = await post(`${apiUrl}/v1-evaluate`, JSON.stringify(payload), {
+      Authorization: `Bearer ${apiKey}`,
     });
-    clearTimeout(timer);
-    if (!res.ok) {
-      const err = await res.json().catch(() => ({ message: res.statusText }));
-      throw new Error(`AtlaSent API error ${res.status}: ${err.message}`);
-    }
-    result = await res.json();
-  } catch (e) {
-    clearTimeout(timer);
-    core.setFailed(`AtlaSent evaluation failed: ${e instanceof Error ? e.message : String(e)}`);
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    warning(`AtlaSent API request failed: ${message}`);
+    warning("Network error — failing open. The deployment will proceed without authorization.");
+    setOutput("decision", "error");
     return;
   }
 
-  core.setOutput('decision', result.decision);
-  core.setOutput('risk-level', result.risk?.level ?? 'unknown');
-  core.setOutput('risk-score', String(result.risk?.score ?? 0));
-  core.setOutput('evaluation-id', result.id ?? '');
-  core.setOutput('permit-id', result.permitId ?? '');
+  // 4. Parse response
+  if (response.status < 200 || response.status >= 300) {
+    const msg = `AtlaSent API returned HTTP ${response.status}: ${response.body}`;
+    if (failOnDeny) {
+      setFailed(msg);
+    } else {
+      warning(msg);
+      setOutput("decision", "error");
+      return;
+    }
+  }
 
-  core.info(`AtlaSent decision: ${result.decision} (risk: ${result.risk?.level}, score: ${result.risk?.score})`);
+  let result: {
+    decision?: string;
+    permit_token?: string;
+    evaluation_id?: string;
+    proof_hash?: string;
+    deny_reason?: string;
+    hold_reason?: string;
+  };
 
-  if (result.decision === 'deny') {
-    const msg = `AtlaSent denied action "${actionId}" — risk ${result.risk?.level} (${result.risk?.score}/100)`;
-    if (failOnDeny) core.setFailed(msg);
-    else core.warning(msg);
-  } else if (result.decision === 'require_approval') {
-    core.warning(`AtlaSent requires approval for action "${actionId}". Permit: ${result.permitId ?? 'none'}`);
-  } else {
-    core.info(`AtlaSent allowed action "${actionId}". Permit: ${result.permitId}`);
+  try {
+    result = JSON.parse(response.body);
+  } catch {
+    setFailed(`Failed to parse AtlaSent response: ${response.body}`);
+  }
+
+  const decision = result!.decision ?? "unknown";
+  const permitToken = result!.permit_token ?? "";
+  const evaluationId = result!.evaluation_id ?? "";
+  const proofHash = result!.proof_hash ?? "";
+
+  // 5. Set outputs
+  setOutput("decision", decision);
+  setOutput("permit-token", permitToken);
+  setOutput("evaluation-id", evaluationId);
+  setOutput("proof-hash", proofHash);
+
+  // 6. Handle decision
+  switch (decision) {
+    case "allow":
+      info(`Authorization GRANTED`);
+      info(`  Permit token: ${permitToken}`);
+      info(`  Proof hash:   ${proofHash}`);
+      info(`  Evaluation:   ${evaluationId}`);
+      break;
+
+    case "deny":
+      if (failOnDeny) {
+        setFailed(`Authorization DENIED: ${result!.deny_reason ?? "no reason provided"}`);
+      } else {
+        warning(`Authorization DENIED: ${result!.deny_reason ?? "no reason provided"}`);
+      }
+      break;
+
+    case "hold":
+      if (failOnDeny) {
+        setFailed(`Authorization on HOLD: ${result!.hold_reason ?? "awaiting approval"}`);
+      } else {
+        warning(`Authorization on HOLD: ${result!.hold_reason ?? "awaiting approval"}`);
+      }
+      break;
+
+    case "escalate":
+      if (failOnDeny) {
+        setFailed("Authorization ESCALATED — manual review required");
+      } else {
+        warning("Authorization ESCALATED — manual review required");
+      }
+      break;
+
+    default:
+      warning(`Unexpected decision: ${decision}`);
+      if (failOnDeny) {
+        setFailed(`Unexpected decision from AtlaSent: ${decision}`);
+      }
   }
 }
 
-run();
+run().catch((err) => {
+  console.log(`::error::Unexpected error: ${err instanceof Error ? err.message : String(err)}`);
+  process.exit(1);
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,12 +2,13 @@
   "compilerOptions": {
     "target": "ES2022",
     "module": "commonjs",
-    "lib": ["ES2022"],
+    "moduleResolution": "node",
     "strict": true,
     "esModuleInterop": true,
-    "skipLibCheck": true,
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "declaration": false,
+    "skipLibCheck": true
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Summary

Ports the working v1 github-action implementation from `atlasent-api/github-action/` (née `atlasent-console/github-action/`) into this repo, which is the correct canonical home for a marketplace-publishable Action.

## Why

Before this PR, `atlasent-action` contained a v2-style implementation (`X-AtlaSent-Key` header, `require_approval` decision type, different endpoint shape) that **did not talk to any deployed backend**. The actually-working Action was a copy in `atlasent-api/github-action/`.

Per the canonical-homes decision recorded in `atlasent-api/docs/REPO_STRUCTURE_2026-04-23.md`, `atlasent-action` should be the canonical repo. This PR aligns the implementation with the repo.

## What changed

- **`action.yml`** — input schema now matches the live v1 backend: `api-key`, `action`, `actor`, `environment`, `api-url`, `fail-on-deny`, `context`. Outputs are `decision`, `permit-token`, `evaluation-id`, `proof-hash`.
- **`src/index.ts`** — zero-dependency Node implementation. Reads `INPUT_*` env vars directly (no `@actions/core`) and uses `node:https` so the compiled bundle is minimal. Fail-open on network error by design (an AtlaSent outage shouldn't block every customer's prod deploy).
- **`package.json`** — `2.0.0` → `1.1.0`. "v2" implied a rewrite that never shipped; v1.1.0 accurately describes an iterative release on the already-live v1 backend. Drops `@actions/core` + `@actions/github` deps, adds `esbuild` for single-file bundling.
- **`tsconfig.json`** — targets the bundler config (CommonJS, node20).
- **`README.md`** — documents the real input schema, shows how to protect `main` with a required status check, explains the fail-open-on-network design choice.
- **`LICENSE`** — unchanged.

## Follow-up (manual steps after merge)

1. `npm install && npm run build` to produce `dist/index.js`.
2. Commit `dist/index.js` (GitHub Actions runs the built bundle, not source).
3. Tag the release:
   ```bash
   git tag -a v1.1.0 -m "Port working v1 implementation"
   git push origin v1.1.0
   git tag -f v1  # floating major tag
   git push -f origin v1
   ```
4. Update marketplace listing if needed.

After `v1` resolves to this implementation, a follow-up PR in `atlasent-api` will delete `atlasent-api/github-action/`.

## Test plan

- [ ] `npm run typecheck` passes
- [ ] `npm run build` produces `dist/index.js` without errors
- [ ] Live smoke test: run a workflow with `uses: AtlaSent-Systems-Inc/atlasent-action@<this-sha>` against an `ask_test_*` key and confirm it receives a decision
- [ ] README renders on GitHub
- [ ] Fail-open behaviour: `api-url` pointed at an unreachable host logs a `::warning::` and returns `decision=error` (does not fail the workflow)

https://claude.ai/code/session_018wMfiqwViZoNyCxNWtZ3Ku

---
_Generated by [Claude Code](https://claude.ai/code/session_018wMfiqwViZoNyCxNWtZ3Ku)_