### PR TITLE
feat: target-id input and risk-score output (1.2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to `atlasent-action` are documented here.
 
+## [1.2.0] — 2026-04-25
+
+### Added
+- `target-id` input — identifies the resource being acted on (service
+  name, artifact id, etc). Threaded into both top-level `target_id`
+  and `context.target_id` in the evaluate request so policies can
+  gate on _what_ is being deployed in addition to _who_ is deploying.
+- `risk-score` output — exposes the numeric risk score from the
+  Decision response. Probes the canonical `result.risk.score` shape
+  first (matches atlasent-api openapi `Decision.risk`) and falls back
+  to a flat `result.risk_score` for older evaluators. Empty string
+  when neither is present so downstream `if: steps.gate.outputs.risk-score`
+  branches don't see `undefined`.
+
+### Notes
+- Source-only release. `dist/index.js` must be rebuilt
+  (`npm run build`) before tagging — release engineering tracks the
+  rebuild step.
+
 ## [1.0.0] — 2026-04-17
 
 ### Added

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,9 @@ inputs:
     description: 'Actor identity (defaults to github.actor)'
     required: false
     default: '${{ github.actor }}'
+  target-id:
+    description: 'Target resource being acted on (service name, artifact id, etc). Threaded into both top-level target_id and context.target_id so policies can gate on what is being deployed, not just who is deploying.'
+    required: false
   environment:
     description: 'Environment (defaults to live for main branch, test otherwise)'
     required: false
@@ -38,6 +41,8 @@ outputs:
     description: 'The evaluation ID for audit trail'
   proof-hash:
     description: 'The cryptographic proof hash'
+  risk-score:
+    description: 'The numeric risk score from the Decision response. Empty string when the evaluator did not return a risk assessment.'
 runs:
   using: 'node20'
   main: 'dist/index.js'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atlasent-action",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "GitHub Action for AtlaSent authorization gates — require a permit before critical CI/CD actions execute",
   "main": "dist/index.js",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -140,6 +140,30 @@ function resolveEnvironment(explicit: string, ref: string, apiKey: string): stri
 }
 
 // ---------------------------------------------------------------------------
+// Risk-score extraction
+// ---------------------------------------------------------------------------
+
+// The v1-evaluate response carries risk in two shapes depending on how
+// the rule engine was wired:
+//   - Canonical (per atlasent-api openapi `Decision.risk`):
+//       { risk: { level, score, reasons, ... } }
+//   - Flat (older / minimal evaluator):
+//       { risk_score: number }
+// Try canonical first, fall back to flat. Returns "" when neither is
+// present so the GitHub output is still set (callers can branch on
+// empty string).
+function extractRiskScore(result: Record<string, unknown>): string {
+  const risk = result["risk"];
+  if (risk && typeof risk === "object" && "score" in risk) {
+    const score = (risk as { score?: unknown }).score;
+    if (typeof score === "number") return String(score);
+  }
+  const flat = result["risk_score"];
+  if (typeof flat === "number") return String(flat);
+  return "";
+}
+
+// ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
 
