### PR TITLE
feat(v2.1): B.AC1–B.AC3 — list input, batch fan-out, streaming-wait

### DIFF
--- a/docs/V2_ROLLOUT.md
+++ b/docs/V2_ROLLOUT.md
@@ -1,0 +1,34 @@
+# atlasent-action — v2.1 rollout
+
+Wave B of the [umbrella v2 rollout](https://github.com/AtlaSent-Systems-Inc/atlasent/blob/claude/plan-v2-rollout-5IPGF/V2_ROLLOUT.md). Companion implementation to plan PR #15.
+
+## Status
+
+| Item | Module | State |
+|---|---|---|
+| B.AC1 — list-input parser (`evaluations:`) | `src/inputs.ts` | landed (this PR, draft) |
+| B.AC2 — batch fan-out via `/v1/evaluate/batch` | `src/batch.ts` | landed (this PR, draft) |
+| B.AC3 — streaming-wait for change_window | `src/stream.ts` | landed (this PR, draft) |
+| B.AC4 — wire v2.1 modules into `action.yml` + `src/index.ts` | not in this PR | pending review of the new shape |
+
+## Scope (this PR)
+
+New files only. `action.yml` and `src/index.ts` are untouched so the
+v2.0 entry point keeps shipping unchanged. The v2.1 entry point at
+`src/v21.ts` is a preview surface; B.AC4 wires it in after this PR
+settles.
+
+## Tenant flags
+
+- `v2_batch` — `evaluateMany()` switches between `/v1/evaluate/batch`
+  and per-item loop.
+- `v2_streaming` — `waitForTerminalDecision()` switches between SSE
+  consumption and 5s polling.
+
+## Why this PR is a draft
+
+- B.AC4 wiring waits on review of the input shape (single vs list).
+- The v2.1 entry point is reviewable in `src/v21.ts` without touching
+  the production action.
+- Endpoints behind both flags are gated by `atlasent-control-plane#5`
+  (now landed as control-plane#6).

--- a/src/__tests__/batch.test.ts
+++ b/src/__tests__/batch.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { evaluateMany } from "../batch";
+
+describe("evaluateMany", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("hits /v1/evaluate/batch when v2Batch=true", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          results: [
+            {
+              decision: "allow",
+              evaluatedAt: "2026-04-25T00:00:00Z",
+            },
+          ],
+          batchId: "b1",
+        }),
+      ),
+    );
+    const out = await evaluateMany(
+      "https://api.test",
+      "k",
+      [{ action: "a", actor: "u" }],
+      true,
+    );
+    expect(out.batchId).toBe("b1");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.test/v1/evaluate/batch",
+      expect.anything(),
+    );
+  });
+
+  it("loops /v1/evaluate when v2Batch=false", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          decision: "allow",
+          evaluatedAt: "2026-04-25T00:00:00Z",
+        }),
+      ),
+    );
+    const out = await evaluateMany(
+      "https://api.test",
+      "k",
+      [
+        { action: "a", actor: "u" },
+        { action: "b", actor: "u" },
+      ],
+      false,
+    );
+    expect(out.decisions).toHaveLength(2);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(out.batchId).toMatch(/^loop-/);
+  });
+
+  it("throws on non-2xx batch response", async () => {
+    fetchMock.mockResolvedValueOnce(new Response("x", { status: 500 }));
+    await expect(
+      evaluateMany("https://api.test", "k", [{ action: "a", actor: "u" }], true),
+    ).rejects.toThrow(/500/);
+  });
+});

--- a/src/__tests__/inputs.test.ts
+++ b/src/__tests__/inputs.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { parseInputs } from "../inputs";
+
+describe("parseInputs", () => {
+  it("parses v2.0 single-input path", () => {
+    const out = parseInputs({
+      "INPUT_API-KEY": "ask_test",
+      INPUT_ACTION: "production_deploy",
+      GITHUB_ACTOR: "alice",
+    });
+    expect(out.evaluations).toBeUndefined();
+    expect(out.single?.action).toBe("production_deploy");
+    expect(out.single?.actor).toBe("alice");
+  });
+
+  it("parses v2.1 list-input path", () => {
+    const out = parseInputs({
+      "INPUT_API-KEY": "ask_test",
+      INPUT_EVALUATIONS: JSON.stringify([
+        { action: "deploy.staging", actor: "alice" },
+        { action: "deploy.prod", actor: "alice" },
+      ]),
+    });
+    expect(out.evaluations).toHaveLength(2);
+    expect(out.evaluations?.[1].action).toBe("deploy.prod");
+  });
+
+  it("prefers list when both are set", () => {
+    const out = parseInputs({
+      "INPUT_API-KEY": "ask_test",
+      INPUT_ACTION: "ignored",
+      INPUT_EVALUATIONS: JSON.stringify([
+        { action: "deploy.prod", actor: "alice" },
+      ]),
+    });
+    expect(out.evaluations).toHaveLength(1);
+    expect(out.single).toBeUndefined();
+  });
+
+  it("throws on empty list", () => {
+    expect(() =>
+      parseInputs({
+        "INPUT_API-KEY": "ask_test",
+        INPUT_EVALUATIONS: "[]",
+      }),
+    ).toThrow(/non-empty/);
+  });
+
+  it("throws when neither single nor list is set", () => {
+    expect(() => parseInputs({ "INPUT_API-KEY": "ask_test" })).toThrow(
+      /Missing required input: action/,
+    );
+  });
+});

--- a/src/batch.ts
+++ b/src/batch.ts
@@ -1,0 +1,54 @@
+// Wave B.AC2 — batch fan-out helper.
+//
+// When the per-tenant `v2_batch` flag is on, posts a single batch to
+// /v1/evaluate/batch. Otherwise, per-item /v1/evaluate loop. Either
+// path returns the same `BatchResult` shape so the action's render
+// step does not branch on transport.
+
+import type { Decision, EvaluateRequest } from "./types";
+
+export interface BatchResult {
+  decisions: Decision[];
+  /** Originating batchId, or `loop-<ts>` when the loop fallback ran. */
+  batchId: string;
+}
+
+export async function evaluateMany(
+  apiUrl: string,
+  apiKey: string,
+  items: EvaluateRequest[],
+  v2Batch: boolean,
+): Promise<BatchResult> {
+  const headers = {
+    "content-type": "application/json",
+    authorization: `Bearer ${apiKey}`,
+  };
+  if (v2Batch) {
+    const r = await fetch(`${apiUrl}/v1/evaluate/batch`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ items }),
+    });
+    if (!r.ok) {
+      throw new Error(`atlasent /v1/evaluate/batch ${r.status}`);
+    }
+    const data = (await r.json()) as {
+      results: Decision[];
+      batchId: string;
+    };
+    return { decisions: data.results, batchId: data.batchId };
+  }
+  const decisions: Decision[] = [];
+  for (const item of items) {
+    const r = await fetch(`${apiUrl}/v1/evaluate`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(item),
+    });
+    if (!r.ok) {
+      throw new Error(`atlasent /v1/evaluate ${r.status}`);
+    }
+    decisions.push((await r.json()) as Decision);
+  }
+  return { decisions, batchId: `loop-${Date.now()}` };
+}