@@ -148,6 +172,7 @@ async function run(): Promise<void> {
   const apiKey = getInput("api-key", true);
   const actionType = getInput("action", true);
   const actor = getInput("actor") || "unknown";
+  const targetId = getInput("target-id");
   const explicitEnv = getInput("environment");
   const apiUrl = getInput("api-url") || "https://ihghhasvxtltlbizvkqy.supabase.co/functions/v1";
   const failOnDeny = getInput("fail-on-deny") !== "false";
@@ -165,7 +190,7 @@ async function run(): Promise<void> {
   const gh = getGitHubContext();
   const environment = resolveEnvironment(explicitEnv, gh.ref, apiKey);
 
-  const payload = {
+  const payload: Record<string, unknown> = {
     action_type: actionType,
     actor_id: `github:${actor}`,
     context: {
@@ -180,11 +205,20 @@ async function run(): Promise<void> {
       event_name: gh.event_name,
       pr_number: gh.pr_number ?? null,
       run_url: `${gh.server_url}/${gh.repository}/actions/runs/${gh.run_id}`,
+      // target_id is also threaded into context so policies that read
+      // context.target_id (rather than the top-level target_id) match.
+      ...(targetId ? { target_id: targetId } : {}),
       ...extraContext,
     },
   };
 
-  info(`AtlaSent Gate: evaluating "${actionType}" for actor "${actor}" in ${environment} environment`);
+  // Top-level target_id matches the canonical EvaluationParams shape
+  // used by `@atlasent/sdk` and atlasent-console. Older evaluators
+  // that only inspect context will still see it via the context
+  // mirror above.
+  if (targetId) payload["target_id"] = targetId;
+
+  info(`AtlaSent Gate: evaluating "${actionType}" for actor "${actor}" in ${environment} environment${targetId ? ` (target=${targetId})` : ""}`);
 
   // 3. Call the evaluate endpoint.
   // Infrastructure errors (network, timeout, 5xx, 401/403, 429) are
@@ -271,6 +305,7 @@ async function run(): Promise<void> {
   const permitToken = result.permit_token ?? "";
   const evaluationId = result.evaluation_id ?? "";
   const proofHash = result.proof_hash ?? "";
+  const riskScore = extractRiskScore(result as Record<string, unknown>);
 
   // Mask the permit token + proof hash so they don't appear verbatim
   // in action logs. The API key already gets masked at line 162;
@@ -286,6 +321,7 @@ async function run(): Promise<void> {
   setOutput("permit-token", permitToken);
   setOutput("evaluation-id", evaluationId);
   setOutput("proof-hash", proofHash);
+  setOutput("risk-score", riskScore);
 
   // 6. Handle decision
   switch (decision) {
@@ -294,6 +330,7 @@ async function run(): Promise<void> {
       info(`  Permit token: (set as 'permit-token' output, masked in logs)`);
       info(`  Proof hash:   (set as 'proof-hash' output, masked in logs)`);
       info(`  Evaluation:   ${evaluationId}`);
+      if (riskScore) info(`  Risk score:   ${riskScore}`);
       break;
 
     case "deny":


### PR DESCRIPTION
## Summary

Adds the `target-id` input and `risk-score` output that PR #10
(closed unmerged) was originally meant to ship. Lets policies gate on
_what_ is being deployed in addition to _who_, and exposes the risk
score from the Decision response so downstream workflow steps can
branch on it.

## Changes

- **`src/index.ts`** — read `target-id` input, thread into both
  top-level `target_id` and `context.target_id` (covers both
  evaluator shapes); `extractRiskScore()` probes
  `result.risk.score` (canonical openapi `Decision.risk`) first and
  falls back to flat `result.risk_score` for older evaluators
- **`action.yml`** — declare `target-id` input and `risk-score`
  output with operator-friendly descriptions
- **`package.json`** — bump `1.1.0` → `1.2.0`
- **`CHANGELOG.md`** — add `1.2.0` entry. Note: there's an existing
  drift gap where `1.0.0` is the last documented version even though
  `package.json` was already at `1.1.0`; preserved that gap rather
  than backfill 1.1.0 with content I don't have authority over.

## Why a fresh PR vs. revive #10

PR #10's body claimed `src/index.ts` was already calling
`core.getInput('target-id')` and the action.yml was missing the
declaration. Reading current `main`: `src/index.ts` does not
reference target-id at all, and uses raw env-var probing rather than
`@actions/core`. The actual gap is that the feature was never
implemented end-to-end. This PR implements both source + manifest
together so they can't drift again.

## Test plan

- [x] `target-id` is optional; absence → no `target_id` field on the
  payload (back-compat with existing `evaluate` rules)
- [x] When set, `target_id` lands at both top-level and inside
  `context.target_id` so neither evaluator shape misses it
- [x] `risk-score` output is set even when the evaluator returns
  no risk assessment (empty string, not `undefined`) — downstream
  `if: steps.gate.outputs.risk-score` branches stay clean
- [ ] **`dist/index.js` rebuild** — `npm run build` needs to run on
  `main` after merge before tagging `v1.2.0`. Not done in this PR
  because the build step isn't reproducible from this environment.
  Tracked as a blocker on the release tag, not the merge.
- [ ] Manual smoke: a workflow using `with: { target-id: 'svc-prod' }`
  sees `target_id` reach the policy engine
- [ ] Manual smoke: a policy returning `risk: { score: 42 }` results
  in `steps.gate.outputs.risk-score == '42'` downstream

## Stays in draft until

The dist rebuild and the manual smokes above land. Source-only
changes are safe to review/merge as a starter; the v1.2.0 tag should
wait on the rebuild commit.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LPxM4t8nrXdcw2ygcgeQc6)_