--- a/src/inputs.ts
+++ b/src/inputs.ts
@@ -1,0 +1,70 @@
+// Wave B.AC1 — input parser.
+//
+// The action accepts either:
+//   - a single `action` input (v2.0 behavior, preserved exactly), or
+//   - a list of evaluations as a JSON `evaluations` input (v2.1).
+//
+// When both are set, `evaluations` wins and `action` is ignored. This
+// is auto-detected so existing workflows continue to work unchanged.
+
+import type { EvaluateRequest } from "./types";
+
+export interface ActionInputs {
+  apiKey: string;
+  apiUrl: string;
+  failOnDeny: boolean;
+  /** When provided, fan out via evaluateMany. Otherwise single eval. */
+  evaluations?: EvaluateRequest[];
+  /** Single-input fallback (v2.0 path). */
+  single?: EvaluateRequest;
+  /** Optional change_window evaluation id to wait on after dispatch. */
+  waitForId?: string;
+  waitTimeoutMs?: number;
+}
+
+export function parseInputs(env: Record<string, string | undefined>): ActionInputs {
+  const apiKey = required(env, "INPUT_API-KEY");
+  const apiUrl = env["INPUT_API-URL"] || "https://api.atlasent.io";
+  const failOnDeny = (env["INPUT_FAIL-ON-DENY"] || "true") === "true";
+
+  const evaluationsRaw = env["INPUT_EVALUATIONS"];
+  if (evaluationsRaw && evaluationsRaw.trim()) {
+    const parsed = JSON.parse(evaluationsRaw) as EvaluateRequest[];
+    if (!Array.isArray(parsed) || parsed.length === 0) {
+      throw new Error(
+        "`evaluations` must be a non-empty JSON array of evaluation requests",
+      );
+    }
+    return {
+      apiKey,
+      apiUrl,
+      failOnDeny,
+      evaluations: parsed,
+      waitForId: env["INPUT_WAIT-FOR-ID"] || undefined,
+      waitTimeoutMs: parseInt(env["INPUT_WAIT-TIMEOUT-MS"] || "600000", 10),
+    };
+  }
+
+  const action = required(env, "INPUT_ACTION");
+  const actor = env["INPUT_ACTOR"] || env["GITHUB_ACTOR"] || "unknown";
+  const environment = env["INPUT_ENVIRONMENT"];
+  const contextRaw = env["INPUT_CONTEXT"] || "{}";
+  const context = JSON.parse(contextRaw) as Record<string, unknown>;
+
+  return {
+    apiKey,
+    apiUrl,
+    failOnDeny,
+    single: { action, actor, environment, context },
+    waitForId: env["INPUT_WAIT-FOR-ID"] || undefined,
+    waitTimeoutMs: parseInt(env["INPUT_WAIT-TIMEOUT-MS"] || "600000", 10),
+  };
+}
+
+function required(env: Record<string, string | undefined>, key: string): string {
+  const v = env[key];
+  if (!v) {
+    throw new Error(`Missing required input: ${key.replace("INPUT_", "").toLowerCase()}`);
+  }
+  return v;
+}

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -1,0 +1,95 @@
+// Wave B.AC3 — streaming-wait helper.
+//
+// Consumes /v1/evaluate/stream Server-Sent Events for the duration of
+// a change_window approval. Resolves with the first terminal decision
+// (allow / deny) for the watched evaluation id, or rejects on timeout.
+//
+// When the per-tenant `v2_streaming` flag is off, falls back to
+// polling /v1/evaluate/:id every 5 seconds.
+
+import type { Decision } from "./types";
+
+const POLL_INTERVAL_MS = 5_000;
+const SSE_LINE = /^data: (.+)$/;
+
+export interface WaitOptions {
+  apiUrl: string;
+  apiKey: string;
+  evaluationId: string;
+  timeoutMs: number;
+  v2Streaming: boolean;
+  signal?: AbortSignal;
+}
+
+export async function waitForTerminalDecision(
+  opts: WaitOptions,
+): Promise<Decision> {
+  if (opts.v2Streaming) {
+    return waitViaStream(opts);
+  }
+  return waitViaPolling(opts);
+}
+
+async function waitViaStream(opts: WaitOptions): Promise<Decision> {
+  const r = await fetch(`${opts.apiUrl}/v1/evaluate/stream`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      authorization: `Bearer ${opts.apiKey}`,
+      accept: "text/event-stream",
+    },
+    body: JSON.stringify({ evaluationId: opts.evaluationId }),
+    signal: opts.signal,
+  });
+  if (!r.ok || !r.body) {
+    throw new Error(`atlasent /v1/evaluate/stream ${r.status}`);
+  }
+  const reader = r.body.getReader();
+  const decoder = new TextDecoder();
+  const deadline = Date.now() + opts.timeoutMs;
+  let buf = "";
+  while (Date.now() < deadline) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    buf += decoder.decode(value, { stream: true });
+    let idx: number;
+    while ((idx = buf.indexOf("\n\n")) !== -1) {
+      const block = buf.slice(0, idx);
+      buf = buf.slice(idx + 2);
+      for (const line of block.split("\n")) {
+        const m = SSE_LINE.exec(line);
+        if (!m) continue;
+        const event = JSON.parse(m[1]) as Decision;
+        if (event.decision === "allow" || event.decision === "deny") {
+          return event;
+        }
+      }
+    }
+  }
+  throw new Error(
+    `atlasent stream timeout after ${opts.timeoutMs}ms for ${opts.evaluationId}`,
+  );
+}
+
+async function waitViaPolling(opts: WaitOptions): Promise<Decision> {
+  const deadline = Date.now() + opts.timeoutMs;
+  while (Date.now() < deadline) {
+    const r = await fetch(
+      `${opts.apiUrl}/v1/evaluate/${encodeURIComponent(opts.evaluationId)}`,
+      {
+        headers: { authorization: `Bearer ${opts.apiKey}` },
+        signal: opts.signal,
+      },
+    );
+    if (r.ok) {
+      const decision = (await r.json()) as Decision;
+      if (decision.decision === "allow" || decision.decision === "deny") {
+        return decision;
+      }
+    }
+    await new Promise((res) => setTimeout(res, POLL_INTERVAL_MS));
+  }
+  throw new Error(
+    `atlasent poll timeout after ${opts.timeoutMs}ms for ${opts.evaluationId}`,
+  );
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,20 @@
+// Shared types for the v2.1 modules. Kept separate from the v2.0
+// entry point in src/index.ts so that file remains untouched until
+// B.AC4 wires the new modules in.
+
+export interface EvaluateRequest {
+  action: string;
+  actor: string;
+  environment?: string;
+  context?: Record<string, unknown>;
+}
+
+export interface Decision {
+  /** Evaluation id (for streaming-wait + audit). */
+  id?: string;
+  decision: "allow" | "deny" | "hold" | "escalate";
+  permitToken?: string;
+  proofHash?: string;
+  reasons?: string[];
+  evaluatedAt: string;
+}

--- a/src/v21.ts
+++ b/src/v21.ts
@@ -1,0 +1,66 @@
+// Wave B.AC4 preview — v2.1 entry point.
+//
+// Kept separate from src/index.ts so the existing v2.0 entry point
+// stays byte-identical. B.AC4 wires this in once the new shape is
+// reviewed.
+//
+// Flow:
+//   1. parseInputs() detects single vs list shape.
+//   2. evaluateMany() runs (single becomes a 1-item batch under the
+//      hood, no separate code path).
+//   3. If any decision is hold|escalate AND a wait-for-id is set,
+//      waitForTerminalDecision() blocks until the upstream approver
+//      flips it.
+//   4. Job summary is rendered per evaluation.
+
+import { evaluateMany } from "./batch";
+import { parseInputs } from "./inputs";
+import { waitForTerminalDecision } from "./stream";
+import type { Decision } from "./types";
+
+export interface RunOutput {
+  decisions: Decision[];
+  failed: boolean;
+  batchId: string;
+}
+
+export async function runV21(
+  env: Record<string, string | undefined>,
+  flags: { v2Batch: boolean; v2Streaming: boolean },
+): Promise<RunOutput> {
+  const inputs = parseInputs(env);
+  const items = inputs.evaluations ?? [inputs.single!];
+
+  const batch = await evaluateMany(
+    inputs.apiUrl,
+    inputs.apiKey,
+    items,
+    flags.v2Batch,
+  );
+
+  let decisions = batch.decisions;
+
+  if (inputs.waitForId) {
+    const idx = decisions.findIndex(
+      (d) =>
+        d.id === inputs.waitForId &&
+        (d.decision === "hold" || d.decision === "escalate"),
+    );
+    if (idx >= 0) {
+      const terminal = await waitForTerminalDecision({
+        apiUrl: inputs.apiUrl,
+        apiKey: inputs.apiKey,
+        evaluationId: inputs.waitForId,
+        timeoutMs: inputs.waitTimeoutMs ?? 600_000,
+        v2Streaming: flags.v2Streaming,
+      });
+      decisions = [...decisions];
+      decisions[idx] = terminal;
+    }
+  }
+
+  const failed =
+    inputs.failOnDeny && decisions.some((d) => d.decision === "deny");
+
+  return { decisions, failed, batchId: batch.batchId };
+}


### PR DESCRIPTION
## Summary

Wave B of the [v2 rollout](https://github.com/AtlaSent-Systems-Inc/atlasent/blob/claude/plan-v2-rollout-5IPGF/V2_ROLLOUT.md). Companion implementation to plan PR #15. Lands the v2.1 modules **alongside** the existing v2.0 entry point — no changes to `action.yml` or `src/index.ts`, so the production action keeps shipping byte-identically until B.AC4 wires this in.

## What's in this PR

| Item | Module | Notes |
|---|---|---|
| **B.AC1** input parser | `src/inputs.ts` | Auto-detects single (`action:`) vs list (`evaluations:`) input. List wins when both are set; v2.0 single-input path is preserved exactly. |
| **B.AC2** batch fan-out | `src/batch.ts` | `evaluateMany()` flips between `/v1/evaluate/batch` and per-item loop on `v2_batch`. Same `BatchResult` shape either way. |
| **B.AC3** streaming-wait | `src/stream.ts` | `waitForTerminalDecision()` consumes `/v1/evaluate/stream` SSE for `change_window` approvals; falls back to 5s polling on `/v1/evaluate/:id` when `v2_streaming=false`. |
| Shared types | `src/types.ts` | `EvaluateRequest`, `Decision`. |
| v2.1 entry preview | `src/v21.ts` | Demonstrates the v2.1 flow end-to-end. Not yet wired into `action.yml`. |
| Tests | `src/__tests__/inputs.test.ts`, `batch.test.ts` | 5 + 3 Vitest cases. |

## Why split from v2.0

`action.yml` and `src/index.ts` are intentionally untouched in this PR. New files sit alongside the v2.0 entry point as a review surface. **B.AC4** (wiring into `action.yml`'s inputs + `src/index.ts`'s main flow) lands once the input shape is reviewed and signed off.

## Tenant flag behavior

| Flag | Module | True | False/unset |
|---|---|---|---|
| `v2_batch` | `evaluateMany` | `POST /v1/evaluate/batch` | per-item loop |
| `v2_streaming` | `waitForTerminalDecision` | SSE consumer | 5s poll on `/v1/evaluate/:id` |

Flags resolved per the canonical resolver in [atlasent-control-plane#6](https://github.com/AtlaSent-Systems-Inc/atlasent-control-plane/pull/6).

## Why draft

- B.AC4 wiring waits on the input-shape decision (plan #15 open question: single vs list, auto-detect or distinct fields).
- Endpoints behind both flags need Waqas's `/v1/evaluate/batch` and `/v1/evaluate/stream` to land.
- v2.0 entry point (`src/index.ts`) is byte-identical so the `dist/index.js` bundle is unchanged.

## Test plan

- [ ] `npm test src/__tests__/inputs.test.ts src/__tests__/batch.test.ts` — 8 tests pass
- [ ] After B.AC4 lands: end-to-end with a real `evaluations:` list against staging
- [ ] After SDK 2.x publishes: optionally swap fetch implementations to `@atlasent/sdk@2`

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DJ43ZHKpdK2nkzZxxaKjm3)_