### PR TITLE
feat: v1.3.0 — verify-permit contract, v2.1 batch path, enforce unification, 87 SIM tests

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -8,11 +8,11 @@ on:
     branches: [main]
   workflow_dispatch:
     inputs:
-      force_denial:
-        description: 'Force a denial (sets approvals=0, change_window=false)'
+      fail_on_deny:
+        description: 'Fail the job if the gate denies the deploy (default: true)'
         required: false
         type: boolean
-        default: false
+        default: true
       environment:
         description: 'Target environment'
         required: false
@@ -32,19 +32,19 @@ jobs:
         id: gate
         uses: ./
         with:
-          atlasent_api_key: ${{ secrets.ATLASENT_API_KEY }}
-          atlasent_anon_key: ${{ vars.ATLASENT_ANON_KEY }}
-          action: production-deploy
+          api-key: ${{ secrets.ATLASENT_API_KEY }}
+          action: production_deploy
+          actor: ${{ github.actor }}
           environment: ${{ inputs.environment || 'prod' }}
-          approvals: ${{ inputs.force_denial == true && '0' || '2' }}
-          change_window: ${{ inputs.force_denial == true && 'false' || 'true' }}
+          fail-on-deny: ${{ inputs.fail_on_deny == false && 'false' || 'true' }}
 
-      # Only reached if AtlaSent authorized the deploy
+      # Only reached if AtlaSent authorized the deploy (verified=true)
       - name: Deploy to ${{ inputs.environment || 'prod' }}
         run: |
-          echo "Decision:    ${{ steps.gate.outputs.decision }}"
-          echo "Decision ID: ${{ steps.gate.outputs.decision_id }}"
-          echo "Audit Hash:  ${{ steps.gate.outputs.audit_hash }}"
-          echo "Verified:    ${{ steps.gate.outputs.verified }}"
+          echo "Decision:     ${{ steps.gate.outputs.decision }}"
+          echo "Verified:     ${{ steps.gate.outputs.verified }}"
+          echo "Evaluation:   ${{ steps.gate.outputs.evaluation-id }}"
+          echo "Proof hash:   ${{ steps.gate.outputs.proof-hash }}"
+          echo "Risk score:   ${{ steps.gate.outputs.risk-score }}"
           echo ""
           echo "Replace this with your real deploy command."

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,12 +28,26 @@ print('action.yml valid')
 
       - name: Check evaluate step present
         run: |
-          grep -q 'v1-evaluate' action.yml && echo 'evaluate step found'
+          grep -q 'v1-evaluate' src/gate.ts && echo 'evaluate step found'
 
       - name: Check verify step present
         run: |
-          grep -q 'v1-verify-permit' action.yml && echo 'verify step found'
+          grep -q 'v1-verify-permit' src/gate.ts && echo 'verify step found'
 
       - name: Check fail-closed logic
         run: |
-          grep -q 'fail-closed' action.yml && echo 'fail-closed logic found'
+          grep -q 'fail-closed' src/gate.ts && echo 'fail-closed logic found'
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Build and typecheck
+        run: |
+          npm install
+          npm run typecheck
+          npm run build
+
+      - name: Run SIM tests
+        run: npm test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ print('action.yml valid')
 
       - name: Check evaluate step present
         run: |
-          grep -q 'v1-evaluate' src/gate.ts && echo 'evaluate step found'
+          grep -q 'v1/evaluate' src/batch.ts && echo 'evaluate step found'
 
       - name: Check verify step present
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,37 @@ All notable changes to `atlasent-action` are documented here.
 
 ## [1.3.0] — 2026-04-30
 
+### Bug fixes
+- **`wait-for-id` allow path was permanently broken** — when
+  `waitForTerminalDecision` resolved a hold/escalate to `allow`,
+  `v21.ts` assigned the terminal decision without calling `verifyOne`.
+  `verified` was always `undefined`, so `allVerified` was always
+  `false`. The hold → allow path now calls `verifyOne` on the terminal
+  permit (no `permitToken` → `verified=false`, fail-closed).
+- **`decisions` and `batch-id` outputs unset on batch error** —
+  the `runV21()` catch block only wrote `verified=false` before
+  `setFailed`. Downstream steps using `if: always()` got unset values.
+  Now emits `decisions=[]` and `batch-id=""` before failing.
+- **Transport ECONNRESET crash** — `packages/enforce/src/transport.ts`
+  had no `res.on("error")` handler. A mid-response connection reset
+  fired an unhandled EventEmitter error and crashed Node.js. Fixed by
+  adding `res.on("error", reject)` alongside `req.on("error", reject)`.
+- **Polling retried 5xx but not network errors** — `waitViaPolling`
+  swallowed non-2xx responses but let `fetch` throws (network errors,
+  malformed-JSON 200s) propagate immediately, breaking the retry
+  contract. Both cases now swallowed and retried; `AbortError` is
+  re-thrown so caller cancellation still works.
+- **Raw `SyntaxError` leaked on bad `evaluations`/`context` JSON** —
+  `parseInputs` called `JSON.parse` without try/catch; invalid JSON
+  surfaced as `Unexpected error: SyntaxError: ...`. Now reports
+  `` `evaluations` is not valid JSON `` and `` `context` is not valid
+  JSON ``.
+- **`GateInfraError` labelled "Unexpected error"** — the batch catch
+  block in `index.ts` only recognised `EnforceError` for clean message
+  formatting. `GateInfraError` from `verifyOne` on a 5xx appeared as
+  `Unexpected error: verify-permit HTTP 500`. Now detected alongside
+  `EnforceError`.
+
 ### Action — v1-verify-permit wiring (A5 end-to-end)
 - `verified` output: `"true"` only when evaluate returned `decision=allow`
   AND `/v1/verify-permit` confirmed `verified=true`; `"false"` in every

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 All notable changes to `atlasent-action` are documented here.
 
+## [Unreleased] — verify-permit wiring (A5 end-to-end)
+
+### Added
+- `verified` output: `"true"` only when `/v1-evaluate` returned
+  `decision=allow` AND `/v1-verify-permit` confirmed `verified=true`;
+  `"false"` in every other case. Downstream steps should branch on
+  `verified`, not re-derive from `decision`.
+- `src/gate.ts`: testable fetch-based core that encapsulates the
+  evaluate → verify-permit flow. `src/index.ts` delegates all HTTP to
+  this module; GH Actions I/O stays in `src/index.ts`.
+- SIM tests (`src/__tests__/gate.test.ts`) covering all 12 paths in
+  the decision matrix (happy path, replay, expired, no permit_token,
+  policy deny/hold/escalate, and infra errors on both sides).
+
+### Changed
+- The `permit-token` output is now an **audit reference**, not a
+  re-verifiable artifact. The token is single-use and is consumed by
+  the action's own verify call; downstream steps that re-verify would
+  get `outcome=permit_consumed`.
+- `src/index.ts` refactored to import `runGate` from `src/gate.ts`
+  (removes the inline Node `https` HTTP helper; gate uses `fetch`
+  which is available natively in the node20 runner).
+
+### Security
+- Replay protection: a stale or already-consumed `permit_token` now
+  produces `verified=false` and blocks the deploy, instead of passing
+  through as `decision=allow`.
+- Fail-closed end-to-end: all infrastructure errors (network timeout,
+  5xx, 401, 429, no permit_token) throw `GateInfraError` and are
+  never confused with a policy decision.
+
 ## [1.2.0] — 2026-04-25
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,14 @@ All notable changes to `atlasent-action` are documented here.
   mock both evaluate and verify-permit calls (78 total).
 - Built `packages/enforce/dist/` (`index.js`, `index.d.ts`).
 
+### Action — stream SIM tests (B.AC3)
+- 8 SIM tests for `waitForTerminalDecision()` (`src/__tests__/stream.test.ts`),
+  covering the polling path (immediate allow/deny, non-terminal retry,
+  timeout) and the SSE streaming path (terminal event, non-terminal skip,
+  body shape, non-2xx error).
+- Timeout test uses `vi.useFakeTimers()` / `vi.advanceTimersByTimeAsync()`
+  to avoid real 5-second poll intervals in CI.
+
 ### Action — enforce unification
 - Single-eval path now uses `@atlasent/enforce` as the canonical
   enforcement wrapper; `runGate()` (parallel fetch-based implementation)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,8 +44,10 @@ All notable changes to `atlasent-action` are documented here.
   `verifyOutcome`.
 - New `EnforcePhase` value: `"verify-permit"`.
 - 14 SIM tests (`verify-permit.test.ts`); `enforce.test.ts` updated to
-  mock both evaluate and verify-permit calls (78 total).
-- Built `packages/enforce/dist/` (`index.js`, `index.d.ts`).
+  mock both evaluate and verify-permit calls.
+- 5 socket-level tests (`transport.test.ts`) covering success, request
+  error, response-stream error (ECONNRESET), timeout, and header forwarding.
+- Built `packages/enforce/dist/` (`index.js`, `index.d.ts`, `transport.js`).
 
 ### Action — v21 + stream SIM tests
 - 10 SIM tests for `runV21()` (`src/__tests__/v21.test.ts`): items passed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,13 +46,22 @@ All notable changes to `atlasent-action` are documented here.
   mock both evaluate and verify-permit calls (78 total).
 - Built `packages/enforce/dist/` (`index.js`, `index.d.ts`).
 
-### Action — stream SIM tests (B.AC3)
+### Action — v21 + stream SIM tests
+- 10 SIM tests for `runV21()` (`src/__tests__/v21.test.ts`): items passed
+  to `evaluateMany`, single action wrapped into a 1-item batch, batchId
+  forwarded, `failed` flag respects `failOnDeny`, `waitForTerminalDecision`
+  called/skipped based on `waitForId` matching a hold/escalate id.
+  Dependencies mocked via `vi.mock()`.
 - 8 SIM tests for `waitForTerminalDecision()` (`src/__tests__/stream.test.ts`),
   covering the polling path (immediate allow/deny, non-terminal retry,
   timeout) and the SSE streaming path (terminal event, non-terminal skip,
   body shape, non-2xx error).
 - Timeout test uses `vi.useFakeTimers()` / `vi.advanceTimersByTimeAsync()`
   to avoid real 5-second poll intervals in CI.
+
+### CI
+- `test.yml`: `Check evaluate step present` updated to grep `src/batch.ts`
+  for `v1/evaluate` instead of the removed `runGate()` path in `src/gate.ts`.
 
 ### Action — enforce unification
 - Single-eval path now uses `@atlasent/enforce` as the canonical

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,36 +2,57 @@
 
 All notable changes to `atlasent-action` are documented here.
 
-## [Unreleased] — verify-permit wiring (A5 end-to-end)
+## [Unreleased]
 
-### Added
+### Action — v1-verify-permit wiring (A5 end-to-end)
 - `verified` output: `"true"` only when `/v1-evaluate` returned
   `decision=allow` AND `/v1-verify-permit` confirmed `verified=true`;
-  `"false"` in every other case. Downstream steps should branch on
+  `"false"` in every other case. Downstream steps must branch on
   `verified`, not re-derive from `decision`.
-- `src/gate.ts`: testable fetch-based core that encapsulates the
-  evaluate → verify-permit flow. `src/index.ts` delegates all HTTP to
-  this module; GH Actions I/O stays in `src/index.ts`.
-- SIM tests (`src/__tests__/gate.test.ts`) covering all 12 paths in
-  the decision matrix (happy path, replay, expired, no permit_token,
-  policy deny/hold/escalate, and infra errors on both sides).
+- `src/gate.ts`: fetch-based core (`runGate`, `verifyOne`) encapsulating
+  the evaluate → verify-permit flow with `GateInfraError` for all
+  infrastructure failures (network, 5xx, 401, 429, no permit_token).
+- 18 SIM tests (`src/__tests__/gate.test.ts`) covering all paths in
+  the decision matrix.
+- `permit-token` output is now an audit reference (single-use, already
+  consumed by the action's own verify call).
+- Replay protection: stale or consumed `permit_token` → `verified=false`.
 
-### Changed
-- The `permit-token` output is now an **audit reference**, not a
-  re-verifiable artifact. The token is single-use and is consumed by
-  the action's own verify call; downstream steps that re-verify would
-  get `outcome=permit_consumed`.
-- `src/index.ts` refactored to import `runGate` from `src/gate.ts`
-  (removes the inline Node `https` HTTP helper; gate uses `fetch`
-  which is available natively in the node20 runner).
+### Action — v2.1 batch entry point (B.AC4)
+- `evaluations` input: JSON array of evaluation requests for batch
+  mode. When set, `action` / `actor` / `context` are ignored and the
+  v2.1 path (`runV21` → `evaluateMany` → per-decision `verifyOne`) is
+  used instead of the single-eval path.
+- `wait-for-id`, `wait-timeout-ms` inputs: block on a hold/escalate
+  decision until the upstream approver flips it (SSE stream or polling).
+- `v2-batch`, `v2-streaming` flags: opt in to `/v1/evaluate/batch` and
+  SSE streaming respectively.
+- `decisions` output: JSON array of per-item results for the batch path.
+- `batch-id` output: server-assigned batch ID (or `loop-<ts>` for the
+  sequential fallback).
+- `verified` on the batch path: `"true"` only when every allow decision
+  verified; `"false"` otherwise.
+- 6 batch SIM tests (`src/__tests__/batch.test.ts`).
 
-### Security
-- Replay protection: a stale or already-consumed `permit_token` now
-  produces `verified=false` and blocks the deploy, instead of passing
-  through as `decision=allow`.
-- Fail-closed end-to-end: all infrastructure errors (network timeout,
-  5xx, 401, 429, no permit_token) throw `GateInfraError` and are
-  never confused with a policy decision.
+### `@atlasent/enforce` — verifyPermit step
+- `verifyPermit(config, decision)`: calls POST `/v1/verify-permit`;
+  throws `EnforceError(phase="verify-permit")` for replay, expired
+  tokens, no permit_token, network errors, and `!2xx` responses.
+- `enforce()` updated: `evaluate → verify → verifyPermit → execute`.
+  `fn` never runs unless all three gates pass. Return gains
+  `verifyOutcome`.
+- New `EnforcePhase` value: `"verify-permit"`.
+- 14 SIM tests (`verify-permit.test.ts`); `enforce.test.ts` updated to
+  mock both evaluate and verify-permit calls (78 total).
+- Built `packages/enforce/dist/` (`index.js`, `index.d.ts`).
+
+### Workflows
+- `deploy.yaml`: fixed stale inputs (`atlasent_api_key` → `api-key`,
+  removed `atlasent_anon_key`/`approvals`/`change_window`) and stale
+  outputs (`decision_id` → `evaluation-id`, `audit_hash` →
+  `proof-hash`) to match current `action.yml`.
+- `test.yml`: grep targets corrected to `src/gate.ts`; build,
+  typecheck, and test steps added to CI.
 
 ## [1.2.0] — 2026-04-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,22 @@ All notable changes to `atlasent-action` are documented here.
   mock both evaluate and verify-permit calls (78 total).
 - Built `packages/enforce/dist/` (`index.js`, `index.d.ts`).
 
+### Action — enforce unification
+- Single-eval path now uses `@atlasent/enforce` as the canonical
+  enforcement wrapper; `runGate()` (parallel fetch-based implementation)
+  removed from production code. `src/gate.ts` now only exports
+  `verifyOne()` and `GateInfraError` for the v2.1 batch path.
+- `@atlasent/enforce` added as a workspace dependency; esbuild bundles
+  it into `dist/index.js`.
+- Default `api-url` changed from the Supabase function base to
+  `https://api.atlasent.io` to match the enforce package's default and
+  the current REST API.
+- `fail-on-deny=false` behaviour preserved: only `phase="verify"` errors
+  (policy decisions) respect the flag; all other phases remain
+  fail-closed.
+- Gate SIM tests retargeted: 18 `runGate()` tests replaced with 9
+  focused `verifyOne()` tests (`src/__tests__/gate.test.ts`).
+
 ### Workflows
 - `deploy.yaml`: fixed stale inputs (`atlasent_api_key` → `api-key`,
   removed `atlasent_anon_key`/`approvals`/`change_window`) and stale

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,17 +5,16 @@ All notable changes to `atlasent-action` are documented here.
 ## [Unreleased]
 
 ### Action — v1-verify-permit wiring (A5 end-to-end)
-- `verified` output: `"true"` only when `/v1-evaluate` returned
-  `decision=allow` AND `/v1-verify-permit` confirmed `verified=true`;
-  `"false"` in every other case. Downstream steps must branch on
-  `verified`, not re-derive from `decision`.
-- `src/gate.ts`: fetch-based core (`runGate`, `verifyOne`) encapsulating
-  the evaluate → verify-permit flow with `GateInfraError` for all
-  infrastructure failures (network, 5xx, 401, 429, no permit_token).
-- 18 SIM tests (`src/__tests__/gate.test.ts`) covering all paths in
-  the decision matrix.
-- `permit-token` output is now an audit reference (single-use, already
-  consumed by the action's own verify call).
+- `verified` output: `"true"` only when evaluate returned `decision=allow`
+  AND `/v1/verify-permit` confirmed `verified=true`; `"false"` in every
+  other case. Downstream steps must branch on `verified`, not re-derive
+  from `decision`.
+- `src/gate.ts`: `verifyOne()` and `GateInfraError` for the verify-permit
+  round-trip; infrastructure failures (network, 5xx, 401, 429, no
+  permit_token) are always fail-closed. Single-eval enforcement delegated
+  to `@atlasent/enforce`; `verifyOne()` is used by the v2.1 batch path.
+- 9 SIM tests (`src/__tests__/gate.test.ts`) for `verifyOne()`.
+- `permit-token` output is an audit reference (single-use, already consumed).
 - Replay protection: stale or consumed `permit_token` → `verified=false`.
 
 ### Action — v2.1 batch entry point (B.AC4)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to `atlasent-action` are documented here.
 
 ## [Unreleased]
 
+## [1.3.0] — 2026-04-30
+
 ### Action — v1-verify-permit wiring (A5 end-to-end)
 - `verified` output: `"true"` only when evaluate returned `decision=allow`
   AND `/v1/verify-permit` confirmed `verified=true`; `"false"` in every

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ Push to main → AtlaSent evaluates → permit issued → deploy
 
 ## Using Outputs
 
-The action sets several outputs you can reference in subsequent steps:
+The action sets several outputs you can reference in subsequent steps.
+**Always gate on `verified`, not `decision`** — `verified=true` means the evaluation returned `allow` AND the server confirmed the permit token hasn't been replayed.
 
 ```yaml
 - name: Authorization Gate
@@ -47,43 +48,85 @@ The action sets several outputs you can reference in subsequent steps:
     target-id: api-service
 
 - name: Deploy
-  if: steps.gate.outputs.decision == 'allow'
+  if: steps.gate.outputs.verified == 'true'
   run: |
-    echo "Deploying with permit: ${{ steps.gate.outputs.permit-token }}"
     echo "Proof hash: ${{ steps.gate.outputs.proof-hash }}"
     echo "Risk score: ${{ steps.gate.outputs.risk-score }}"
-    ./deploy.sh --permit "${{ steps.gate.outputs.permit-token }}"
+    ./deploy.sh
 ```
 
-### Outputs
+### Outputs — single-eval path
 
-| Output          | Description                                                       |
-|-----------------|-------------------------------------------------------------------|
-| `decision`      | The evaluation result: `allow`, `deny`, `hold`, or `escalate`     |
-| `permit-token`  | The permit token for authorized actions (`pt_*` prefix)           |
-| `evaluation-id` | Unique evaluation ID for the audit trail                          |
-| `proof-hash`    | Cryptographic proof hash for tamper detection                     |
-| `risk-score`    | Numeric risk score 0–100; empty string when not assessed          |
+| Output          | Description                                                            |
+|-----------------|------------------------------------------------------------------------|
+| `verified`      | `"true"` only when `decision=allow` AND permit verified; `"false"` otherwise |
+| `decision`      | The evaluation result: `allow`, `deny`, `hold`, or `escalate`          |
+| `permit-token`  | Single-use permit token (already consumed; kept for audit reference)   |
+| `evaluation-id` | Unique evaluation ID for the audit trail                               |
+| `proof-hash`    | Cryptographic proof hash for tamper detection                          |
+| `risk-score`    | Numeric risk score 0–100; empty string when not assessed               |
+
+### Outputs — batch path (`evaluations` input set)
+
+| Output      | Description                                                                                      |
+|-------------|--------------------------------------------------------------------------------------------------|
+| `verified`  | `"true"` only when every allow decision verified; `"false"` otherwise                            |
+| `decisions` | JSON array of per-item results: `{decision, verified, evaluationId, permitToken, reasons, verifyOutcome}` |
+| `batch-id`  | Server-assigned batch ID, or `loop-<ts>` for the sequential fallback                            |
 
 ## Inputs
+
+### Single-eval inputs
 
 | Input          | Required | Default                | Description                                             |
 |----------------|----------|------------------------|---------------------------------------------------------|
 | `api-key`      | Yes      | —                      | AtlaSent API key (`ask_live_*` or `ask_test_*`)         |
-| `action`       | Yes      | —                      | Action type to evaluate (e.g. `production_deploy`)      |
+| `action`       | Yes*     | —                      | Action type to evaluate (e.g. `production_deploy`). Ignored when `evaluations` is set. |
 | `actor`        | No       | `${{ github.actor }}`  | Actor identity                                          |
-| `target-id`    | No       | `GITHUB_REPOSITORY`    | Target resource being acted on (service, artifact, etc) |
+| `target-id`    | No       | —                      | Target resource being acted on (service, artifact, etc) |
 | `environment`  | No       | Auto-detected          | `live` for `main`/`master`, `test` otherwise            |
-| `api-url`      | No       | Production URL         | AtlaSent API endpoint                                   |
-| `fail-on-deny` | No       | `true`                 | Fail the step if denied                                 |
+| `api-url`      | No       | `https://api.atlasent.io` | AtlaSent API base URL                               |
+| `fail-on-deny` | No       | `true`                 | Fail the step on deny/hold/escalate                     |
 | `context`      | No       | `{}`                   | Additional JSON context for evaluation                  |
+
+### Batch inputs (v2.1)
+
+| Input              | Required | Default   | Description                                                          |
+|--------------------|----------|-----------|----------------------------------------------------------------------|
+| `evaluations`      | No       | —         | JSON array of evaluation requests. When set, single-eval inputs are ignored. |
+| `wait-for-id`      | No       | —         | Evaluation ID to block on until it reaches a terminal state (allow/deny). |
+| `wait-timeout-ms`  | No       | `600000`  | Max milliseconds to wait for a terminal decision (default: 10 min). |
+| `v2-batch`         | No       | `false`   | Use the `/v1/evaluate/batch` endpoint instead of sequential loop.   |
+| `v2-streaming`     | No       | `false`   | Use Server-Sent Events for `wait-for-id` polling instead of HTTP polling. |
+
+## Batch Mode
+
+Evaluate multiple actions in a single step:
+
+```yaml
+- name: Batch Authorization Gate
+  id: gate
+  uses: AtlaSent-Systems-Inc/atlasent-action@v1
+  with:
+    api-key: ${{ secrets.ATLASENT_API_KEY }}
+    evaluations: |
+      [
+        {"action": "deploy.staging", "actor": "${{ github.actor }}"},
+        {"action": "deploy.prod",    "actor": "${{ github.actor }}"}
+      ]
+
+- name: Deploy
+  if: steps.gate.outputs.verified == 'true'
+  run: ./deploy.sh
+```
 
 ## How It Works
 
-1. **Evaluate** — POST `/v1-evaluate` with `action_type`, `actor_id`, `target_id`, and a context object populated from GitHub workflow metadata (repo, ref, sha, workflow, run id, PR number, optional user-supplied `context`).
+1. **Evaluate** — POST `/v1/evaluate` with `action_type`, `actor_id`, `target_id`, and a context object populated from GitHub workflow metadata (repo, ref, sha, workflow, run id, PR number, optional user-supplied `context`).
 2. **Decide** — Server returns `allow` / `deny` / `hold` / `escalate` plus a single-use `permit_token` (only when `allow`) and an optional `risk-score`.
-3. **Proceed or block** — `fail-on-deny: true` (default) surfaces deny/hold/escalate as a failing step. `false` demotes them to a workflow `::warning`.
-4. **Audit** — Every evaluation writes to the AtlaSent append-only, hash-chained audit log. The `evaluation-id` and `proof-hash` outputs reference the record.
+3. **Verify permit** — POST `/v1/verify-permit` to confirm the token hasn't been replayed. `verified=true` only when both steps pass.
+4. **Proceed or block** — `fail-on-deny: true` (default) surfaces deny/hold/escalate as a failing step. `false` demotes them to a workflow `::warning`.
+5. **Audit** — Every evaluation writes to the AtlaSent append-only, hash-chained audit log. The `evaluation-id` and `proof-hash` outputs reference the record.
 
 ## Protecting `main`
 

--- a/action.yml
+++ b/action.yml
@@ -36,13 +36,15 @@ outputs:
   decision:
     description: 'The evaluation decision (allow/deny/hold/escalate)'
   permit-token:
-    description: 'The permit token (if allowed)'
+    description: 'The permit token consumed by the gate (audit reference; single-use, already consumed by v1-verify-permit)'
   evaluation-id:
     description: 'The evaluation ID for audit trail'
   proof-hash:
     description: 'The cryptographic proof hash'
   risk-score:
     description: 'The numeric risk score from the Decision response. Empty string when the evaluator did not return a risk assessment.'
+  verified:
+    description: '"true" only when v1-evaluate returned decision=allow AND v1-verify-permit confirmed verified=true; "false" otherwise (fail-closed)'
 runs:
   using: 'node20'
   main: 'dist/index.js'

--- a/action.yml
+++ b/action.yml
@@ -21,9 +21,9 @@ inputs:
     description: 'Environment (defaults to live for main branch, test otherwise)'
     required: false
   api-url:
-    description: 'AtlaSent API URL (defaults to production)'
+    description: 'AtlaSent API URL base (defaults to production). The enforcement wrapper appends /v1/evaluate and /v1/verify-permit.'
     required: false
-    default: 'https://ihghhasvxtltlbizvkqy.supabase.co/functions/v1'
+    default: 'https://api.atlasent.io'
   fail-on-deny:
     description: 'Fail the workflow step if the action is denied (default: true)'
     required: false

--- a/action.yml
+++ b/action.yml
@@ -8,10 +8,10 @@ inputs:
     description: 'AtlaSent API key (ask_live_* or ask_test_*)'
     required: true
   action:
-    description: 'Action type to evaluate (e.g., production_deploy)'
-    required: true
+    description: 'Action type to evaluate (e.g., production_deploy). Used for single-eval path. Ignored when evaluations is set.'
+    required: false
   actor:
-    description: 'Actor identity (defaults to github.actor)'
+    description: 'Actor identity (defaults to github.actor). Used for single-eval path.'
     required: false
     default: '${{ github.actor }}'
   target-id:
@@ -29,22 +29,44 @@ inputs:
     required: false
     default: 'true'
   context:
-    description: 'JSON context to include in the evaluation (optional)'
+    description: 'JSON context to include in the evaluation (optional). Used for single-eval path.'
     required: false
     default: '{}'
+  evaluations:
+    description: 'JSON array of evaluation requests for batch mode, e.g. [{"action":"deploy.prod","actor":"alice"}]. When set, single-eval inputs (action, actor, context) are ignored.'
+    required: false
+  wait-for-id:
+    description: 'Evaluation ID to block on until it reaches a terminal state (allow/deny). Used with hold/escalate decisions that require async approval.'
+    required: false
+  wait-timeout-ms:
+    description: 'Maximum milliseconds to wait for a terminal decision when wait-for-id is set (default: 600000 = 10 min).'
+    required: false
+    default: '600000'
+  v2-batch:
+    description: 'Enable the /v1/evaluate/batch endpoint for batch evaluations (default: false, falls back to sequential /v1/evaluate loop).'
+    required: false
+    default: 'false'
+  v2-streaming:
+    description: 'Enable Server-Sent Events stream for wait-for-id polling (default: false, falls back to HTTP polling).'
+    required: false
+    default: 'false'
 outputs:
   decision:
-    description: 'The evaluation decision (allow/deny/hold/escalate)'
+    description: 'The evaluation decision (allow/deny/hold/escalate). Set for single-eval path only.'
   permit-token:
-    description: 'The permit token consumed by the gate (audit reference; single-use, already consumed by v1-verify-permit)'
+    description: 'The permit token consumed by the gate (audit reference; single-use, already consumed by v1-verify-permit). Single-eval path only.'
   evaluation-id:
-    description: 'The evaluation ID for audit trail'
+    description: 'The evaluation ID for audit trail. Single-eval path only.'
   proof-hash:
-    description: 'The cryptographic proof hash'
+    description: 'The cryptographic proof hash. Single-eval path only.'
   risk-score:
-    description: 'The numeric risk score from the Decision response. Empty string when the evaluator did not return a risk assessment.'
+    description: 'The numeric risk score from the Decision response. Empty string when the evaluator did not return a risk assessment. Single-eval path only.'
   verified:
-    description: '"true" only when v1-evaluate returned decision=allow AND v1-verify-permit confirmed verified=true; "false" otherwise (fail-closed)'
+    description: '"true" when evaluate=allow AND verify-permit=true for ALL evaluations; "false" otherwise (fail-closed). Set on both single and batch paths.'
+  decisions:
+    description: 'JSON array of per-item decision results for the batch path. Each item: {decision, verified, evaluationId, permitToken, reasons, verifyOutcome}.'
+  batch-id:
+    description: 'Batch identifier for the v2.1 batch path (either the server-assigned batchId or loop-<ts> for the sequential fallback).'
 runs:
   using: 'node20'
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -319,7 +319,12 @@ function parseInputs(env) {
   const failOnDeny = (env["INPUT_FAIL-ON-DENY"] || "true") === "true";
   const evaluationsRaw = env["INPUT_EVALUATIONS"];
   if (evaluationsRaw && evaluationsRaw.trim()) {
-    const parsed = JSON.parse(evaluationsRaw);
+    let parsed;
+    try {
+      parsed = JSON.parse(evaluationsRaw);
+    } catch {
+      throw new Error("`evaluations` is not valid JSON \u2014 expected a JSON array of evaluation requests");
+    }
     if (!Array.isArray(parsed) || parsed.length === 0) {
       throw new Error(
         "`evaluations` must be a non-empty JSON array of evaluation requests"
@@ -338,7 +343,12 @@ function parseInputs(env) {
   const actor = env["INPUT_ACTOR"] || env["GITHUB_ACTOR"] || "unknown";
   const environment = env["INPUT_ENVIRONMENT"];
   const contextRaw = env["INPUT_CONTEXT"] || "{}";
-  const context = JSON.parse(contextRaw);
+  let context = {};
+  try {
+    context = JSON.parse(contextRaw);
+  } catch {
+    throw new Error("`context` is not valid JSON \u2014 expected a JSON object");
+  }
   return {
     apiKey,
     apiUrl,
@@ -551,7 +561,7 @@ async function run() {
         { v2Batch, v2Streaming }
       );
     } catch (err) {
-      const msg = err instanceof import_enforce.EnforceError ? err.message : `Unexpected error: ${err instanceof Error ? err.message : String(err)}`;
+      const msg = err instanceof import_enforce.EnforceError || err instanceof GateInfraError ? err.message : `Unexpected error: ${err instanceof Error ? err.message : String(err)}`;
       setOutput("verified", "false");
       setFailed(`AtlaSent Gate (batch): ${msg}. Deploy blocked (fail-closed).`);
       return;

--- a/dist/index.js
+++ b/dist/index.js
@@ -420,18 +420,23 @@ async function waitViaStream(opts) {
 async function waitViaPolling(opts) {
   const deadline = Date.now() + opts.timeoutMs;
   while (Date.now() < deadline) {
-    const r = await fetch(
-      `${opts.apiUrl}/v1/evaluate/${encodeURIComponent(opts.evaluationId)}`,
-      {
-        headers: { authorization: `Bearer ${opts.apiKey}` },
-        signal: opts.signal
+    try {
+      const r = await fetch(
+        `${opts.apiUrl}/v1/evaluate/${encodeURIComponent(opts.evaluationId)}`,
+        {
+          headers: { authorization: `Bearer ${opts.apiKey}` },
+          signal: opts.signal
+        }
+      );
+      if (r.ok) {
+        const decision = await r.json();
+        if (decision.decision === "allow" || decision.decision === "deny") {
+          return decision;
+        }
       }
-    );
-    if (r.ok) {
-      const decision = await r.json();
-      if (decision.decision === "allow" || decision.decision === "deny") {
-        return decision;
-      }
+    } catch (err) {
+      if (err instanceof Error && err.name === "AbortError")
+        throw err;
     }
     await new Promise((res) => setTimeout(res, POLL_INTERVAL_MS));
   }

--- a/dist/index.js
+++ b/dist/index.js
@@ -569,6 +569,8 @@ async function run() {
     } catch (err) {
       const msg = err instanceof import_enforce.EnforceError || err instanceof GateInfraError ? err.message : `Unexpected error: ${err instanceof Error ? err.message : String(err)}`;
       setOutput("verified", "false");
+      setOutput("decisions", "[]");
+      setOutput("batch-id", "");
       setFailed(`AtlaSent Gate (batch): ${msg}. Deploy blocked (fail-closed).`);
       return;
     }

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,4 +1,220 @@
 "use strict";
+var __create = Object.create;
+var __defProp = Object.defineProperty;
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+var __getOwnPropNames = Object.getOwnPropertyNames;
+var __getProtoOf = Object.getPrototypeOf;
+var __hasOwnProp = Object.prototype.hasOwnProperty;
+var __commonJS = (cb, mod) => function __require() {
+  return mod || (0, cb[__getOwnPropNames(cb)[0]])((mod = { exports: {} }).exports, mod), mod.exports;
+};
+var __copyProps = (to, from, except, desc) => {
+  if (from && typeof from === "object" || typeof from === "function") {
+    for (let key of __getOwnPropNames(from))
+      if (!__hasOwnProp.call(to, key) && key !== except)
+        __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+  }
+  return to;
+};
+var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__getProtoOf(mod)) : {}, __copyProps(
+  // If the importer is in node compatibility mode or this is not an ESM
+  // file that has been converted to a CommonJS file using a Babel-
+  // compatible transform (i.e. "__esModule" has not been set), then set
+  // "default" to the CommonJS "module.exports" for node compatibility.
+  isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", { value: mod, enumerable: true }) : target,
+  mod
+));
+
+// packages/enforce/dist/transport.js
+var require_transport = __commonJS({
+  "packages/enforce/dist/transport.js"(exports2) {
+    "use strict";
+    var __importDefault = exports2 && exports2.__importDefault || function(mod) {
+      return mod && mod.__esModule ? mod : { "default": mod };
+    };
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    exports2.post = post;
+    var node_https_1 = __importDefault(require("node:https"));
+    var node_http_1 = __importDefault(require("node:http"));
+    function post(url, body, headers) {
+      return new Promise((resolve, reject) => {
+        const parsed = new URL(url);
+        const transport = parsed.protocol === "https:" ? node_https_1.default : node_http_1.default;
+        const req = transport.request({
+          hostname: parsed.hostname,
+          port: parsed.port || (parsed.protocol === "https:" ? 443 : 80),
+          path: parsed.pathname + parsed.search,
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "Content-Length": Buffer.byteLength(body),
+            ...headers
+          },
+          timeout: 3e4
+        }, (res) => {
+          const chunks = [];
+          res.on("data", (chunk) => chunks.push(chunk));
+          res.on("end", () => resolve({ status: res.statusCode ?? 0, body: Buffer.concat(chunks).toString("utf-8") }));
+        });
+        req.on("error", reject);
+        req.on("timeout", () => {
+          req.destroy();
+          reject(new Error("Request timed out after 30s"));
+        });
+        req.write(body);
+        req.end();
+      });
+    }
+  }
+});
+
+// packages/enforce/dist/index.js
+var require_dist = __commonJS({
+  "packages/enforce/dist/index.js"(exports2) {
+    "use strict";
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    exports2.EnforceError = void 0;
+    exports2.evaluate = evaluate;
+    exports2.verify = verify;
+    exports2.verifyPermit = verifyPermit;
+    exports2.enforce = enforce2;
+    var transport_1 = require_transport();
+    var DEFAULT_API_URL = "https://api.atlasent.io";
+    var EnforceError2 = class extends Error {
+      phase;
+      decision;
+      constructor(message, phase, decision = null) {
+        super(message);
+        this.name = "EnforceError";
+        this.phase = phase;
+        this.decision = decision;
+      }
+    };
+    exports2.EnforceError = EnforceError2;
+    async function evaluate(config) {
+      const apiUrl = (config.apiUrl ?? DEFAULT_API_URL).replace(/\/$/, "");
+      const payload = {
+        action_type: config.action,
+        actor_id: config.actor,
+        context: {
+          ...config.environment ? { environment: config.environment } : {},
+          ...config.targetId ? { target_id: config.targetId } : {},
+          ...config.context
+        }
+      };
+      if (config.targetId)
+        payload["target_id"] = config.targetId;
+      let status;
+      let body;
+      try {
+        ({ status, body } = await (0, transport_1.post)(`${apiUrl}/v1/evaluate`, JSON.stringify(payload), {
+          Authorization: `Bearer ${config.apiKey}`
+        }));
+      } catch (err) {
+        throw new EnforceError2(`AtlaSent API unreachable: ${err instanceof Error ? err.message : String(err)}`, "evaluate");
+      }
+      if (status >= 500) {
+        throw new EnforceError2(`Infrastructure failure (HTTP ${status})`, "evaluate");
+      }
+      if (status === 401 || status === 403) {
+        throw new EnforceError2(`Authentication failed (HTTP ${status})`, "evaluate");
+      }
+      if (status === 429) {
+        throw new EnforceError2("Rate limited (HTTP 429)", "evaluate");
+      }
+      if (status < 200 || status >= 300) {
+        throw new EnforceError2(`Unexpected response (HTTP ${status})`, "evaluate");
+      }
+      let raw;
+      try {
+        raw = JSON.parse(body);
+      } catch {
+        throw new EnforceError2("Non-JSON response from AtlaSent API", "evaluate");
+      }
+      return mapDecision(raw);
+    }
+    function verify(decision) {
+      switch (decision.decision) {
+        case "allow":
+          return;
+        case "deny":
+          throw new EnforceError2(`Denied: ${decision.denyReason ?? "no reason provided"}`, "verify", decision);
+        case "hold":
+          throw new EnforceError2(`On hold: ${decision.holdReason ?? "awaiting approval"}`, "verify", decision);
+        case "escalate":
+          throw new EnforceError2("Escalated \u2014 manual review required", "verify", decision);
+        default:
+          throw new EnforceError2(`Unknown decision: ${String(decision.decision)}`, "verify", decision);
+      }
+    }
+    async function verifyPermit(config, decision) {
+      if (!decision.permitToken) {
+        throw new EnforceError2("evaluate returned allow but no permit_token \u2014 refusing to execute without verifiable permit", "verify-permit", decision);
+      }
+      const apiUrl = (config.apiUrl ?? DEFAULT_API_URL).replace(/\/$/, "");
+      let status;
+      let body;
+      try {
+        ({ status, body } = await (0, transport_1.post)(`${apiUrl}/v1/verify-permit`, JSON.stringify({
+          permit_token: decision.permitToken,
+          action_type: config.action,
+          actor_id: config.actor
+        }), { Authorization: `Bearer ${config.apiKey}` }));
+      } catch (err) {
+        throw new EnforceError2(`verify-permit unreachable: ${err instanceof Error ? err.message : String(err)}`, "verify-permit", decision);
+      }
+      if (status >= 500) {
+        throw new EnforceError2(`verify-permit infrastructure failure (HTTP ${status})`, "verify-permit", decision);
+      }
+      if (status < 200 || status >= 300) {
+        throw new EnforceError2(`verify-permit failed (HTTP ${status})`, "verify-permit", decision);
+      }
+      let raw;
+      try {
+        raw = JSON.parse(body);
+      } catch {
+        throw new EnforceError2("Non-JSON response from verify-permit", "verify-permit", decision);
+      }
+      if (raw.verified !== true) {
+        throw new EnforceError2(`Permit verification failed (outcome=${raw.outcome ?? "unknown"})`, "verify-permit", decision);
+      }
+      return { verified: true, outcome: raw.outcome };
+    }
+    async function enforce2(config, fn) {
+      const decision = await evaluate(config);
+      verify(decision);
+      const vp = await verifyPermit(config, decision);
+      const result = await fn();
+      return { result, decision, verifyOutcome: vp.outcome };
+    }
+    function mapDecision(raw) {
+      return {
+        decision: raw["decision"],
+        evaluationId: raw["evaluation_id"],
+        permitToken: raw["permit_token"],
+        proofHash: raw["proof_hash"],
+        riskScore: extractRiskScore(raw),
+        denyReason: raw["deny_reason"],
+        holdReason: raw["hold_reason"]
+      };
+    }
+    function extractRiskScore(raw) {
+      const risk = raw["risk"];
+      if (risk && typeof risk === "object" && "score" in risk) {
+        const score = risk.score;
+        if (typeof score === "number")
+          return score;
+      }
+      const flat = raw["risk_score"];
+      if (typeof flat === "number")
+        return flat;
+      return void 0;
+    }
+  }
+});
+
+// src/index.ts
+var import_enforce = __toESM(require_dist());
 
 // src/gate.ts
 var GateInfraError = class extends Error {
@@ -39,106 +255,6 @@ async function verifyOne(params) {
     throw new GateInfraError("failed to parse verify-permit response as JSON");
   }
   return { verified: body.verified === true, outcome: body.outcome };
-}
-async function runGate(params) {
-  let evalRes;
-  try {
-    evalRes = await fetch(`${params.apiUrl}/v1-evaluate`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${params.apiKey}`
-      },
-      body: JSON.stringify(params.payload)
-    });
-  } catch (err) {
-    throw new GateInfraError(
-      `evaluate unreachable: ${err instanceof Error ? err.message : String(err)}`
-    );
-  }
-  if (evalRes.status >= 500) {
-    throw new GateInfraError(
-      `evaluate HTTP ${evalRes.status} \u2014 infrastructure failure, not a policy decision`,
-      evalRes.status
-    );
-  }
-  if (evalRes.status === 401 || evalRes.status === 403) {
-    throw new GateInfraError(
-      `evaluate auth failed (HTTP ${evalRes.status}). Check ATLASENT_API_KEY scopes.`,
-      evalRes.status
-    );
-  }
-  if (evalRes.status === 429) {
-    throw new GateInfraError(
-      `evaluate rate-limited (HTTP 429). Retry or raise rate_limit_per_minute.`,
-      429
-    );
-  }
-  if (!evalRes.ok) {
-    throw new GateInfraError(`evaluate HTTP ${evalRes.status}`, evalRes.status);
-  }
-  let evalBody;
-  try {
-    evalBody = await evalRes.json();
-  } catch {
-    throw new GateInfraError("failed to parse evaluate response as JSON");
-  }
-  const decision = evalBody["decision"] ?? "unknown";
-  const permitToken = evalBody["permit_token"] ?? "";
-  const evaluationId = evalBody["evaluation_id"] ?? "";
-  const proofHash = evalBody["proof_hash"] ?? "";
-  const riskScore = extractRiskScore(evalBody);
-  if (decision !== "allow") {
-    const reason = evalBody["deny_reason"] ?? evalBody["hold_reason"] ?? "";
-    return { ok: false, decision, verified: false, permitToken, evaluationId, proofHash, riskScore, reason };
-  }
-  if (!permitToken) {
-    throw new GateInfraError(
-      `evaluate=allow but no permit_token \u2014 refusing to gate-open without a verifiable permit (evaluation: ${evaluationId})`
-    );
-  }
-  const verify = await verifyOne({
-    apiUrl: params.apiUrl,
-    apiKey: params.apiKey,
-    actionType: params.actionType,
-    actorId: params.actorId,
-    permitToken
-  });
-  if (!verify.verified) {
-    return {
-      ok: false,
-      decision: "allow",
-      verified: false,
-      permitToken,
-      evaluationId,
-      proofHash,
-      riskScore,
-      reason: `permit verification failed (outcome=${verify.outcome ?? "unknown"})`,
-      verifyOutcome: verify.outcome
-    };
-  }
-  return {
-    ok: true,
-    decision: "allow",
-    verified: true,
-    permitToken,
-    evaluationId,
-    proofHash,
-    riskScore,
-    verifyOutcome: verify.outcome ?? "verified"
-  };
-}
-function extractRiskScore(result) {
-  const risk = result["risk"];
-  if (risk && typeof risk === "object" && "score" in risk) {
-    const score = risk.score;
-    if (typeof score === "number")
-      return String(score);
-  }
-  const flat = result["risk_score"];
-  if (typeof flat === "number")
-    return String(flat);
-  return "";
 }
 
 // src/batch.ts
@@ -399,9 +515,20 @@ function resolveEnvironment(explicit, ref, apiKey) {
   const branch = ref.replace("refs/heads/", "");
   return branch === "main" || branch === "master" ? "live" : "test";
 }
+function setDecisionOutputs(d) {
+  if (d.permitToken)
+    maskValue(d.permitToken);
+  if (d.proofHash)
+    maskValue(d.proofHash);
+  setOutput("decision", d.decision);
+  setOutput("permit-token", d.permitToken ?? "");
+  setOutput("evaluation-id", d.evaluationId ?? "");
+  setOutput("proof-hash", d.proofHash ?? "");
+  setOutput("risk-score", d.riskScore !== void 0 ? String(d.riskScore) : "");
+}
 async function run() {
   const apiKey = getInput("api-key", true);
-  const apiUrl = getInput("api-url") || "https://ihghhasvxtltlbizvkqy.supabase.co/functions/v1";
+  const apiUrl = getInput("api-url") || "https://api.atlasent.io";
   const failOnDeny = getInput("fail-on-deny") !== "false";
   maskValue(apiKey);
   const evaluationsRaw = getInput("evaluations");
@@ -410,9 +537,9 @@ async function run() {
     const waitTimeoutMs = parseInt(getInput("wait-timeout-ms") || "600000", 10);
     const v2Batch = getInput("v2-batch") === "true";
     const v2Streaming = getInput("v2-streaming") === "true";
-    let result2;
+    let result;
     try {
-      result2 = await runV21(
+      result = await runV21(
         {
           "INPUT_API-KEY": apiKey,
           "INPUT_API-URL": apiUrl,
@@ -424,28 +551,28 @@ async function run() {
         { v2Batch, v2Streaming }
       );
     } catch (err) {
-      const msg = err instanceof GateInfraError ? err.message : `Unexpected error: ${err instanceof Error ? err.message : String(err)}`;
+      const msg = err instanceof import_enforce.EnforceError ? err.message : `Unexpected error: ${err instanceof Error ? err.message : String(err)}`;
       setOutput("verified", "false");
       setFailed(`AtlaSent Gate (batch): ${msg}. Deploy blocked (fail-closed).`);
       return;
     }
     const decisionsJson = JSON.stringify(
-      result2.decisions.map((d) => ({
-        decision: d.decision,
-        verified: d.verified ?? false,
-        evaluationId: d.id ?? "",
-        permitToken: d.permitToken ? "(masked)" : "",
-        reasons: d.reasons ?? [],
-        verifyOutcome: d.verifyOutcome ?? ""
+      result.decisions.map((d2) => ({
+        decision: d2.decision,
+        verified: d2.verified ?? false,
+        evaluationId: d2.id ?? "",
+        permitToken: d2.permitToken ? "(masked)" : "",
+        reasons: d2.reasons ?? [],
+        verifyOutcome: d2.verifyOutcome ?? ""
       }))
     );
-    const allVerified = result2.decisions.every(
-      (d) => d.decision !== "allow" || d.verified === true
+    const allVerified = result.decisions.every(
+      (d2) => d2.decision !== "allow" || d2.verified === true
     );
-    setOutput("batch-id", result2.batchId);
+    setOutput("batch-id", result.batchId);
     setOutput("decisions", decisionsJson);
     setOutput("verified", allVerified ? "true" : "false");
-    if (result2.failed) {
+    if (result.failed) {
       setFailed(
         `AtlaSent Gate: one or more evaluations denied. See 'decisions' output for details.`
       );
@@ -457,13 +584,13 @@ async function run() {
       );
       return;
     }
-    info(`AtlaSent Gate: all ${result2.decisions.length} evaluation(s) allowed and verified`);
-    info(`  Batch ID: ${result2.batchId}`);
+    info(`AtlaSent Gate: all ${result.decisions.length} evaluation(s) allowed and verified`);
+    info(`  Batch ID: ${result.batchId}`);
     return;
   }
   const actionType = getInput("action", true);
   const actor = getInput("actor") || "unknown";
-  const targetId = getInput("target-id");
+  const targetId = getInput("target-id") || void 0;
   const explicitEnv = getInput("environment");
   let extraContext = {};
   try {
@@ -473,11 +600,17 @@ async function run() {
   }
   const gh = getGitHubContext();
   const environment = resolveEnvironment(explicitEnv, gh.ref, apiKey);
-  const payload = {
-    action_type: actionType,
-    actor_id: `github:${actor}`,
+  info(
+    `AtlaSent Gate: evaluating "${actionType}" for actor "github:${actor}" in ${environment} environment` + (targetId ? ` (target=${targetId})` : "")
+  );
+  const config = {
+    apiKey,
+    apiUrl,
+    action: actionType,
+    actor: `github:${actor}`,
+    environment,
+    targetId,
     context: {
-      environment,
       source: "github-action",
       repository: gh.repository,
       ref: gh.ref,
@@ -488,87 +621,97 @@ async function run() {
       event_name: gh.event_name,
       pr_number: gh.pr_number ?? null,
       run_url: `${gh.server_url}/${gh.repository}/actions/runs/${gh.run_id}`,
-      ...targetId ? { target_id: targetId } : {},
       ...extraContext
     }
   };
-  if (targetId)
-    payload["target_id"] = targetId;
-  info(
-    `AtlaSent Gate: evaluating "${actionType}" for actor "${actor}" in ${environment} environment` + (targetId ? ` (target=${targetId})` : "")
-  );
-  let result;
+  let enforceResult;
   try {
-    result = await runGate({
-      apiUrl,
-      apiKey,
-      actionType,
-      actorId: `github:${actor}`,
-      payload
+    enforceResult = await (0, import_enforce.enforce)(config, async () => {
     });
   } catch (err) {
-    const msg = err instanceof GateInfraError ? err.message : `Unexpected error: ${err instanceof Error ? err.message : String(err)}`;
+    if (err instanceof import_enforce.EnforceError) {
+      if (err.decision) {
+        setDecisionOutputs(err.decision);
+      } else {
+        setOutput("decision", "error");
+        setOutput("permit-token", "");
+        setOutput("evaluation-id", "");
+        setOutput("proof-hash", "");
+        setOutput("risk-score", "");
+      }
+      setOutput("verified", "false");
+      if (err.phase === "verify" && !failOnDeny) {
+        switch (err.decision?.decision) {
+          case "deny":
+            warning(`Authorization DENIED: ${err.decision.denyReason ?? "no reason provided"}`);
+            break;
+          case "hold":
+            warning(`Authorization on HOLD: ${err.decision.holdReason ?? "awaiting approval"}`);
+            break;
+          case "escalate":
+            warning("Authorization ESCALATED \u2014 manual review required");
+            break;
+          default:
+            warning(`Authorization ${err.decision?.decision ?? "unknown"}`);
+        }
+        return;
+      }
+      switch (err.phase) {
+        case "evaluate":
+          setFailed(
+            `AtlaSent Gate: ${err.message}. Deploy blocked \u2014 the gate cannot confirm authorization (fail-closed).`
+          );
+          break;
+        case "verify":
+          switch (err.decision?.decision) {
+            case "deny":
+              setFailed(
+                `Authorization DENIED: ${err.decision.denyReason ?? "no reason provided"}`
+              );
+              break;
+            case "hold":
+              setFailed(
+                `Authorization on HOLD: ${err.decision.holdReason ?? "awaiting approval"}`
+              );
+              break;
+            case "escalate":
+              setFailed("Authorization ESCALATED \u2014 manual review required");
+              break;
+            default:
+              setFailed(`Unexpected decision from AtlaSent: ${err.decision?.decision ?? "unknown"}`);
+          }
+          break;
+        case "verify-permit":
+          setFailed(
+            `AtlaSent Gate: ${err.message}. Deploy blocked (fail-closed).`
+          );
+          break;
+        default:
+          setFailed(`AtlaSent Gate: ${err.message}`);
+      }
+      return;
+    }
     setOutput("decision", "error");
+    setOutput("permit-token", "");
+    setOutput("evaluation-id", "");
+    setOutput("proof-hash", "");
+    setOutput("risk-score", "");
     setOutput("verified", "false");
     setFailed(
-      `AtlaSent Gate: ${msg}. Deploy blocked \u2014 the gate cannot confirm authorization (fail-closed).`
+      `AtlaSent Gate: Unexpected error: ${err instanceof Error ? err.message : String(err)}`
     );
     return;
   }
-  if (result.permitToken)
-    maskValue(result.permitToken);
-  if (result.proofHash)
-    maskValue(result.proofHash);
-  setOutput("decision", result.decision);
-  setOutput("permit-token", result.permitToken);
-  setOutput("evaluation-id", result.evaluationId);
-  setOutput("proof-hash", result.proofHash);
-  setOutput("risk-score", result.riskScore);
-  setOutput("verified", result.verified ? "true" : "false");
-  if (result.ok) {
-    info(`Authorization GRANTED (evaluate + verify)`);
-    info(`  Permit token: (set as 'permit-token' output, masked in logs)`);
-    info(`  Proof hash:   (set as 'proof-hash' output, masked in logs)`);
-    info(`  Evaluation:   ${result.evaluationId}`);
-    if (result.riskScore)
-      info(`  Risk score:   ${result.riskScore}`);
-    info(`  Verify:       ${result.verifyOutcome}`);
-    return;
-  }
-  if (result.decision === "allow") {
-    setFailed(
-      `Permit verification failed (outcome=${result.verifyOutcome ?? "unknown"}). Deploy blocked. This typically means the permit was already consumed by an earlier verify, or it expired.`
-    );
-    return;
-  }
-  switch (result.decision) {
-    case "deny":
-      if (failOnDeny) {
-        setFailed(`Authorization DENIED: ${result.reason || "no reason provided"}`);
-      } else {
-        warning(`Authorization DENIED: ${result.reason || "no reason provided"}`);
-      }
-      break;
-    case "hold":
-      if (failOnDeny) {
-        setFailed(`Authorization on HOLD: ${result.reason || "awaiting approval"}`);
-      } else {
-        warning(`Authorization on HOLD: ${result.reason || "awaiting approval"}`);
-      }
-      break;
-    case "escalate":
-      if (failOnDeny) {
-        setFailed("Authorization ESCALATED \u2014 manual review required");
-      } else {
-        warning("Authorization ESCALATED \u2014 manual review required");
-      }
-      break;
-    default:
-      warning(`Unexpected decision: ${result.decision}`);
-      if (failOnDeny) {
-        setFailed(`Unexpected decision from AtlaSent: ${result.decision}`);
-      }
-  }
+  const { decision: d, verifyOutcome } = enforceResult;
+  setDecisionOutputs(d);
+  setOutput("verified", "true");
+  info(`Authorization GRANTED (evaluate + verify)`);
+  info(`  Permit token: (set as 'permit-token' output, masked in logs)`);
+  info(`  Proof hash:   (set as 'proof-hash' output, masked in logs)`);
+  info(`  Evaluation:   ${d.evaluationId ?? ""}`);
+  if (d.riskScore !== void 0)
+    info(`  Risk score:   ${d.riskScore}`);
+  info(`  Verify:       ${verifyOutcome ?? "verified"}`);
 }
 run().catch((err) => {
   console.log(`::error::Unexpected error: ${err instanceof Error ? err.message : String(err)}`);

--- a/dist/index.js
+++ b/dist/index.js
@@ -55,6 +55,7 @@ var require_transport = __commonJS({
           const chunks = [];
           res.on("data", (chunk) => chunks.push(chunk));
           res.on("end", () => resolve({ status: res.statusCode ?? 0, body: Buffer.concat(chunks).toString("utf-8") }));
+          res.on("error", reject);
         });
         req.on("error", reject);
         req.on("timeout", () => {

--- a/dist/index.js
+++ b/dist/index.js
@@ -486,7 +486,7 @@ async function runV21(env, flags) {
       }
     }
   }
-  const failed = inputs.failOnDeny && decisions.some((d) => d.decision === "deny");
+  const failed = inputs.failOnDeny && decisions.some((d) => d.decision === "deny" || d.decision === "hold" || d.decision === "escalate");
   return { decisions, failed, batchId: batch.batchId };
 }
 
@@ -605,7 +605,7 @@ async function run() {
     setOutput("verified", allVerified ? "true" : "false");
     if (result.failed) {
       setFailed(
-        `AtlaSent Gate: one or more evaluations denied. See 'decisions' output for details.`
+        `AtlaSent Gate: one or more evaluations were not allowed (deny/hold/escalate). See 'decisions' output for details.`
       );
       return;
     }

--- a/dist/index.js
+++ b/dist/index.js
@@ -8,6 +8,38 @@ var GateInfraError = class extends Error {
     this.name = "GateInfraError";
   }
 };
+async function verifyOne(params) {
+  const path = params.verifyPath ?? "/v1-verify-permit";
+  let res;
+  try {
+    res = await fetch(`${params.apiUrl}${path}`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${params.apiKey}`
+      },
+      body: JSON.stringify({
+        permit_token: params.permitToken,
+        action_type: params.actionType,
+        actor_id: params.actorId
+      })
+    });
+  } catch (err) {
+    throw new GateInfraError(
+      `verify-permit unreachable: ${err instanceof Error ? err.message : String(err)}`
+    );
+  }
+  if (!res.ok) {
+    throw new GateInfraError(`verify-permit HTTP ${res.status}`, res.status);
+  }
+  let body;
+  try {
+    body = await res.json();
+  } catch {
+    throw new GateInfraError("failed to parse verify-permit response as JSON");
+  }
+  return { verified: body.verified === true, outcome: body.outcome };
+}
 async function runGate(params) {
   let evalRes;
   try {
@@ -65,38 +97,14 @@ async function runGate(params) {
       `evaluate=allow but no permit_token \u2014 refusing to gate-open without a verifiable permit (evaluation: ${evaluationId})`
     );
   }
-  let verifyRes;
-  try {
-    verifyRes = await fetch(`${params.apiUrl}/v1-verify-permit`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${params.apiKey}`
-      },
-      body: JSON.stringify({
-        permit_token: permitToken,
-        action_type: params.actionType,
-        actor_id: params.actorId
-      })
-    });
-  } catch (err) {
-    throw new GateInfraError(
-      `verify-permit unreachable: ${err instanceof Error ? err.message : String(err)}`
-    );
-  }
-  if (!verifyRes.ok) {
-    throw new GateInfraError(
-      `verify-permit HTTP ${verifyRes.status}`,
-      verifyRes.status
-    );
-  }
-  let verifyBody;
-  try {
-    verifyBody = await verifyRes.json();
-  } catch {
-    throw new GateInfraError("failed to parse verify-permit response as JSON");
-  }
-  if (verifyBody.verified !== true) {
+  const verify = await verifyOne({
+    apiUrl: params.apiUrl,
+    apiKey: params.apiKey,
+    actionType: params.actionType,
+    actorId: params.actorId,
+    permitToken
+  });
+  if (!verify.verified) {
     return {
       ok: false,
       decision: "allow",
@@ -105,8 +113,8 @@ async function runGate(params) {
       evaluationId,
       proofHash,
       riskScore,
-      reason: `permit verification failed (outcome=${verifyBody.outcome ?? "unknown"})`,
-      verifyOutcome: verifyBody.outcome
+      reason: `permit verification failed (outcome=${verify.outcome ?? "unknown"})`,
+      verifyOutcome: verify.outcome
     };
   }
   return {
@@ -117,7 +125,7 @@ async function runGate(params) {
     evaluationId,
     proofHash,
     riskScore,
-    verifyOutcome: verifyBody.outcome ?? "verified"
+    verifyOutcome: verify.outcome ?? "verified"
   };
 }
 function extractRiskScore(result) {
@@ -133,11 +141,215 @@ function extractRiskScore(result) {
   return "";
 }
 
+// src/batch.ts
+async function evaluateMany(apiUrl, apiKey, items, v2Batch) {
+  const headers = {
+    "content-type": "application/json",
+    authorization: `Bearer ${apiKey}`
+  };
+  let decisions;
+  let batchId;
+  if (v2Batch) {
+    const r = await fetch(`${apiUrl}/v1/evaluate/batch`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ items })
+    });
+    if (!r.ok) {
+      throw new Error(`atlasent /v1/evaluate/batch ${r.status}`);
+    }
+    const data = await r.json();
+    decisions = data.results;
+    batchId = data.batchId;
+  } else {
+    decisions = [];
+    for (const item of items) {
+      const r = await fetch(`${apiUrl}/v1/evaluate`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(item)
+      });
+      if (!r.ok) {
+        throw new Error(`atlasent /v1/evaluate ${r.status}`);
+      }
+      decisions.push(await r.json());
+    }
+    batchId = `loop-${Date.now()}`;
+  }
+  const verified = await Promise.all(
+    decisions.map(async (d, i) => {
+      if (d.decision !== "allow" || !d.permitToken) {
+        return { ...d, verified: d.decision === "allow" ? false : void 0 };
+      }
+      const item = items[i];
+      const result = await verifyOne({
+        apiUrl,
+        apiKey,
+        actionType: item.action,
+        actorId: item.actor,
+        permitToken: d.permitToken,
+        verifyPath: "/v1/verify-permit"
+      });
+      return { ...d, verified: result.verified, verifyOutcome: result.outcome };
+    })
+  );
+  return { decisions: verified, batchId };
+}
+
+// src/inputs.ts
+function parseInputs(env) {
+  const apiKey = required(env, "INPUT_API-KEY");
+  const apiUrl = env["INPUT_API-URL"] || "https://api.atlasent.io";
+  const failOnDeny = (env["INPUT_FAIL-ON-DENY"] || "true") === "true";
+  const evaluationsRaw = env["INPUT_EVALUATIONS"];
+  if (evaluationsRaw && evaluationsRaw.trim()) {
+    const parsed = JSON.parse(evaluationsRaw);
+    if (!Array.isArray(parsed) || parsed.length === 0) {
+      throw new Error(
+        "`evaluations` must be a non-empty JSON array of evaluation requests"
+      );
+    }
+    return {
+      apiKey,
+      apiUrl,
+      failOnDeny,
+      evaluations: parsed,
+      waitForId: env["INPUT_WAIT-FOR-ID"] || void 0,
+      waitTimeoutMs: parseInt(env["INPUT_WAIT-TIMEOUT-MS"] || "600000", 10)
+    };
+  }
+  const action = required(env, "INPUT_ACTION");
+  const actor = env["INPUT_ACTOR"] || env["GITHUB_ACTOR"] || "unknown";
+  const environment = env["INPUT_ENVIRONMENT"];
+  const contextRaw = env["INPUT_CONTEXT"] || "{}";
+  const context = JSON.parse(contextRaw);
+  return {
+    apiKey,
+    apiUrl,
+    failOnDeny,
+    single: { action, actor, environment, context },
+    waitForId: env["INPUT_WAIT-FOR-ID"] || void 0,
+    waitTimeoutMs: parseInt(env["INPUT_WAIT-TIMEOUT-MS"] || "600000", 10)
+  };
+}
+function required(env, key) {
+  const v = env[key];
+  if (!v) {
+    throw new Error(`Missing required input: ${key.replace("INPUT_", "").toLowerCase()}`);
+  }
+  return v;
+}
+
+// src/stream.ts
+var POLL_INTERVAL_MS = 5e3;
+var SSE_LINE = /^data: (.+)$/;
+async function waitForTerminalDecision(opts) {
+  if (opts.v2Streaming) {
+    return waitViaStream(opts);
+  }
+  return waitViaPolling(opts);
+}
+async function waitViaStream(opts) {
+  const r = await fetch(`${opts.apiUrl}/v1/evaluate/stream`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      authorization: `Bearer ${opts.apiKey}`,
+      accept: "text/event-stream"
+    },
+    body: JSON.stringify({ evaluationId: opts.evaluationId }),
+    signal: opts.signal
+  });
+  if (!r.ok || !r.body) {
+    throw new Error(`atlasent /v1/evaluate/stream ${r.status}`);
+  }
+  const reader = r.body.getReader();
+  const decoder = new TextDecoder();
+  const deadline = Date.now() + opts.timeoutMs;
+  let buf = "";
+  while (Date.now() < deadline) {
+    const { value, done } = await reader.read();
+    if (done)
+      break;
+    buf += decoder.decode(value, { stream: true });
+    let idx;
+    while ((idx = buf.indexOf("\n\n")) !== -1) {
+      const block = buf.slice(0, idx);
+      buf = buf.slice(idx + 2);
+      for (const line of block.split("\n")) {
+        const m = SSE_LINE.exec(line);
+        if (!m)
+          continue;
+        const event = JSON.parse(m[1]);
+        if (event.decision === "allow" || event.decision === "deny") {
+          return event;
+        }
+      }
+    }
+  }
+  throw new Error(
+    `atlasent stream timeout after ${opts.timeoutMs}ms for ${opts.evaluationId}`
+  );
+}
+async function waitViaPolling(opts) {
+  const deadline = Date.now() + opts.timeoutMs;
+  while (Date.now() < deadline) {
+    const r = await fetch(
+      `${opts.apiUrl}/v1/evaluate/${encodeURIComponent(opts.evaluationId)}`,
+      {
+        headers: { authorization: `Bearer ${opts.apiKey}` },
+        signal: opts.signal
+      }
+    );
+    if (r.ok) {
+      const decision = await r.json();
+      if (decision.decision === "allow" || decision.decision === "deny") {
+        return decision;
+      }
+    }
+    await new Promise((res) => setTimeout(res, POLL_INTERVAL_MS));
+  }
+  throw new Error(
+    `atlasent poll timeout after ${opts.timeoutMs}ms for ${opts.evaluationId}`
+  );
+}
+
+// src/v21.ts
+async function runV21(env, flags) {
+  const inputs = parseInputs(env);
+  const items = inputs.evaluations ?? [inputs.single];
+  const batch = await evaluateMany(
+    inputs.apiUrl,
+    inputs.apiKey,
+    items,
+    flags.v2Batch
+  );
+  let decisions = batch.decisions;
+  if (inputs.waitForId) {
+    const idx = decisions.findIndex(
+      (d) => d.id === inputs.waitForId && (d.decision === "hold" || d.decision === "escalate")
+    );
+    if (idx >= 0) {
+      const terminal = await waitForTerminalDecision({
+        apiUrl: inputs.apiUrl,
+        apiKey: inputs.apiKey,
+        evaluationId: inputs.waitForId,
+        timeoutMs: inputs.waitTimeoutMs ?? 6e5,
+        v2Streaming: flags.v2Streaming
+      });
+      decisions = [...decisions];
+      decisions[idx] = terminal;
+    }
+  }
+  const failed = inputs.failOnDeny && decisions.some((d) => d.decision === "deny");
+  return { decisions, failed, batchId: batch.batchId };
+}
+
 // src/index.ts
-function getInput(name, required = false) {
+function getInput(name, required2 = false) {
   const envKey = `INPUT_${name.replace(/-/g, "_").toUpperCase()}`;
   const val = (process.env[envKey] ?? "").trim();
-  if (required && !val) {
+  if (required2 && !val) {
     setFailed(`Input required and not supplied: ${name}`);
   }
   return val;
@@ -189,19 +401,76 @@ function resolveEnvironment(explicit, ref, apiKey) {
 }
 async function run() {
   const apiKey = getInput("api-key", true);
+  const apiUrl = getInput("api-url") || "https://ihghhasvxtltlbizvkqy.supabase.co/functions/v1";
+  const failOnDeny = getInput("fail-on-deny") !== "false";
+  maskValue(apiKey);
+  const evaluationsRaw = getInput("evaluations");
+  if (evaluationsRaw) {
+    const waitForId = getInput("wait-for-id") || void 0;
+    const waitTimeoutMs = parseInt(getInput("wait-timeout-ms") || "600000", 10);
+    const v2Batch = getInput("v2-batch") === "true";
+    const v2Streaming = getInput("v2-streaming") === "true";
+    let result2;
+    try {
+      result2 = await runV21(
+        {
+          "INPUT_API-KEY": apiKey,
+          "INPUT_API-URL": apiUrl,
+          "INPUT_FAIL-ON-DENY": failOnDeny ? "true" : "false",
+          INPUT_EVALUATIONS: evaluationsRaw,
+          "INPUT_WAIT-FOR-ID": waitForId,
+          "INPUT_WAIT-TIMEOUT-MS": String(waitTimeoutMs)
+        },
+        { v2Batch, v2Streaming }
+      );
+    } catch (err) {
+      const msg = err instanceof GateInfraError ? err.message : `Unexpected error: ${err instanceof Error ? err.message : String(err)}`;
+      setOutput("verified", "false");
+      setFailed(`AtlaSent Gate (batch): ${msg}. Deploy blocked (fail-closed).`);
+      return;
+    }
+    const decisionsJson = JSON.stringify(
+      result2.decisions.map((d) => ({
+        decision: d.decision,
+        verified: d.verified ?? false,
+        evaluationId: d.id ?? "",
+        permitToken: d.permitToken ? "(masked)" : "",
+        reasons: d.reasons ?? [],
+        verifyOutcome: d.verifyOutcome ?? ""
+      }))
+    );
+    const allVerified = result2.decisions.every(
+      (d) => d.decision !== "allow" || d.verified === true
+    );
+    setOutput("batch-id", result2.batchId);
+    setOutput("decisions", decisionsJson);
+    setOutput("verified", allVerified ? "true" : "false");
+    if (result2.failed) {
+      setFailed(
+        `AtlaSent Gate: one or more evaluations denied. See 'decisions' output for details.`
+      );
+      return;
+    }
+    if (!allVerified) {
+      setFailed(
+        `AtlaSent Gate: one or more allow decisions failed permit verification. Deploy blocked.`
+      );
+      return;
+    }
+    info(`AtlaSent Gate: all ${result2.decisions.length} evaluation(s) allowed and verified`);
+    info(`  Batch ID: ${result2.batchId}`);
+    return;
+  }
   const actionType = getInput("action", true);
   const actor = getInput("actor") || "unknown";
   const targetId = getInput("target-id");
   const explicitEnv = getInput("environment");
-  const apiUrl = getInput("api-url") || "https://ihghhasvxtltlbizvkqy.supabase.co/functions/v1";
-  const failOnDeny = getInput("fail-on-deny") !== "false";
   let extraContext = {};
   try {
     extraContext = JSON.parse(getInput("context") || "{}");
   } catch {
     warning("Could not parse 'context' input as JSON \u2014 ignoring");
   }
-  maskValue(apiKey);
   const gh = getGitHubContext();
   const environment = resolveEnvironment(explicitEnv, gh.ref, apiKey);
   const payload = {

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,0 +1,307 @@
+"use strict";
+
+// src/gate.ts
+var GateInfraError = class extends Error {
+  constructor(message, statusCode) {
+    super(message);
+    this.statusCode = statusCode;
+    this.name = "GateInfraError";
+  }
+};
+async function runGate(params) {
+  let evalRes;
+  try {
+    evalRes = await fetch(`${params.apiUrl}/v1-evaluate`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${params.apiKey}`
+      },
+      body: JSON.stringify(params.payload)
+    });
+  } catch (err) {
+    throw new GateInfraError(
+      `evaluate unreachable: ${err instanceof Error ? err.message : String(err)}`
+    );
+  }
+  if (evalRes.status >= 500) {
+    throw new GateInfraError(
+      `evaluate HTTP ${evalRes.status} \u2014 infrastructure failure, not a policy decision`,
+      evalRes.status
+    );
+  }
+  if (evalRes.status === 401 || evalRes.status === 403) {
+    throw new GateInfraError(
+      `evaluate auth failed (HTTP ${evalRes.status}). Check ATLASENT_API_KEY scopes.`,
+      evalRes.status
+    );
+  }
+  if (evalRes.status === 429) {
+    throw new GateInfraError(
+      `evaluate rate-limited (HTTP 429). Retry or raise rate_limit_per_minute.`,
+      429
+    );
+  }
+  if (!evalRes.ok) {
+    throw new GateInfraError(`evaluate HTTP ${evalRes.status}`, evalRes.status);
+  }
+  let evalBody;
+  try {
+    evalBody = await evalRes.json();
+  } catch {
+    throw new GateInfraError("failed to parse evaluate response as JSON");
+  }
+  const decision = evalBody["decision"] ?? "unknown";
+  const permitToken = evalBody["permit_token"] ?? "";
+  const evaluationId = evalBody["evaluation_id"] ?? "";
+  const proofHash = evalBody["proof_hash"] ?? "";
+  const riskScore = extractRiskScore(evalBody);
+  if (decision !== "allow") {
+    const reason = evalBody["deny_reason"] ?? evalBody["hold_reason"] ?? "";
+    return { ok: false, decision, verified: false, permitToken, evaluationId, proofHash, riskScore, reason };
+  }
+  if (!permitToken) {
+    throw new GateInfraError(
+      `evaluate=allow but no permit_token \u2014 refusing to gate-open without a verifiable permit (evaluation: ${evaluationId})`
+    );
+  }
+  let verifyRes;
+  try {
+    verifyRes = await fetch(`${params.apiUrl}/v1-verify-permit`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${params.apiKey}`
+      },
+      body: JSON.stringify({
+        permit_token: permitToken,
+        action_type: params.actionType,
+        actor_id: params.actorId
+      })
+    });
+  } catch (err) {
+    throw new GateInfraError(
+      `verify-permit unreachable: ${err instanceof Error ? err.message : String(err)}`
+    );
+  }
+  if (!verifyRes.ok) {
+    throw new GateInfraError(
+      `verify-permit HTTP ${verifyRes.status}`,
+      verifyRes.status
+    );
+  }
+  let verifyBody;
+  try {
+    verifyBody = await verifyRes.json();
+  } catch {
+    throw new GateInfraError("failed to parse verify-permit response as JSON");
+  }
+  if (verifyBody.verified !== true) {
+    return {
+      ok: false,
+      decision: "allow",
+      verified: false,
+      permitToken,
+      evaluationId,
+      proofHash,
+      riskScore,
+      reason: `permit verification failed (outcome=${verifyBody.outcome ?? "unknown"})`,
+      verifyOutcome: verifyBody.outcome
+    };
+  }
+  return {
+    ok: true,
+    decision: "allow",
+    verified: true,
+    permitToken,
+    evaluationId,
+    proofHash,
+    riskScore,
+    verifyOutcome: verifyBody.outcome ?? "verified"
+  };
+}
+function extractRiskScore(result) {
+  const risk = result["risk"];
+  if (risk && typeof risk === "object" && "score" in risk) {
+    const score = risk.score;
+    if (typeof score === "number")
+      return String(score);
+  }
+  const flat = result["risk_score"];
+  if (typeof flat === "number")
+    return String(flat);
+  return "";
+}
+
+// src/index.ts
+function getInput(name, required = false) {
+  const envKey = `INPUT_${name.replace(/-/g, "_").toUpperCase()}`;
+  const val = (process.env[envKey] ?? "").trim();
+  if (required && !val) {
+    setFailed(`Input required and not supplied: ${name}`);
+  }
+  return val;
+}
+function setOutput(name, value) {
+  const outputFile = process.env["GITHUB_OUTPUT"];
+  if (outputFile) {
+    const fs = require("node:fs");
+    fs.appendFileSync(outputFile, `${name}=${value}
+`);
+  }
+  console.log(`::set-output name=${name}::${value}`);
+}
+function setFailed(message) {
+  console.log(`::error::${message}`);
+  process.exit(1);
+}
+function warning(message) {
+  console.log(`::warning::${message}`);
+}
+function info(message) {
+  console.log(message);
+}
+function maskValue(value) {
+  console.log(`::add-mask::${value}`);
+}
+function getGitHubContext() {
+  return {
+    repository: process.env["GITHUB_REPOSITORY"] ?? "",
+    ref: process.env["GITHUB_REF"] ?? "",
+    sha: process.env["GITHUB_SHA"] ?? "",
+    run_id: process.env["GITHUB_RUN_ID"] ?? "",
+    run_number: process.env["GITHUB_RUN_NUMBER"] ?? "",
+    workflow: process.env["GITHUB_WORKFLOW"] ?? "",
+    event_name: process.env["GITHUB_EVENT_NAME"] ?? "",
+    pr_number: process.env["GITHUB_REF"]?.match(/^refs\/pull\/(\d+)\//)?.[1],
+    server_url: process.env["GITHUB_SERVER_URL"] ?? "https://github.com"
+  };
+}
+function resolveEnvironment(explicit, ref, apiKey) {
+  if (explicit)
+    return explicit;
+  if (apiKey.startsWith("ask_test_"))
+    return "test";
+  if (apiKey.startsWith("ask_live_"))
+    return "live";
+  const branch = ref.replace("refs/heads/", "");
+  return branch === "main" || branch === "master" ? "live" : "test";
+}
+async function run() {
+  const apiKey = getInput("api-key", true);
+  const actionType = getInput("action", true);
+  const actor = getInput("actor") || "unknown";
+  const targetId = getInput("target-id");
+  const explicitEnv = getInput("environment");
+  const apiUrl = getInput("api-url") || "https://ihghhasvxtltlbizvkqy.supabase.co/functions/v1";
+  const failOnDeny = getInput("fail-on-deny") !== "false";
+  let extraContext = {};
+  try {
+    extraContext = JSON.parse(getInput("context") || "{}");
+  } catch {
+    warning("Could not parse 'context' input as JSON \u2014 ignoring");
+  }
+  maskValue(apiKey);
+  const gh = getGitHubContext();
+  const environment = resolveEnvironment(explicitEnv, gh.ref, apiKey);
+  const payload = {
+    action_type: actionType,
+    actor_id: `github:${actor}`,
+    context: {
+      environment,
+      source: "github-action",
+      repository: gh.repository,
+      ref: gh.ref,
+      sha: gh.sha,
+      workflow: gh.workflow,
+      run_id: gh.run_id,
+      run_number: gh.run_number,
+      event_name: gh.event_name,
+      pr_number: gh.pr_number ?? null,
+      run_url: `${gh.server_url}/${gh.repository}/actions/runs/${gh.run_id}`,
+      ...targetId ? { target_id: targetId } : {},
+      ...extraContext
+    }
+  };
+  if (targetId)
+    payload["target_id"] = targetId;
+  info(
+    `AtlaSent Gate: evaluating "${actionType}" for actor "${actor}" in ${environment} environment` + (targetId ? ` (target=${targetId})` : "")
+  );
+  let result;
+  try {
+    result = await runGate({
+      apiUrl,
+      apiKey,
+      actionType,
+      actorId: `github:${actor}`,
+      payload
+    });
+  } catch (err) {
+    const msg = err instanceof GateInfraError ? err.message : `Unexpected error: ${err instanceof Error ? err.message : String(err)}`;
+    setOutput("decision", "error");
+    setOutput("verified", "false");
+    setFailed(
+      `AtlaSent Gate: ${msg}. Deploy blocked \u2014 the gate cannot confirm authorization (fail-closed).`
+    );
+    return;
+  }
+  if (result.permitToken)
+    maskValue(result.permitToken);
+  if (result.proofHash)
+    maskValue(result.proofHash);
+  setOutput("decision", result.decision);
+  setOutput("permit-token", result.permitToken);
+  setOutput("evaluation-id", result.evaluationId);
+  setOutput("proof-hash", result.proofHash);
+  setOutput("risk-score", result.riskScore);
+  setOutput("verified", result.verified ? "true" : "false");
+  if (result.ok) {
+    info(`Authorization GRANTED (evaluate + verify)`);
+    info(`  Permit token: (set as 'permit-token' output, masked in logs)`);
+    info(`  Proof hash:   (set as 'proof-hash' output, masked in logs)`);
+    info(`  Evaluation:   ${result.evaluationId}`);
+    if (result.riskScore)
+      info(`  Risk score:   ${result.riskScore}`);
+    info(`  Verify:       ${result.verifyOutcome}`);
+    return;
+  }
+  if (result.decision === "allow") {
+    setFailed(
+      `Permit verification failed (outcome=${result.verifyOutcome ?? "unknown"}). Deploy blocked. This typically means the permit was already consumed by an earlier verify, or it expired.`
+    );
+    return;
+  }
+  switch (result.decision) {
+    case "deny":
+      if (failOnDeny) {
+        setFailed(`Authorization DENIED: ${result.reason || "no reason provided"}`);
+      } else {
+        warning(`Authorization DENIED: ${result.reason || "no reason provided"}`);
+      }
+      break;
+    case "hold":
+      if (failOnDeny) {
+        setFailed(`Authorization on HOLD: ${result.reason || "awaiting approval"}`);
+      } else {
+        warning(`Authorization on HOLD: ${result.reason || "awaiting approval"}`);
+      }
+      break;
+    case "escalate":
+      if (failOnDeny) {
+        setFailed("Authorization ESCALATED \u2014 manual review required");
+      } else {
+        warning("Authorization ESCALATED \u2014 manual review required");
+      }
+      break;
+    default:
+      warning(`Unexpected decision: ${result.decision}`);
+      if (failOnDeny) {
+        setFailed(`Unexpected decision from AtlaSent: ${result.decision}`);
+      }
+  }
+}
+run().catch((err) => {
+  console.log(`::error::Unexpected error: ${err instanceof Error ? err.message : String(err)}`);
+  process.exit(1);
+});

--- a/dist/index.js
+++ b/dist/index.js
@@ -470,7 +470,20 @@ async function runV21(env, flags) {
         v2Streaming: flags.v2Streaming
       });
       decisions = [...decisions];
-      decisions[idx] = terminal;
+      if (terminal.decision === "allow") {
+        const item = items[idx];
+        const vr = terminal.permitToken ? await verifyOne({
+          apiUrl: inputs.apiUrl,
+          apiKey: inputs.apiKey,
+          actionType: item.action,
+          actorId: item.actor,
+          permitToken: terminal.permitToken,
+          verifyPath: "/v1/verify-permit"
+        }) : { verified: false, outcome: void 0 };
+        decisions[idx] = { ...terminal, verified: vr.verified, verifyOutcome: vr.outcome };
+      } else {
+        decisions[idx] = terminal;
+      }
     }
   }
   const failed = inputs.failOnDeny && decisions.some((d) => d.decision === "deny");

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,10 @@
         "packages/*"
       ],
       "devDependencies": {
+        "@types/node": "^20.0.0",
         "esbuild": "^0.20.0",
-        "typescript": "^5.4.0"
+        "typescript": "^5.4.0",
+        "vitest": "^1.0.0"
       }
     },
     "node_modules/@atlasent/enforce": {
@@ -794,6 +796,16 @@
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.39",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
+      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
     },
     "node_modules/@vitest/expect": {
       "version": "1.6.1",
@@ -1632,6 +1644,13 @@
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
       "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,9 @@
       "workspaces": [
         "packages/*"
       ],
+      "dependencies": {
+        "@atlasent/enforce": "*"
+      },
       "devDependencies": {
         "@types/node": "^20.0.0",
         "esbuild": "^0.20.0",

--- a/package.json
+++ b/package.json
@@ -6,11 +6,14 @@
   "workspaces": ["packages/*"],
   "scripts": {
     "build": "esbuild src/index.ts --bundle --platform=node --target=node20 --outfile=dist/index.js",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
   },
   "devDependencies": {
+    "@types/node": "^20.0.0",
     "esbuild": "^0.20.0",
-    "typescript": "^5.4.0"
+    "typescript": "^5.4.0",
+    "vitest": "^1.0.0"
   },
   "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atlasent-action",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "GitHub Action for AtlaSent authorization gates — require a permit before critical CI/CD actions execute",
   "main": "dist/index.js",
   "workspaces": ["packages/*"],

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run"
   },
+  "dependencies": {
+    "@atlasent/enforce": "*"
+  },
   "devDependencies": {
     "@types/node": "^20.0.0",
     "esbuild": "^0.20.0",

--- a/packages/enforce/dist/index.d.ts
+++ b/packages/enforce/dist/index.d.ts
@@ -1,0 +1,36 @@
+export interface EnforceConfig {
+    apiKey: string;
+    apiUrl?: string;
+    action: string;
+    actor: string;
+    environment?: string;
+    targetId?: string;
+    context?: Record<string, unknown>;
+}
+export interface Decision {
+    decision: "allow" | "deny" | "hold" | "escalate";
+    evaluationId?: string;
+    permitToken?: string;
+    proofHash?: string;
+    riskScore?: number;
+    denyReason?: string;
+    holdReason?: string;
+}
+export interface VerifyPermitResult {
+    verified: boolean;
+    outcome?: string;
+}
+export type EnforcePhase = "evaluate" | "verify" | "verify-permit" | "execute";
+export declare class EnforceError extends Error {
+    readonly phase: EnforcePhase;
+    readonly decision: Decision | null;
+    constructor(message: string, phase: EnforcePhase, decision?: Decision | null);
+}
+export declare function evaluate(config: EnforceConfig): Promise<Decision>;
+export declare function verify(decision: Decision): void;
+export declare function verifyPermit(config: EnforceConfig, decision: Decision): Promise<VerifyPermitResult>;
+export declare function enforce<T>(config: EnforceConfig, fn: () => Promise<T>): Promise<{
+    result: T;
+    decision: Decision;
+    verifyOutcome?: string;
+}>;

--- a/packages/enforce/dist/index.js
+++ b/packages/enforce/dist/index.js
@@ -1,0 +1,170 @@
+"use strict";
+// @atlasent/enforce — fail-closed execution wrapper.
+//
+// Enforces the evaluate → verify → verifyPermit → execute contract:
+//   1. evaluate()     — calls POST /v1/evaluate; any infra error blocks execution
+//   2. verify()       — rejects non-allow decisions (deny / hold / escalate)
+//   3. verifyPermit() — calls POST /v1/verify-permit; replay/expired tokens block
+//   4. enforce()      — composes all three; fn never runs unless all steps pass
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.EnforceError = void 0;
+exports.evaluate = evaluate;
+exports.verify = verify;
+exports.verifyPermit = verifyPermit;
+exports.enforce = enforce;
+const transport_1 = require("./transport");
+const DEFAULT_API_URL = "https://api.atlasent.io";
+class EnforceError extends Error {
+    phase;
+    decision;
+    constructor(message, phase, decision = null) {
+        super(message);
+        this.name = "EnforceError";
+        this.phase = phase;
+        this.decision = decision;
+    }
+}
+exports.EnforceError = EnforceError;
+// ---------------------------------------------------------------------------
+// Step 1 — evaluate
+// ---------------------------------------------------------------------------
+async function evaluate(config) {
+    const apiUrl = (config.apiUrl ?? DEFAULT_API_URL).replace(/\/$/, "");
+    const payload = {
+        action_type: config.action,
+        actor_id: config.actor,
+        context: {
+            ...(config.environment ? { environment: config.environment } : {}),
+            ...(config.targetId ? { target_id: config.targetId } : {}),
+            ...config.context,
+        },
+    };
+    if (config.targetId)
+        payload["target_id"] = config.targetId;
+    let status;
+    let body;
+    try {
+        ({ status, body } = await (0, transport_1.post)(`${apiUrl}/v1/evaluate`, JSON.stringify(payload), {
+            Authorization: `Bearer ${config.apiKey}`,
+        }));
+    }
+    catch (err) {
+        throw new EnforceError(`AtlaSent API unreachable: ${err instanceof Error ? err.message : String(err)}`, "evaluate");
+    }
+    if (status >= 500) {
+        throw new EnforceError(`Infrastructure failure (HTTP ${status})`, "evaluate");
+    }
+    if (status === 401 || status === 403) {
+        throw new EnforceError(`Authentication failed (HTTP ${status})`, "evaluate");
+    }
+    if (status === 429) {
+        throw new EnforceError("Rate limited (HTTP 429)", "evaluate");
+    }
+    if (status < 200 || status >= 300) {
+        throw new EnforceError(`Unexpected response (HTTP ${status})`, "evaluate");
+    }
+    let raw;
+    try {
+        raw = JSON.parse(body);
+    }
+    catch {
+        throw new EnforceError("Non-JSON response from AtlaSent API", "evaluate");
+    }
+    return mapDecision(raw);
+}
+// ---------------------------------------------------------------------------
+// Step 2 — verify (decision check — no HTTP call)
+// ---------------------------------------------------------------------------
+function verify(decision) {
+    switch (decision.decision) {
+        case "allow":
+            return;
+        case "deny":
+            throw new EnforceError(`Denied: ${decision.denyReason ?? "no reason provided"}`, "verify", decision);
+        case "hold":
+            throw new EnforceError(`On hold: ${decision.holdReason ?? "awaiting approval"}`, "verify", decision);
+        case "escalate":
+            throw new EnforceError("Escalated — manual review required", "verify", decision);
+        default:
+            throw new EnforceError(`Unknown decision: ${String(decision.decision)}`, "verify", decision);
+    }
+}
+// ---------------------------------------------------------------------------
+// Step 3 — verifyPermit (calls /v1/verify-permit, fail-closed)
+//
+// Without this round-trip the enforce wrapper is evaluate-only: a tampered or
+// replayed permit_token would still surface decision=allow. This step consumes
+// the token — downstream re-verify returns outcome=permit_consumed.
+// ---------------------------------------------------------------------------
+async function verifyPermit(config, decision) {
+    if (!decision.permitToken) {
+        throw new EnforceError("evaluate returned allow but no permit_token — refusing to execute without verifiable permit", "verify-permit", decision);
+    }
+    const apiUrl = (config.apiUrl ?? DEFAULT_API_URL).replace(/\/$/, "");
+    let status;
+    let body;
+    try {
+        ({ status, body } = await (0, transport_1.post)(`${apiUrl}/v1/verify-permit`, JSON.stringify({
+            permit_token: decision.permitToken,
+            action_type: config.action,
+            actor_id: config.actor,
+        }), { Authorization: `Bearer ${config.apiKey}` }));
+    }
+    catch (err) {
+        throw new EnforceError(`verify-permit unreachable: ${err instanceof Error ? err.message : String(err)}`, "verify-permit", decision);
+    }
+    if (status >= 500) {
+        throw new EnforceError(`verify-permit infrastructure failure (HTTP ${status})`, "verify-permit", decision);
+    }
+    if (status < 200 || status >= 300) {
+        throw new EnforceError(`verify-permit failed (HTTP ${status})`, "verify-permit", decision);
+    }
+    let raw;
+    try {
+        raw = JSON.parse(body);
+    }
+    catch {
+        throw new EnforceError("Non-JSON response from verify-permit", "verify-permit", decision);
+    }
+    if (raw.verified !== true) {
+        // outcome=permit_consumed (replay), permit_expired, etc.
+        throw new EnforceError(`Permit verification failed (outcome=${raw.outcome ?? "unknown"})`, "verify-permit", decision);
+    }
+    return { verified: true, outcome: raw.outcome };
+}
+// ---------------------------------------------------------------------------
+// Step 4 — enforce (evaluate → verify → verifyPermit → execute, fail-closed)
+// ---------------------------------------------------------------------------
+async function enforce(config, fn) {
+    const decision = await evaluate(config); // throws EnforceError → fn never runs
+    verify(decision); // throws EnforceError → fn never runs
+    const vp = await verifyPermit(config, decision); // throws EnforceError → fn never runs
+    const result = await fn();
+    return { result, decision, verifyOutcome: vp.outcome };
+}
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+function mapDecision(raw) {
+    return {
+        decision: raw["decision"],
+        evaluationId: raw["evaluation_id"],
+        permitToken: raw["permit_token"],
+        proofHash: raw["proof_hash"],
+        riskScore: extractRiskScore(raw),
+        denyReason: raw["deny_reason"],
+        holdReason: raw["hold_reason"],
+    };
+}
+function extractRiskScore(raw) {
+    const risk = raw["risk"];
+    if (risk && typeof risk === "object" && "score" in risk) {
+        const score = risk.score;
+        if (typeof score === "number")
+            return score;
+    }
+    const flat = raw["risk_score"];
+    if (typeof flat === "number")
+        return flat;
+    return undefined;
+}

--- a/packages/enforce/dist/transport.d.ts
+++ b/packages/enforce/dist/transport.d.ts
@@ -1,0 +1,5 @@
+export interface HttpResponse {
+    status: number;
+    body: string;
+}
+export declare function post(url: string, body: string, headers: Record<string, string>): Promise<HttpResponse>;

--- a/packages/enforce/dist/transport.js
+++ b/packages/enforce/dist/transport.js
@@ -25,6 +25,7 @@ function post(url, body, headers) {
             const chunks = [];
             res.on("data", (chunk) => chunks.push(chunk));
             res.on("end", () => resolve({ status: res.statusCode ?? 0, body: Buffer.concat(chunks).toString("utf-8") }));
+            res.on("error", reject);
         });
         req.on("error", reject);
         req.on("timeout", () => {

--- a/packages/enforce/dist/transport.js
+++ b/packages/enforce/dist/transport.js
@@ -1,0 +1,37 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.post = post;
+const node_https_1 = __importDefault(require("node:https"));
+const node_http_1 = __importDefault(require("node:http"));
+function post(url, body, headers) {
+    return new Promise((resolve, reject) => {
+        const parsed = new URL(url);
+        const transport = parsed.protocol === "https:" ? node_https_1.default : node_http_1.default;
+        const req = transport.request({
+            hostname: parsed.hostname,
+            port: parsed.port || (parsed.protocol === "https:" ? 443 : 80),
+            path: parsed.pathname + parsed.search,
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                "Content-Length": Buffer.byteLength(body),
+                ...headers,
+            },
+            timeout: 30_000,
+        }, (res) => {
+            const chunks = [];
+            res.on("data", (chunk) => chunks.push(chunk));
+            res.on("end", () => resolve({ status: res.statusCode ?? 0, body: Buffer.concat(chunks).toString("utf-8") }));
+        });
+        req.on("error", reject);
+        req.on("timeout", () => {
+            req.destroy();
+            reject(new Error("Request timed out after 30s"));
+        });
+        req.write(body);
+        req.end();
+    });
+}

--- a/packages/enforce/package.json
+++ b/packages/enforce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atlasent/enforce",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Fail-closed execution wrapper enforcing the AtlaSent evaluate → verify → execute contract",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/enforce/src/__tests__/enforce.test.ts
+++ b/packages/enforce/src/__tests__/enforce.test.ts
@@ -17,23 +17,39 @@ const BASE_CONFIG = {
 // Raw API response shapes (snake_case) used for mock HTTP bodies
 const ALLOW_RESPONSE = { decision: "allow", evaluation_id: "ev-1", permit_token: "pt-abc" };
 const DENY_RESPONSE = { decision: "deny", deny_reason: "policy blocked" };
+const VERIFY_OK = { verified: true, outcome: "ok" };
 
 function mockResponse(status: number, body: unknown) {
   mockPost.mockResolvedValueOnce({ status, body: JSON.stringify(body) });
+}
+
+/** Queue: evaluate response, then verify-permit response. */
+function mockAllow() {
+  mockResponse(200, ALLOW_RESPONSE);
+  mockResponse(200, VERIFY_OK);
 }
 
 describe("enforce — contract invariants", () => {
   beforeEach(() => mockPost.mockReset());
   afterEach(() => vi.restoreAllMocks());
 
-  it("executes fn and returns { result, decision } when allow", async () => {
-    mockResponse(200, ALLOW_RESPONSE);
+  it("executes fn and returns { result, decision, verifyOutcome } when allow+verified", async () => {
+    mockAllow();
     const fn = vi.fn().mockResolvedValue("deployed");
     const out = await enforce(BASE_CONFIG, fn);
     expect(fn).toHaveBeenCalledOnce();
     expect(out.result).toBe("deployed");
     expect(out.decision.decision).toBe("allow");
     expect(out.decision.permitToken).toBe("pt-abc");
+    expect(out.verifyOutcome).toBe("ok");
+  });
+
+  it("calls evaluate then verify-permit (two POST calls)", async () => {
+    mockAllow();
+    await enforce(BASE_CONFIG, vi.fn().mockResolvedValue(null));
+    expect(mockPost).toHaveBeenCalledTimes(2);
+    expect(mockPost.mock.calls[0][0]).toBe("https://api.test/v1/evaluate");
+    expect(mockPost.mock.calls[1][0]).toBe("https://api.test/v1/verify-permit");
   });
 
   it("fn never runs when evaluate throws (network failure)", async () => {
@@ -73,8 +89,40 @@ describe("enforce — contract invariants", () => {
     expect(fn).not.toHaveBeenCalled();
   });
 
-  it("propagates fn errors naturally after a successful allow", async () => {
+  it("fn never runs when verifyPermit returns verified=false (replay)", async () => {
     mockResponse(200, ALLOW_RESPONSE);
+    mockResponse(200, { verified: false, outcome: "permit_consumed" });
+    const fn = vi.fn();
+    await expect(enforce(BASE_CONFIG, fn)).rejects.toSatisfy(
+      (e: EnforceError) => e instanceof EnforceError && e.phase === "verify-permit",
+    );
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it("fn never runs when verifyPermit is unreachable", async () => {
+    mockResponse(200, ALLOW_RESPONSE);
+    mockPost.mockRejectedValueOnce(new Error("ETIMEDOUT"));
+    const fn = vi.fn();
+    await expect(enforce(BASE_CONFIG, fn)).rejects.toSatisfy(
+      (e: EnforceError) => e instanceof EnforceError && e.phase === "verify-permit",
+    );
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it("fn never runs when evaluate returns allow but no permit_token", async () => {
+    mockResponse(200, { decision: "allow", evaluation_id: "ev-1" }); // no permit_token
+    const fn = vi.fn();
+    await expect(enforce(BASE_CONFIG, fn)).rejects.toSatisfy(
+      (e: EnforceError) =>
+        e instanceof EnforceError &&
+        e.phase === "verify-permit" &&
+        /no permit_token/.test(e.message),
+    );
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it("propagates fn errors naturally after a successful allow+verify", async () => {
+    mockAllow();
     const boom = new Error("deploy exploded");
     const fn = vi.fn().mockRejectedValue(boom);
     await expect(enforce(BASE_CONFIG, fn)).rejects.toBe(boom);
@@ -97,5 +145,16 @@ describe("enforce — contract invariants", () => {
     expect(err).toBeInstanceOf(EnforceError);
     expect(err.phase).toBe("verify");
     expect(err.decision?.decision).toBe("deny");
+  });
+
+  it("error from verify-permit phase carries the decision", async () => {
+    mockResponse(200, ALLOW_RESPONSE);
+    mockResponse(200, { verified: false, outcome: "permit_expired" });
+    const fn = vi.fn();
+    const err = await enforce(BASE_CONFIG, fn).catch((e: unknown) => e as EnforceError);
+    expect(err).toBeInstanceOf(EnforceError);
+    expect(err.phase).toBe("verify-permit");
+    expect(err.decision?.decision).toBe("allow");
+    expect(err.decision?.permitToken).toBe("pt-abc");
   });
 });

--- a/packages/enforce/src/__tests__/transport.test.ts
+++ b/packages/enforce/src/__tests__/transport.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { EventEmitter } from "node:events";
+
+// Test transport.ts at the socket level by mocking node:https directly.
+// All other enforce tests mock the transport module itself — this file
+// exercises the actual request/response plumbing.
+
+vi.mock("node:https", () => ({ default: { request: vi.fn() } }));
+vi.mock("node:http", () => ({ default: { request: vi.fn() } }));
+
+import https from "node:https";
+import { post } from "../transport";
+
+const mockRequest = https.request as ReturnType<typeof vi.fn>;
+
+afterEach(() => mockRequest.mockReset());
+
+// Minimal fake ClientRequest
+function fakeReq() {
+  const em = new EventEmitter();
+  return Object.assign(em, { write: vi.fn(), end: vi.fn(), destroy: vi.fn() });
+}
+
+// Minimal fake IncomingMessage
+function fakeRes(statusCode: number) {
+  return Object.assign(new EventEmitter(), { statusCode });
+}
+
+describe("transport.post", () => {
+  it("resolves with status and concatenated body chunks", async () => {
+    const req = fakeReq();
+    const res = fakeRes(200);
+
+    mockRequest.mockImplementation((_opts: unknown, cb: unknown) => {
+      (cb as (r: typeof res) => void)(res);
+      return req;
+    });
+
+    const p = post("https://api.test/v1/evaluate", '{"x":1}', { Authorization: "Bearer k" });
+    res.emit("data", Buffer.from('{"ok"'));
+    res.emit("data", Buffer.from(':true}'));
+    res.emit("end");
+
+    const result = await p;
+    expect(result.status).toBe(200);
+    expect(result.body).toBe('{"ok":true}');
+  });
+
+  it("sends Content-Type, Content-Length, and caller headers", async () => {
+    const req = fakeReq();
+    const res = fakeRes(200);
+    let capturedOpts: Record<string, unknown> = {};
+
+    mockRequest.mockImplementation((opts: unknown, cb: unknown) => {
+      capturedOpts = opts as Record<string, unknown>;
+      (cb as (r: typeof res) => void)(res);
+      return req;
+    });
+
+    const p = post("https://api.test/v1/evaluate", '{"x":1}', { Authorization: "Bearer k" });
+    res.emit("end");
+    await p;
+
+    const headers = capturedOpts["headers"] as Record<string, unknown>;
+    expect(headers["Content-Type"]).toBe("application/json");
+    expect(headers["Content-Length"]).toBeGreaterThan(0);
+    expect(headers["Authorization"]).toBe("Bearer k");
+  });
+
+  it("rejects on request-level error (e.g. ECONNREFUSED)", async () => {
+    const req = fakeReq();
+    mockRequest.mockImplementation(() => req);
+
+    const p = post("https://api.test/v1/evaluate", "{}", {});
+    req.emit("error", new Error("ECONNREFUSED"));
+
+    await expect(p).rejects.toThrow("ECONNREFUSED");
+  });
+
+  it("rejects on response-stream error (e.g. ECONNRESET mid-body)", async () => {
+    const req = fakeReq();
+    const res = fakeRes(200);
+
+    mockRequest.mockImplementation((_opts: unknown, cb: unknown) => {
+      (cb as (r: typeof res) => void)(res);
+      return req;
+    });
+
+    const p = post("https://api.test/v1/evaluate", "{}", {});
+    res.emit("data", Buffer.from("partial"));
+    res.emit("error", new Error("ECONNRESET"));
+
+    await expect(p).rejects.toThrow("ECONNRESET");
+  });
+
+  it("rejects with timeout message and destroys the request", async () => {
+    const req = fakeReq();
+    mockRequest.mockImplementation(() => req);
+
+    const p = post("https://api.test/v1/evaluate", "{}", {});
+    req.emit("timeout");
+
+    await expect(p).rejects.toThrow("Request timed out after 30s");
+    expect(req.destroy).toHaveBeenCalled();
+  });
+});

--- a/packages/enforce/src/__tests__/verify-permit.test.ts
+++ b/packages/enforce/src/__tests__/verify-permit.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { verifyPermit, EnforceError } from "../index";
+import type { Decision } from "../index";
+
+vi.mock("../transport", () => ({ post: vi.fn() }));
+
+import { post } from "../transport";
+const mockPost = post as ReturnType<typeof vi.fn>;
+
+const BASE_CONFIG = {
+  apiKey: "ask_test_key",
+  apiUrl: "https://api.test",
+  action: "production_deploy",
+  actor: "alice",
+};
+
+const ALLOW_DECISION: Decision = {
+  decision: "allow",
+  evaluationId: "ev-1",
+  permitToken: "pt-abc",
+};
+
+function mockResponse(status: number, body: unknown) {
+  mockPost.mockResolvedValueOnce({ status, body: JSON.stringify(body) });
+}
+
+describe("verifyPermit", () => {
+  beforeEach(() => mockPost.mockReset());
+  afterEach(() => vi.restoreAllMocks());
+
+  // ── Happy path ──────────────────────────────────────────────────────────────
+
+  it("returns { verified: true, outcome } on success", async () => {
+    mockResponse(200, { verified: true, outcome: "ok" });
+    const r = await verifyPermit(BASE_CONFIG, ALLOW_DECISION);
+    expect(r.verified).toBe(true);
+    expect(r.outcome).toBe("ok");
+  });
+
+  it("hits the correct verify-permit endpoint", async () => {
+    mockResponse(200, { verified: true });
+    await verifyPermit(BASE_CONFIG, ALLOW_DECISION);
+    expect(mockPost.mock.calls[0][0]).toBe("https://api.test/v1/verify-permit");
+  });
+
+  it("sends permit_token + action_type + actor_id in body", async () => {
+    mockResponse(200, { verified: true });
+    await verifyPermit(BASE_CONFIG, ALLOW_DECISION);
+    const body = JSON.parse(mockPost.mock.calls[0][1] as string) as Record<string, unknown>;
+    expect(body.permit_token).toBe("pt-abc");
+    expect(body.action_type).toBe("production_deploy");
+    expect(body.actor_id).toBe("alice");
+  });
+
+  it("sends Authorization header", async () => {
+    mockResponse(200, { verified: true });
+    await verifyPermit(BASE_CONFIG, ALLOW_DECISION);
+    expect((mockPost.mock.calls[0][2] as Record<string, string>)["Authorization"]).toBe(
+      "Bearer ask_test_key",
+    );
+  });
+
+  it("strips trailing slash from apiUrl", async () => {
+    mockResponse(200, { verified: true });
+    await verifyPermit({ ...BASE_CONFIG, apiUrl: "https://api.test/" }, ALLOW_DECISION);
+    expect(mockPost.mock.calls[0][0]).toBe("https://api.test/v1/verify-permit");
+  });
+
+  // ── No permit_token ─────────────────────────────────────────────────────────
+
+  it("throws EnforceError(verify-permit) when decision has no permitToken", async () => {
+    const noToken: Decision = { decision: "allow", evaluationId: "ev-1" };
+    await expect(verifyPermit(BASE_CONFIG, noToken)).rejects.toSatisfy(
+      (e: EnforceError) =>
+        e instanceof EnforceError &&
+        e.phase === "verify-permit" &&
+        /no permit_token/.test(e.message),
+    );
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+
+  // ── Replay / expired permit ──────────────────────────────────────────────────
+
+  it("throws EnforceError(verify-permit) when verified=false (replay)", async () => {
+    mockResponse(200, { verified: false, outcome: "permit_consumed" });
+    await expect(verifyPermit(BASE_CONFIG, ALLOW_DECISION)).rejects.toSatisfy(
+      (e: EnforceError) =>
+        e instanceof EnforceError &&
+        e.phase === "verify-permit" &&
+        e.message.includes("permit_consumed"),
+    );
+  });
+
+  it("throws EnforceError(verify-permit) when verified=false (expired)", async () => {
+    mockResponse(200, { verified: false, outcome: "permit_expired" });
+    await expect(verifyPermit(BASE_CONFIG, ALLOW_DECISION)).rejects.toSatisfy(
+      (e: EnforceError) => e instanceof EnforceError && e.phase === "verify-permit",
+    );
+  });
+
+  it("attaches the decision to verify-permit errors", async () => {
+    mockResponse(200, { verified: false, outcome: "permit_consumed" });
+    const err = await verifyPermit(BASE_CONFIG, ALLOW_DECISION).catch((e: unknown) => e as EnforceError);
+    expect(err.decision).toBe(ALLOW_DECISION);
+  });
+
+  // ── Infrastructure errors ────────────────────────────────────────────────────
+
+  it("throws EnforceError(verify-permit) on network error", async () => {
+    mockPost.mockRejectedValueOnce(new Error("ECONNREFUSED"));
+    await expect(verifyPermit(BASE_CONFIG, ALLOW_DECISION)).rejects.toSatisfy(
+      (e: EnforceError) =>
+        e instanceof EnforceError &&
+        e.phase === "verify-permit" &&
+        /unreachable/.test(e.message),
+    );
+  });
+
+  it.each([500, 502, 503])("throws EnforceError(verify-permit) on HTTP %i", async (status) => {
+    mockResponse(status, {});
+    await expect(verifyPermit(BASE_CONFIG, ALLOW_DECISION)).rejects.toSatisfy(
+      (e: EnforceError) => e instanceof EnforceError && e.phase === "verify-permit",
+    );
+  });
+
+  it("throws EnforceError(verify-permit) on non-JSON body", async () => {
+    mockPost.mockResolvedValueOnce({ status: 200, body: "not-json" });
+    await expect(verifyPermit(BASE_CONFIG, ALLOW_DECISION)).rejects.toSatisfy(
+      (e: EnforceError) =>
+        e instanceof EnforceError &&
+        e.phase === "verify-permit" &&
+        /Non-JSON/.test(e.message),
+    );
+  });
+});

--- a/packages/enforce/src/index.ts
+++ b/packages/enforce/src/index.ts
@@ -1,10 +1,10 @@
 // @atlasent/enforce — fail-closed execution wrapper.
 //
-// Enforces the evaluate → verify → execute contract:
-//   1. evaluate()  — calls POST /v1/evaluate; any infra error blocks execution
-//   2. verify()    — rejects non-allow decisions (deny / hold / escalate)
-//   3. enforce()   — composes the two; the wrapped function never runs unless
-//                    both evaluate and verify succeed
+// Enforces the evaluate → verify → verifyPermit → execute contract:
+//   1. evaluate()     — calls POST /v1/evaluate; any infra error blocks execution
+//   2. verify()       — rejects non-allow decisions (deny / hold / escalate)
+//   3. verifyPermit() — calls POST /v1/verify-permit; replay/expired tokens block
+//   4. enforce()      — composes all three; fn never runs unless all steps pass
 
 import { post } from "./transport";
 
@@ -34,7 +34,12 @@ export interface Decision {
   holdReason?: string;
 }
 
-export type EnforcePhase = "evaluate" | "verify" | "execute";
+export interface VerifyPermitResult {
+  verified: boolean;
+  outcome?: string;
+}
+
+export type EnforcePhase = "evaluate" | "verify" | "verify-permit" | "execute";
 
 export class EnforceError extends Error {
   readonly phase: EnforcePhase;
@@ -103,7 +108,7 @@ export async function evaluate(config: EnforceConfig): Promise<Decision> {
 }
 
 // ---------------------------------------------------------------------------
-// Step 2 — verify
+// Step 2 — verify (decision check — no HTTP call)
 // ---------------------------------------------------------------------------
 
 export function verify(decision: Decision): void {
@@ -134,17 +139,98 @@ export function verify(decision: Decision): void {
 }
 
 // ---------------------------------------------------------------------------
-// Step 3 — enforce (evaluate → verify → execute, fail-closed)
+// Step 3 — verifyPermit (calls /v1/verify-permit, fail-closed)
+//
+// Without this round-trip the enforce wrapper is evaluate-only: a tampered or
+// replayed permit_token would still surface decision=allow. This step consumes
+// the token — downstream re-verify returns outcome=permit_consumed.
+// ---------------------------------------------------------------------------
+
+export async function verifyPermit(
+  config: EnforceConfig,
+  decision: Decision,
+): Promise<VerifyPermitResult> {
+  if (!decision.permitToken) {
+    throw new EnforceError(
+      "evaluate returned allow but no permit_token — refusing to execute without verifiable permit",
+      "verify-permit",
+      decision,
+    );
+  }
+
+  const apiUrl = (config.apiUrl ?? DEFAULT_API_URL).replace(/\/$/, "");
+
+  let status: number;
+  let body: string;
+  try {
+    ({ status, body } = await post(
+      `${apiUrl}/v1/verify-permit`,
+      JSON.stringify({
+        permit_token: decision.permitToken,
+        action_type: config.action,
+        actor_id: config.actor,
+      }),
+      { Authorization: `Bearer ${config.apiKey}` },
+    ));
+  } catch (err) {
+    throw new EnforceError(
+      `verify-permit unreachable: ${err instanceof Error ? err.message : String(err)}`,
+      "verify-permit",
+      decision,
+    );
+  }
+
+  if (status >= 500) {
+    throw new EnforceError(
+      `verify-permit infrastructure failure (HTTP ${status})`,
+      "verify-permit",
+      decision,
+    );
+  }
+  if (status < 200 || status >= 300) {
+    throw new EnforceError(
+      `verify-permit failed (HTTP ${status})`,
+      "verify-permit",
+      decision,
+    );
+  }
+
+  let raw: { verified?: boolean; outcome?: string };
+  try {
+    raw = JSON.parse(body) as { verified?: boolean; outcome?: string };
+  } catch {
+    throw new EnforceError(
+      "Non-JSON response from verify-permit",
+      "verify-permit",
+      decision,
+    );
+  }
+
+  if (raw.verified !== true) {
+    // outcome=permit_consumed (replay), permit_expired, etc.
+    throw new EnforceError(
+      `Permit verification failed (outcome=${raw.outcome ?? "unknown"})`,
+      "verify-permit",
+      decision,
+    );
+  }
+
+  return { verified: true, outcome: raw.outcome };
+}
+
+// ---------------------------------------------------------------------------
+// Step 4 — enforce (evaluate → verify → verifyPermit → execute, fail-closed)
 // ---------------------------------------------------------------------------
 
 export async function enforce<T>(
   config: EnforceConfig,
   fn: () => Promise<T>,
-): Promise<{ result: T; decision: Decision }> {
-  const decision = await evaluate(config); // throws EnforceError → fn never runs
-  verify(decision);                         // throws EnforceError → fn never runs
+): Promise<{ result: T; decision: Decision; verifyOutcome?: string }> {
+  const decision = await evaluate(config);   // throws EnforceError → fn never runs
+  verify(decision);                          // throws EnforceError → fn never runs
+  const vp = await verifyPermit(config, decision); // throws EnforceError → fn never runs
   const result = await fn();
-  return { result, decision };
+  return { result, decision, verifyOutcome: vp.outcome };
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/enforce/src/transport.ts
+++ b/packages/enforce/src/transport.ts
@@ -33,6 +33,7 @@ export function post(
         res.on("end", () =>
           resolve({ status: res.statusCode ?? 0, body: Buffer.concat(chunks).toString("utf-8") }),
         );
+        res.on("error", reject);
       },
     );
     req.on("error", reject);

--- a/src/__tests__/batch.test.ts
+++ b/src/__tests__/batch.test.ts
@@ -41,12 +41,9 @@ describe("evaluateMany", () => {
   });
 
   it("loops /v1/evaluate when v2Batch=false", async () => {
-    fetchMock.mockResolvedValue(
-      new Response(
-        JSON.stringify({
-          decision: "allow",
-          evaluatedAt: "2026-04-25T00:00:00Z",
-        }),
+    fetchMock.mockImplementation(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ decision: "allow", evaluatedAt: "2026-04-25T00:00:00Z" })),
       ),
     );
     const out = await evaluateMany(

--- a/src/__tests__/batch.test.ts
+++ b/src/__tests__/batch.test.ts
@@ -13,39 +13,60 @@ describe("evaluateMany", () => {
     vi.unstubAllGlobals();
   });
 
-  it("hits /v1/evaluate/batch when v2Batch=true", async () => {
-    fetchMock.mockResolvedValueOnce(
-      new Response(
-        JSON.stringify({
-          results: [
-            {
-              decision: "allow",
-              evaluatedAt: "2026-04-25T00:00:00Z",
-            },
-          ],
-          batchId: "b1",
-        }),
-      ),
+  function evalResp(decision = "allow", permitToken = "tok1") {
+    return new Response(
+      JSON.stringify({ decision, evaluatedAt: "2026-04-25T00:00:00Z", permitToken }),
     );
+  }
+
+  function verifyResp(verified = true, outcome = "ok") {
+    return new Response(JSON.stringify({ verified, outcome }));
+  }
+
+  it("hits /v1/evaluate/batch when v2Batch=true and verifies allow decisions", async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            results: [{ decision: "allow", evaluatedAt: "2026-04-25T00:00:00Z", permitToken: "tok1" }],
+            batchId: "b1",
+          }),
+        ),
+      )
+      // verify call for the allow decision
+      .mockResolvedValueOnce(verifyResp(true, "ok"));
+
     const out = await evaluateMany(
       "https://api.test",
       "k",
       [{ action: "a", actor: "u" }],
       true,
     );
+
     expect(out.batchId).toBe("b1");
+    expect(out.decisions[0].verified).toBe(true);
     expect(fetchMock).toHaveBeenCalledWith(
       "https://api.test/v1/evaluate/batch",
       expect.anything(),
     );
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.test/v1/verify-permit",
+      expect.anything(),
+    );
   });
 
-  it("loops /v1/evaluate when v2Batch=false", async () => {
-    fetchMock.mockImplementation(() =>
-      Promise.resolve(
-        new Response(JSON.stringify({ decision: "allow", evaluatedAt: "2026-04-25T00:00:00Z" })),
-      ),
-    );
+  it("loops /v1/evaluate when v2Batch=false and verifies each allow decision", async () => {
+    fetchMock
+      .mockImplementation((url: string) => {
+        if (url.endsWith("/v1/evaluate")) {
+          return Promise.resolve(evalResp("allow", "tok1"));
+        }
+        if (url.endsWith("/v1/verify-permit")) {
+          return Promise.resolve(verifyResp(true));
+        }
+        return Promise.reject(new Error(`unexpected url: ${url}`));
+      });
+
     const out = await evaluateMany(
       "https://api.test",
       "k",
@@ -55,9 +76,46 @@ describe("evaluateMany", () => {
       ],
       false,
     );
+
     expect(out.decisions).toHaveLength(2);
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(out.decisions[0].verified).toBe(true);
+    expect(out.decisions[1].verified).toBe(true);
     expect(out.batchId).toMatch(/^loop-/);
+  });
+
+  it("deny decisions are not verified (no verify call)", async () => {
+    fetchMock.mockImplementation(() =>
+      Promise.resolve(new Response(JSON.stringify({ decision: "deny", evaluatedAt: "2026-04-25T00:00:00Z" }))),
+    );
+
+    const out = await evaluateMany(
+      "https://api.test",
+      "k",
+      [{ action: "a", actor: "u" }],
+      false,
+    );
+
+    // only the evaluate call — no verify call for deny
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(out.decisions[0].decision).toBe("deny");
+    expect(out.decisions[0].verified).toBeUndefined();
+  });
+
+  it("allow with no permitToken → verified=false (no verify call)", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ decision: "allow", evaluatedAt: "2026-04-25T00:00:00Z" })),
+    );
+
+    const out = await evaluateMany(
+      "https://api.test",
+      "k",
+      [{ action: "a", actor: "u" }],
+      false,
+    );
+
+    expect(out.decisions[0].verified).toBe(false);
+    // no verify call
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
   it("throws on non-2xx batch response", async () => {
@@ -65,5 +123,15 @@ describe("evaluateMany", () => {
     await expect(
       evaluateMany("https://api.test", "k", [{ action: "a", actor: "u" }], true),
     ).rejects.toThrow(/500/);
+  });
+
+  it("throws on verify 5xx (fail-closed)", async () => {
+    fetchMock
+      .mockResolvedValueOnce(evalResp("allow", "tok1"))
+      .mockResolvedValueOnce(new Response("err", { status: 500 }));
+
+    await expect(
+      evaluateMany("https://api.test", "k", [{ action: "a", actor: "u" }], false),
+    ).rejects.toThrow(/verify-permit HTTP 500/);
   });
 });

--- a/src/__tests__/gate.test.ts
+++ b/src/__tests__/gate.test.ts
@@ -1,0 +1,245 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { GateInfraError, runGate } from "../gate";
+
+// SIM tests — simulate all decision-matrix paths without real HTTP.
+// Decision matrix (mirrors atlasent-sdk withPermit / with_permit contract):
+//
+//  evaluate result          verify result          gate outcome
+//  ─────────────────────────────────────────────────────────────
+//  transport error          —                      GateInfraError
+//  5xx / 401 / 403 / 429   —                      GateInfraError
+//  decision=deny/hold/esc   —                      ok=false, verified=false
+//  allow, no permit_token   —                      GateInfraError
+//  allow                    transport error        GateInfraError
+//  allow                    !2xx                   GateInfraError
+//  allow                    verified=false         ok=false, verified=false
+//  allow                    verified=true          ok=true,  verified=true
+
+describe("runGate SIM tests", () => {
+  const fetchMock = vi.fn();
+
+  const PARAMS = {
+    apiUrl: "https://api.test",
+    apiKey: "ask_test_key",
+    actionType: "production_deploy",
+    actorId: "github:alice",
+    payload: { action_type: "production_deploy", actor_id: "github:alice", context: {} },
+  };
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function jsonResp(body: unknown, status = 200): Response {
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  // ── Happy path ─────────────────────────────────────────────────────────────
+
+  it("allow + verify=true → ok=true, verified=true", async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResp({ decision: "allow", permit_token: "tok1", evaluation_id: "ev1", proof_hash: "ph1" }),
+      )
+      .mockResolvedValueOnce(jsonResp({ verified: true, outcome: "ok" }));
+
+    const r = await runGate(PARAMS);
+
+    expect(r.ok).toBe(true);
+    expect(r.verified).toBe(true);
+    expect(r.decision).toBe("allow");
+    expect(r.permitToken).toBe("tok1");
+    expect(r.evaluationId).toBe("ev1");
+    if (r.ok) expect(r.verifyOutcome).toBe("ok");
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "https://api.test/v1-evaluate",
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "https://api.test/v1-verify-permit",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("verify call sends permit_token + action_type + actor_id", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResp({ decision: "allow", permit_token: "tok42" }))
+      .mockResolvedValueOnce(jsonResp({ verified: true }));
+
+    await runGate(PARAMS);
+
+    const verifyCall = fetchMock.mock.calls[1];
+    const body = JSON.parse(verifyCall[1].body as string) as Record<string, unknown>;
+    expect(body.permit_token).toBe("tok42");
+    expect(body.action_type).toBe("production_deploy");
+    expect(body.actor_id).toBe("github:alice");
+  });
+
+  it("propagates risk_score (flat shape) from evaluate", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResp({ decision: "allow", permit_token: "t", risk_score: 0.85 }))
+      .mockResolvedValueOnce(jsonResp({ verified: true }));
+
+    const r = await runGate(PARAMS);
+    expect(r.riskScore).toBe("0.85");
+  });
+
+  it("propagates risk.score (canonical shape) from evaluate", async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResp({ decision: "allow", permit_token: "t", risk: { level: "high", score: 0.9 } }),
+      )
+      .mockResolvedValueOnce(jsonResp({ verified: true }));
+
+    const r = await runGate(PARAMS);
+    expect(r.riskScore).toBe("0.9");
+  });
+
+  // ── Replay / expired permit ─────────────────────────────────────────────────
+
+  it("allow + verify.verified=false (replay) → ok=false, verified=false", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResp({ decision: "allow", permit_token: "tok1" }))
+      .mockResolvedValueOnce(jsonResp({ verified: false, outcome: "permit_consumed" }));
+
+    const r = await runGate(PARAMS);
+
+    expect(r.ok).toBe(false);
+    expect(r.verified).toBe(false);
+    expect(r.decision).toBe("allow");
+    if (!r.ok) {
+      expect(r.verifyOutcome).toBe("permit_consumed");
+      expect(r.reason).toMatch(/permit verification failed/);
+    }
+  });
+
+  it("allow + verify.verified=false (expired) → ok=false, verified=false", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResp({ decision: "allow", permit_token: "tok1" }))
+      .mockResolvedValueOnce(jsonResp({ verified: false, outcome: "permit_expired" }));
+
+    const r = await runGate(PARAMS);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.verifyOutcome).toBe("permit_expired");
+  });
+
+  // ── No permit_token on allow ────────────────────────────────────────────────
+
+  it("allow + no permit_token → throws GateInfraError, no verify call", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResp({ decision: "allow", evaluation_id: "ev1" }));
+
+    const err = await runGate(PARAMS).catch((e) => e as GateInfraError);
+    expect(err).toBeInstanceOf(GateInfraError);
+    expect(err.message).toMatch(/no permit_token/);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  // ── Policy decisions (deny / hold / escalate) ───────────────────────────────
+
+  it("deny → ok=false, verified=false, reason=deny_reason, no verify call", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResp({ decision: "deny", deny_reason: "outside change window" }),
+    );
+
+    const r = await runGate(PARAMS);
+    expect(r.ok).toBe(false);
+    expect(r.verified).toBe(false);
+    expect(r.decision).toBe("deny");
+    if (!r.ok) expect(r.reason).toBe("outside change window");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("hold → ok=false, verified=false, no verify call", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResp({ decision: "hold", hold_reason: "awaiting approval" }),
+    );
+
+    const r = await runGate(PARAMS);
+    expect(r.ok).toBe(false);
+    expect(r.decision).toBe("hold");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("escalate → ok=false, verified=false, no verify call", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResp({ decision: "escalate" }));
+
+    const r = await runGate(PARAMS);
+    expect(r.ok).toBe(false);
+    expect(r.decision).toBe("escalate");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  // ── Infrastructure errors (evaluate side) ──────────────────────────────────
+
+  it("evaluate transport error → throws GateInfraError", async () => {
+    fetchMock.mockRejectedValueOnce(new Error("ECONNREFUSED"));
+
+    const err = await runGate(PARAMS).catch((e) => e as GateInfraError);
+    expect(err).toBeInstanceOf(GateInfraError);
+    expect(err.message).toMatch(/evaluate unreachable/);
+  });
+
+  it("evaluate 5xx → throws GateInfraError (fail-closed)", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResp({ error: "internal" }, 500));
+
+    await expect(runGate(PARAMS)).rejects.toThrow(GateInfraError);
+  });
+
+  it("evaluate 401 → throws GateInfraError", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResp({ error: "unauthorized" }, 401));
+
+    await expect(runGate(PARAMS)).rejects.toThrow(GateInfraError);
+  });
+
+  it("evaluate 403 → throws GateInfraError", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResp({ error: "forbidden" }, 403));
+
+    await expect(runGate(PARAMS)).rejects.toThrow(GateInfraError);
+  });
+
+  it("evaluate 429 → throws GateInfraError", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResp({ error: "rate limited" }, 429));
+
+    await expect(runGate(PARAMS)).rejects.toThrow(GateInfraError);
+  });
+
+  // ── Infrastructure errors (verify side) ────────────────────────────────────
+
+  it("allow + verify transport error → throws GateInfraError", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResp({ decision: "allow", permit_token: "tok1" }))
+      .mockRejectedValueOnce(new Error("ETIMEDOUT"));
+
+    const err = await runGate(PARAMS).catch((e) => e as GateInfraError);
+    expect(err).toBeInstanceOf(GateInfraError);
+    expect(err.message).toMatch(/verify-permit unreachable/);
+  });
+
+  it("allow + verify 5xx → throws GateInfraError", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResp({ decision: "allow", permit_token: "tok1" }))
+      .mockResolvedValueOnce(jsonResp({ error: "internal" }, 500));
+
+    await expect(runGate(PARAMS)).rejects.toThrow(GateInfraError);
+  });
+
+  it("allow + verify 4xx → throws GateInfraError", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResp({ decision: "allow", permit_token: "tok1" }))
+      .mockResolvedValueOnce(jsonResp({ error: "bad request" }, 400));
+
+    await expect(runGate(PARAMS)).rejects.toThrow(GateInfraError);
+  });
+});

--- a/src/__tests__/gate.test.ts
+++ b/src/__tests__/gate.test.ts
@@ -1,21 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { GateInfraError, runGate } from "../gate";
+import { GateInfraError, verifyOne } from "../gate";
 
-// SIM tests — simulate all decision-matrix paths without real HTTP.
-// Decision matrix (mirrors atlasent-sdk withPermit / with_permit contract):
-//
-//  evaluate result          verify result          gate outcome
-//  ─────────────────────────────────────────────────────────────
-//  transport error          —                      GateInfraError
-//  5xx / 401 / 403 / 429   —                      GateInfraError
-//  decision=deny/hold/esc   —                      ok=false, verified=false
-//  allow, no permit_token   —                      GateInfraError
-//  allow                    transport error        GateInfraError
-//  allow                    !2xx                   GateInfraError
-//  allow                    verified=false         ok=false, verified=false
-//  allow                    verified=true          ok=true,  verified=true
+// SIM tests for verifyOne() — the verify-permit helper used by the v2.1
+// batch path (src/batch.ts). The single-eval path uses @atlasent/enforce
+// which has its own verify-permit test suite (packages/enforce).
 
-describe("runGate SIM tests", () => {
+describe("verifyOne", () => {
   const fetchMock = vi.fn();
 
   const PARAMS = {
@@ -23,7 +13,7 @@ describe("runGate SIM tests", () => {
     apiKey: "ask_test_key",
     actionType: "production_deploy",
     actorId: "github:alice",
-    payload: { action_type: "production_deploy", actor_id: "github:alice", context: {} },
+    permitToken: "pt-abc",
   };
 
   beforeEach(() => {
@@ -42,207 +32,72 @@ describe("runGate SIM tests", () => {
     });
   }
 
-  // ── Happy path ─────────────────────────────────────────────────────────────
+  // ── Happy path ──────────────────────────────────────────────────────────────
 
-  it("allow + verify=true → ok=true, verified=true", async () => {
-    fetchMock
-      .mockResolvedValueOnce(
-        jsonResp({ decision: "allow", permit_token: "tok1", evaluation_id: "ev1", proof_hash: "ph1" }),
-      )
-      .mockResolvedValueOnce(jsonResp({ verified: true, outcome: "ok" }));
-
-    const r = await runGate(PARAMS);
-
-    expect(r.ok).toBe(true);
+  it("returns { verified: true, outcome } on success", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResp({ verified: true, outcome: "ok" }));
+    const r = await verifyOne(PARAMS);
     expect(r.verified).toBe(true);
-    expect(r.decision).toBe("allow");
-    expect(r.permitToken).toBe("tok1");
-    expect(r.evaluationId).toBe("ev1");
-    if (r.ok) expect(r.verifyOutcome).toBe("ok");
-
-    expect(fetchMock).toHaveBeenCalledTimes(2);
-    expect(fetchMock).toHaveBeenNthCalledWith(
-      1,
-      "https://api.test/v1-evaluate",
-      expect.objectContaining({ method: "POST" }),
-    );
-    expect(fetchMock).toHaveBeenNthCalledWith(
-      2,
-      "https://api.test/v1-verify-permit",
-      expect.objectContaining({ method: "POST" }),
-    );
+    expect(r.outcome).toBe("ok");
   });
 
-  it("verify call sends permit_token + action_type + actor_id", async () => {
-    fetchMock
-      .mockResolvedValueOnce(jsonResp({ decision: "allow", permit_token: "tok42" }))
-      .mockResolvedValueOnce(jsonResp({ verified: true }));
+  it("returns { verified: false } when server returns verified=false", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResp({ verified: false, outcome: "permit_consumed" }));
+    const r = await verifyOne(PARAMS);
+    expect(r.verified).toBe(false);
+    expect(r.outcome).toBe("permit_consumed");
+  });
 
-    await runGate(PARAMS);
+  // ── Request shape ───────────────────────────────────────────────────────────
 
-    const verifyCall = fetchMock.mock.calls[1];
-    const body = JSON.parse(verifyCall[1].body as string) as Record<string, unknown>;
-    expect(body.permit_token).toBe("tok42");
+  it("uses /v1-verify-permit by default", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResp({ verified: true }));
+    await verifyOne(PARAMS);
+    expect(fetchMock.mock.calls[0][0]).toBe("https://api.test/v1-verify-permit");
+  });
+
+  it("uses custom verifyPath when provided", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResp({ verified: true }));
+    await verifyOne({ ...PARAMS, verifyPath: "/v1/verify-permit" });
+    expect(fetchMock.mock.calls[0][0]).toBe("https://api.test/v1/verify-permit");
+  });
+
+  it("sends permit_token, action_type, actor_id in the request body", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResp({ verified: true }));
+    await verifyOne(PARAMS);
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body as string) as Record<string, unknown>;
+    expect(body.permit_token).toBe("pt-abc");
     expect(body.action_type).toBe("production_deploy");
     expect(body.actor_id).toBe("github:alice");
   });
 
-  it("propagates risk_score (flat shape) from evaluate", async () => {
-    fetchMock
-      .mockResolvedValueOnce(jsonResp({ decision: "allow", permit_token: "t", risk_score: 0.85 }))
-      .mockResolvedValueOnce(jsonResp({ verified: true }));
-
-    const r = await runGate(PARAMS);
-    expect(r.riskScore).toBe("0.85");
+  it("sends Authorization header with the api key", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResp({ verified: true }));
+    await verifyOne(PARAMS);
+    const headers = fetchMock.mock.calls[0][1].headers as Record<string, string>;
+    expect(headers["Authorization"]).toBe("Bearer ask_test_key");
   });
 
-  it("propagates risk.score (canonical shape) from evaluate", async () => {
-    fetchMock
-      .mockResolvedValueOnce(
-        jsonResp({ decision: "allow", permit_token: "t", risk: { level: "high", score: 0.9 } }),
-      )
-      .mockResolvedValueOnce(jsonResp({ verified: true }));
+  // ── Infrastructure errors ───────────────────────────────────────────────────
 
-    const r = await runGate(PARAMS);
-    expect(r.riskScore).toBe("0.9");
-  });
-
-  // ── Replay / expired permit ─────────────────────────────────────────────────
-
-  it("allow + verify.verified=false (replay) → ok=false, verified=false", async () => {
-    fetchMock
-      .mockResolvedValueOnce(jsonResp({ decision: "allow", permit_token: "tok1" }))
-      .mockResolvedValueOnce(jsonResp({ verified: false, outcome: "permit_consumed" }));
-
-    const r = await runGate(PARAMS);
-
-    expect(r.ok).toBe(false);
-    expect(r.verified).toBe(false);
-    expect(r.decision).toBe("allow");
-    if (!r.ok) {
-      expect(r.verifyOutcome).toBe("permit_consumed");
-      expect(r.reason).toMatch(/permit verification failed/);
-    }
-  });
-
-  it("allow + verify.verified=false (expired) → ok=false, verified=false", async () => {
-    fetchMock
-      .mockResolvedValueOnce(jsonResp({ decision: "allow", permit_token: "tok1" }))
-      .mockResolvedValueOnce(jsonResp({ verified: false, outcome: "permit_expired" }));
-
-    const r = await runGate(PARAMS);
-    expect(r.ok).toBe(false);
-    if (!r.ok) expect(r.verifyOutcome).toBe("permit_expired");
-  });
-
-  // ── No permit_token on allow ────────────────────────────────────────────────
-
-  it("allow + no permit_token → throws GateInfraError, no verify call", async () => {
-    fetchMock.mockResolvedValueOnce(jsonResp({ decision: "allow", evaluation_id: "ev1" }));
-
-    let caught: unknown;
-    await runGate(PARAMS).catch((e) => { caught = e; });
-    expect(caught).toBeInstanceOf(GateInfraError);
-    expect((caught as GateInfraError).message).toMatch(/no permit_token/);
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-  });
-
-  // ── Policy decisions (deny / hold / escalate) ───────────────────────────────
-
-  it("deny → ok=false, verified=false, reason=deny_reason, no verify call", async () => {
-    fetchMock.mockResolvedValueOnce(
-      jsonResp({ decision: "deny", deny_reason: "outside change window" }),
-    );
-
-    const r = await runGate(PARAMS);
-    expect(r.ok).toBe(false);
-    expect(r.verified).toBe(false);
-    expect(r.decision).toBe("deny");
-    if (!r.ok) expect(r.reason).toBe("outside change window");
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-  });
-
-  it("hold → ok=false, verified=false, no verify call", async () => {
-    fetchMock.mockResolvedValueOnce(
-      jsonResp({ decision: "hold", hold_reason: "awaiting approval" }),
-    );
-
-    const r = await runGate(PARAMS);
-    expect(r.ok).toBe(false);
-    expect(r.decision).toBe("hold");
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-  });
-
-  it("escalate → ok=false, verified=false, no verify call", async () => {
-    fetchMock.mockResolvedValueOnce(jsonResp({ decision: "escalate" }));
-
-    const r = await runGate(PARAMS);
-    expect(r.ok).toBe(false);
-    expect(r.decision).toBe("escalate");
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-  });
-
-  // ── Infrastructure errors (evaluate side) ──────────────────────────────────
-
-  it("evaluate transport error → throws GateInfraError", async () => {
+  it("throws GateInfraError on transport error", async () => {
     fetchMock.mockRejectedValueOnce(new Error("ECONNREFUSED"));
-
     let caught: unknown;
-    await runGate(PARAMS).catch((e) => { caught = e; });
-    expect(caught).toBeInstanceOf(GateInfraError);
-    expect((caught as GateInfraError).message).toMatch(/evaluate unreachable/);
-  });
-
-  it("evaluate 5xx → throws GateInfraError (fail-closed)", async () => {
-    fetchMock.mockResolvedValueOnce(jsonResp({ error: "internal" }, 500));
-
-    await expect(runGate(PARAMS)).rejects.toThrow(GateInfraError);
-  });
-
-  it("evaluate 401 → throws GateInfraError", async () => {
-    fetchMock.mockResolvedValueOnce(jsonResp({ error: "unauthorized" }, 401));
-
-    await expect(runGate(PARAMS)).rejects.toThrow(GateInfraError);
-  });
-
-  it("evaluate 403 → throws GateInfraError", async () => {
-    fetchMock.mockResolvedValueOnce(jsonResp({ error: "forbidden" }, 403));
-
-    await expect(runGate(PARAMS)).rejects.toThrow(GateInfraError);
-  });
-
-  it("evaluate 429 → throws GateInfraError", async () => {
-    fetchMock.mockResolvedValueOnce(jsonResp({ error: "rate limited" }, 429));
-
-    await expect(runGate(PARAMS)).rejects.toThrow(GateInfraError);
-  });
-
-  // ── Infrastructure errors (verify side) ────────────────────────────────────
-
-  it("allow + verify transport error → throws GateInfraError", async () => {
-    fetchMock
-      .mockResolvedValueOnce(jsonResp({ decision: "allow", permit_token: "tok1" }))
-      .mockRejectedValueOnce(new Error("ETIMEDOUT"));
-
-    let caught: unknown;
-    await runGate(PARAMS).catch((e) => { caught = e; });
+    await verifyOne(PARAMS).catch((e) => { caught = e; });
     expect(caught).toBeInstanceOf(GateInfraError);
     expect((caught as GateInfraError).message).toMatch(/verify-permit unreachable/);
   });
 
-  it("allow + verify 5xx → throws GateInfraError", async () => {
-    fetchMock
-      .mockResolvedValueOnce(jsonResp({ decision: "allow", permit_token: "tok1" }))
-      .mockResolvedValueOnce(jsonResp({ error: "internal" }, 500));
-
-    await expect(runGate(PARAMS)).rejects.toThrow(GateInfraError);
+  it("throws GateInfraError on 5xx", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResp({ error: "internal" }, 500));
+    let caught: unknown;
+    await verifyOne(PARAMS).catch((e) => { caught = e; });
+    expect(caught).toBeInstanceOf(GateInfraError);
+    expect((caught as GateInfraError).statusCode).toBe(500);
   });
 
-  it("allow + verify 4xx → throws GateInfraError", async () => {
-    fetchMock
-      .mockResolvedValueOnce(jsonResp({ decision: "allow", permit_token: "tok1" }))
-      .mockResolvedValueOnce(jsonResp({ error: "bad request" }, 400));
-
-    await expect(runGate(PARAMS)).rejects.toThrow(GateInfraError);
+  it("throws GateInfraError on non-JSON body", async () => {
+    fetchMock.mockResolvedValueOnce(new Response("not-json", { status: 200 }));
+    await expect(verifyOne(PARAMS)).rejects.toThrow(GateInfraError);
   });
 });

--- a/src/__tests__/gate.test.ts
+++ b/src/__tests__/gate.test.ts
@@ -140,9 +140,10 @@ describe("runGate SIM tests", () => {
   it("allow + no permit_token → throws GateInfraError, no verify call", async () => {
     fetchMock.mockResolvedValueOnce(jsonResp({ decision: "allow", evaluation_id: "ev1" }));
 
-    const err = await runGate(PARAMS).catch((e) => e as GateInfraError);
-    expect(err).toBeInstanceOf(GateInfraError);
-    expect(err.message).toMatch(/no permit_token/);
+    let caught: unknown;
+    await runGate(PARAMS).catch((e) => { caught = e; });
+    expect(caught).toBeInstanceOf(GateInfraError);
+    expect((caught as GateInfraError).message).toMatch(/no permit_token/);
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
@@ -186,9 +187,10 @@ describe("runGate SIM tests", () => {
   it("evaluate transport error → throws GateInfraError", async () => {
     fetchMock.mockRejectedValueOnce(new Error("ECONNREFUSED"));
 
-    const err = await runGate(PARAMS).catch((e) => e as GateInfraError);
-    expect(err).toBeInstanceOf(GateInfraError);
-    expect(err.message).toMatch(/evaluate unreachable/);
+    let caught: unknown;
+    await runGate(PARAMS).catch((e) => { caught = e; });
+    expect(caught).toBeInstanceOf(GateInfraError);
+    expect((caught as GateInfraError).message).toMatch(/evaluate unreachable/);
   });
 
   it("evaluate 5xx → throws GateInfraError (fail-closed)", async () => {
@@ -222,9 +224,10 @@ describe("runGate SIM tests", () => {
       .mockResolvedValueOnce(jsonResp({ decision: "allow", permit_token: "tok1" }))
       .mockRejectedValueOnce(new Error("ETIMEDOUT"));
 
-    const err = await runGate(PARAMS).catch((e) => e as GateInfraError);
-    expect(err).toBeInstanceOf(GateInfraError);
-    expect(err.message).toMatch(/verify-permit unreachable/);
+    let caught: unknown;
+    await runGate(PARAMS).catch((e) => { caught = e; });
+    expect(caught).toBeInstanceOf(GateInfraError);
+    expect((caught as GateInfraError).message).toMatch(/verify-permit unreachable/);
   });
 
   it("allow + verify 5xx → throws GateInfraError", async () => {

--- a/src/__tests__/inputs.test.ts
+++ b/src/__tests__/inputs.test.ts
@@ -46,6 +46,25 @@ describe("parseInputs", () => {
     ).toThrow(/non-empty/);
   });
 
+  it("throws a clear error on invalid JSON in evaluations", () => {
+    expect(() =>
+      parseInputs({
+        "INPUT_API-KEY": "ask_test",
+        INPUT_EVALUATIONS: "not-json",
+      }),
+    ).toThrow(/not valid JSON/);
+  });
+
+  it("throws a clear error on invalid JSON in context", () => {
+    expect(() =>
+      parseInputs({
+        "INPUT_API-KEY": "ask_test",
+        INPUT_ACTION: "deploy",
+        INPUT_CONTEXT: "{bad json}",
+      }),
+    ).toThrow(/not valid JSON/);
+  });
+
   it("throws when neither single nor list is set", () => {
     expect(() => parseInputs({ "INPUT_API-KEY": "ask_test" })).toThrow(
       /Missing required input: action/,

--- a/src/__tests__/stream.test.ts
+++ b/src/__tests__/stream.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { waitForTerminalDecision } from "../stream";
+
+// SIM tests for waitForTerminalDecision() — the wait-for-id helper that
+// blocks on hold/escalate decisions until an upstream approver resolves them.
+// Tests cover both the polling path (v2Streaming=false) and the SSE path
+// (v2Streaming=true).
+
+describe("waitForTerminalDecision", () => {
+  const fetchMock = vi.fn();
+
+  const BASE_OPTS = {
+    apiUrl: "https://api.test",
+    apiKey: "ask_test_key",
+    evaluationId: "ev-123",
+    timeoutMs: 30_000,
+    v2Streaming: false,
+  };
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal("fetch", fetchMock);
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  function pollResp(decision: string) {
+    return new Response(
+      JSON.stringify({ decision, evaluatedAt: "2026-04-30T00:00:00Z" }),
+      { status: 200 },
+    );
+  }
+
+  function sseStream(...events: object[]): ReadableStream {
+    const encoder = new TextEncoder();
+    return new ReadableStream({
+      start(controller) {
+        for (const ev of events) {
+          controller.enqueue(encoder.encode(`data: ${JSON.stringify(ev)}\n\n`));
+        }
+        controller.close();
+      },
+    });
+  }
+
+  // ── Polling path ─────────────────────────────────────────────────────────────
+
+  it("polling: returns allow immediately when first response is terminal", async () => {
+    fetchMock.mockResolvedValueOnce(pollResp("allow"));
+    const result = await waitForTerminalDecision(BASE_OPTS);
+    expect(result.decision).toBe("allow");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.test/v1/evaluate/ev-123",
+      expect.objectContaining({
+        headers: expect.objectContaining({ authorization: "Bearer ask_test_key" }),
+      }),
+    );
+  });
+
+  it("polling: returns deny immediately when first response is terminal", async () => {
+    fetchMock.mockResolvedValueOnce(pollResp("deny"));
+    const result = await waitForTerminalDecision(BASE_OPTS);
+    expect(result.decision).toBe("deny");
+  });
+
+  it("polling: waits through non-terminal hold, retries after interval, returns allow", async () => {
+    let callCount = 0;
+    fetchMock.mockImplementation(() => {
+      callCount++;
+      return Promise.resolve(pollResp(callCount === 1 ? "hold" : "allow"));
+    });
+
+    const p = waitForTerminalDecision(BASE_OPTS);
+    await vi.advanceTimersByTimeAsync(5_000);
+    const result = await p;
+
+    expect(result.decision).toBe("allow");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("polling: throws after timeout without a terminal decision", async () => {
+    fetchMock.mockImplementation(() => Promise.resolve(pollResp("hold")));
+
+    const p = waitForTerminalDecision({ ...BASE_OPTS, timeoutMs: 4_999 });
+    // Attach rejection handler before advancing time so the rejection is not
+    // briefly unhandled when the fake timer fires.
+    const check = expect(p).rejects.toThrow(/poll timeout/);
+    await vi.advanceTimersByTimeAsync(5_000);
+    await check;
+  });
+
+  // ── SSE streaming path ────────────────────────────────────────────────────────
+
+  it("stream: returns allow from first SSE event", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        sseStream({ decision: "allow", evaluatedAt: "2026-04-30T00:00:00Z" }),
+        { status: 200 },
+      ),
+    );
+
+    const result = await waitForTerminalDecision({ ...BASE_OPTS, v2Streaming: true });
+
+    expect(result.decision).toBe("allow");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.test/v1/evaluate/stream",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("stream: skips non-terminal event and returns the next terminal event", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        sseStream(
+          { decision: "hold", evaluatedAt: "2026-04-30T00:00:00Z" },
+          { decision: "deny", evaluatedAt: "2026-04-30T00:00:01Z" },
+        ),
+        { status: 200 },
+      ),
+    );
+
+    const result = await waitForTerminalDecision({ ...BASE_OPTS, v2Streaming: true });
+
+    expect(result.decision).toBe("deny");
+  });
+
+  it("stream: sends evaluationId in POST body", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        sseStream({ decision: "allow", evaluatedAt: "2026-04-30T00:00:00Z" }),
+        { status: 200 },
+      ),
+    );
+    await waitForTerminalDecision({ ...BASE_OPTS, v2Streaming: true });
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body as string) as Record<string, unknown>;
+    expect(body.evaluationId).toBe("ev-123");
+  });
+
+  it("stream: throws on non-2xx response", async () => {
+    fetchMock.mockResolvedValueOnce(new Response("error", { status: 500 }));
+
+    await expect(
+      waitForTerminalDecision({ ...BASE_OPTS, v2Streaming: true }),
+    ).rejects.toThrow(/500/);
+  });
+});

--- a/src/__tests__/stream.test.ts
+++ b/src/__tests__/stream.test.ts
@@ -82,6 +82,22 @@ describe("waitForTerminalDecision", () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
+  it("polling: retries after transient network error instead of throwing immediately", async () => {
+    let callCount = 0;
+    fetchMock.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) return Promise.reject(new Error("ECONNREFUSED"));
+      return Promise.resolve(pollResp("allow"));
+    });
+
+    const p = waitForTerminalDecision(BASE_OPTS);
+    await vi.advanceTimersByTimeAsync(5_000);
+    const result = await p;
+
+    expect(result.decision).toBe("allow");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
   it("polling: throws after timeout without a terminal decision", async () => {
     fetchMock.mockImplementation(() => Promise.resolve(pollResp("hold")));
 

--- a/src/__tests__/v21.test.ts
+++ b/src/__tests__/v21.test.ts
@@ -93,8 +93,29 @@ it("failed=true when any decision is deny and failOnDeny=true", async () => {
   expect(out.failed).toBe(true);
 });
 
-it("failed=false when deny but failOnDeny=false", async () => {
-  mockEvaluateMany.mockResolvedValueOnce({ decisions: [decision("deny")], batchId: "b1" });
+it("failed=true when any decision is hold and failOnDeny=true", async () => {
+  mockEvaluateMany.mockResolvedValueOnce({
+    decisions: [decision("allow"), decision("hold", "ev-2")],
+    batchId: "b1",
+  });
+  const out = await runV21(BASE_ENV, FLAGS);
+  expect(out.failed).toBe(true);
+});
+
+it("failed=true when any decision is escalate and failOnDeny=true", async () => {
+  mockEvaluateMany.mockResolvedValueOnce({
+    decisions: [decision("allow"), decision("escalate", "ev-2")],
+    batchId: "b1",
+  });
+  const out = await runV21(BASE_ENV, FLAGS);
+  expect(out.failed).toBe(true);
+});
+
+it("failed=false when non-allow but failOnDeny=false", async () => {
+  mockEvaluateMany.mockResolvedValueOnce({
+    decisions: [decision("deny"), decision("hold", "ev-2"), decision("escalate", "ev-3")],
+    batchId: "b1",
+  });
   const out = await runV21({ ...BASE_ENV, "INPUT_FAIL-ON-DENY": "false" }, FLAGS);
   expect(out.failed).toBe(false);
 });

--- a/src/__tests__/v21.test.ts
+++ b/src/__tests__/v21.test.ts
@@ -5,12 +5,15 @@ import { runV21 } from "../v21";
 // parseInputs + evaluateMany + (optional) waitForTerminalDecision.
 
 vi.mock("../batch", () => ({ evaluateMany: vi.fn() }));
+vi.mock("../gate", () => ({ verifyOne: vi.fn() }));
 vi.mock("../stream", () => ({ waitForTerminalDecision: vi.fn() }));
 
 import { evaluateMany } from "../batch";
+import { verifyOne } from "../gate";
 import { waitForTerminalDecision } from "../stream";
 
 const mockEvaluateMany = evaluateMany as ReturnType<typeof vi.fn>;
+const mockVerifyOne = verifyOne as ReturnType<typeof vi.fn>;
 const mockWait = waitForTerminalDecision as ReturnType<typeof vi.fn>;
 
 // Minimal env that drives the batch path (evaluations set).
@@ -34,6 +37,7 @@ function decision(
 
 beforeEach(() => {
   mockEvaluateMany.mockReset();
+  mockVerifyOne.mockReset();
   mockWait.mockReset();
 });
 
@@ -102,6 +106,7 @@ it("calls waitForTerminalDecision when waitForId matches a hold decision", async
   const terminal = decision("allow", "ev-hold", "pt-1");
   mockEvaluateMany.mockResolvedValueOnce({ decisions: [hold], batchId: "b1" });
   mockWait.mockResolvedValueOnce(terminal);
+  mockVerifyOne.mockResolvedValueOnce({ verified: true, outcome: "ok" });
 
   const out = await runV21({ ...BASE_ENV, "INPUT_WAIT-FOR-ID": "ev-hold" }, FLAGS);
 
@@ -109,7 +114,40 @@ it("calls waitForTerminalDecision when waitForId matches a hold decision", async
   expect(mockWait).toHaveBeenCalledWith(
     expect.objectContaining({ evaluationId: "ev-hold", apiKey: "ask_test_key" }),
   );
+  expect(mockVerifyOne).toHaveBeenCalledOnce();
   expect(out.decisions[0].decision).toBe("allow");
+  expect(out.decisions[0].verified).toBe(true);
+});
+
+it("verifies terminal allow from wait-for-id with correct permit params", async () => {
+  const hold = decision("hold", "ev-hold");
+  const terminal = { ...decision("allow", "ev-hold", "pt-xyz"), verified: undefined };
+  mockEvaluateMany.mockResolvedValueOnce({ decisions: [hold], batchId: "b1" });
+  mockWait.mockResolvedValueOnce(terminal);
+  mockVerifyOne.mockResolvedValueOnce({ verified: true, outcome: "ok" });
+
+  await runV21({ ...BASE_ENV, "INPUT_WAIT-FOR-ID": "ev-hold" }, FLAGS);
+
+  expect(mockVerifyOne).toHaveBeenCalledWith(
+    expect.objectContaining({
+      permitToken: "pt-xyz",
+      actionType: "deploy.prod",
+      actorId: "alice",
+      verifyPath: "/v1/verify-permit",
+    }),
+  );
+});
+
+it("sets verified=false when terminal allow has no permitToken", async () => {
+  const hold = decision("hold", "ev-hold");
+  const terminalNoPermit = { id: "ev-hold", decision: "allow" as const, evaluatedAt: "2026-04-30T00:00:00Z" };
+  mockEvaluateMany.mockResolvedValueOnce({ decisions: [hold], batchId: "b1" });
+  mockWait.mockResolvedValueOnce(terminalNoPermit);
+
+  const out = await runV21({ ...BASE_ENV, "INPUT_WAIT-FOR-ID": "ev-hold" }, FLAGS);
+
+  expect(mockVerifyOne).not.toHaveBeenCalled();
+  expect(out.decisions[0].verified).toBe(false);
 });
 
 it("calls waitForTerminalDecision when waitForId matches an escalate decision", async () => {

--- a/src/__tests__/v21.test.ts
+++ b/src/__tests__/v21.test.ts
@@ -1,0 +1,141 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { runV21 } from "../v21";
+
+// SIM tests for runV21() — the orchestration layer that wires together
+// parseInputs + evaluateMany + (optional) waitForTerminalDecision.
+
+vi.mock("../batch", () => ({ evaluateMany: vi.fn() }));
+vi.mock("../stream", () => ({ waitForTerminalDecision: vi.fn() }));
+
+import { evaluateMany } from "../batch";
+import { waitForTerminalDecision } from "../stream";
+
+const mockEvaluateMany = evaluateMany as ReturnType<typeof vi.fn>;
+const mockWait = waitForTerminalDecision as ReturnType<typeof vi.fn>;
+
+// Minimal env that drives the batch path (evaluations set).
+const BASE_ENV = {
+  "INPUT_API-KEY": "ask_test_key",
+  "INPUT_API-URL": "https://api.test",
+  "INPUT_FAIL-ON-DENY": "true",
+  INPUT_EVALUATIONS: JSON.stringify([{ action: "deploy.prod", actor: "alice" }]),
+  "INPUT_WAIT-TIMEOUT-MS": "30000",
+};
+
+const FLAGS = { v2Batch: false, v2Streaming: false };
+
+function decision(
+  d: "allow" | "deny" | "hold" | "escalate",
+  id = "ev-1",
+  permitToken?: string,
+) {
+  return { id, decision: d, evaluatedAt: "2026-04-30T00:00:00Z", permitToken, verified: d === "allow" || undefined };
+}
+
+beforeEach(() => {
+  mockEvaluateMany.mockReset();
+  mockWait.mockReset();
+});
+
+afterEach(() => { vi.restoreAllMocks(); });
+
+// ── Basic routing ─────────────────────────────────────────────────────────────
+
+it("passes items and flags through to evaluateMany", async () => {
+  mockEvaluateMany.mockResolvedValueOnce({ decisions: [decision("allow")], batchId: "b1" });
+  await runV21(BASE_ENV, { v2Batch: true, v2Streaming: false });
+  expect(mockEvaluateMany).toHaveBeenCalledWith(
+    "https://api.test",
+    "ask_test_key",
+    [{ action: "deploy.prod", actor: "alice" }],
+    true,
+  );
+});
+
+it("wraps single action/actor into a 1-item batch", async () => {
+  mockEvaluateMany.mockResolvedValueOnce({ decisions: [decision("allow")], batchId: "b1" });
+  await runV21(
+    { "INPUT_API-KEY": "ask_test_key", INPUT_ACTION: "deploy.staging", INPUT_ACTOR: "bob" },
+    FLAGS,
+  );
+  expect(mockEvaluateMany).toHaveBeenCalledWith(
+    "https://api.atlasent.io",
+    "ask_test_key",
+    [expect.objectContaining({ action: "deploy.staging", actor: "bob" })],
+    false,
+  );
+});
+
+it("returns batchId from evaluateMany", async () => {
+  mockEvaluateMany.mockResolvedValueOnce({ decisions: [decision("allow")], batchId: "server-batch-99" });
+  const out = await runV21(BASE_ENV, FLAGS);
+  expect(out.batchId).toBe("server-batch-99");
+});
+
+// ── failed flag ───────────────────────────────────────────────────────────────
+
+it("failed=false when all decisions are allow", async () => {
+  mockEvaluateMany.mockResolvedValueOnce({ decisions: [decision("allow")], batchId: "b1" });
+  const out = await runV21(BASE_ENV, FLAGS);
+  expect(out.failed).toBe(false);
+});
+
+it("failed=true when any decision is deny and failOnDeny=true", async () => {
+  mockEvaluateMany.mockResolvedValueOnce({
+    decisions: [decision("allow"), decision("deny", "ev-2")],
+    batchId: "b1",
+  });
+  const out = await runV21(BASE_ENV, FLAGS);
+  expect(out.failed).toBe(true);
+});
+
+it("failed=false when deny but failOnDeny=false", async () => {
+  mockEvaluateMany.mockResolvedValueOnce({ decisions: [decision("deny")], batchId: "b1" });
+  const out = await runV21({ ...BASE_ENV, "INPUT_FAIL-ON-DENY": "false" }, FLAGS);
+  expect(out.failed).toBe(false);
+});
+
+// ── wait-for-id path ──────────────────────────────────────────────────────────
+
+it("calls waitForTerminalDecision when waitForId matches a hold decision", async () => {
+  const hold = decision("hold", "ev-hold");
+  const terminal = decision("allow", "ev-hold", "pt-1");
+  mockEvaluateMany.mockResolvedValueOnce({ decisions: [hold], batchId: "b1" });
+  mockWait.mockResolvedValueOnce(terminal);
+
+  const out = await runV21({ ...BASE_ENV, "INPUT_WAIT-FOR-ID": "ev-hold" }, FLAGS);
+
+  expect(mockWait).toHaveBeenCalledOnce();
+  expect(mockWait).toHaveBeenCalledWith(
+    expect.objectContaining({ evaluationId: "ev-hold", apiKey: "ask_test_key" }),
+  );
+  expect(out.decisions[0].decision).toBe("allow");
+});
+
+it("calls waitForTerminalDecision when waitForId matches an escalate decision", async () => {
+  const escalate = decision("escalate", "ev-esc");
+  const terminal = decision("deny", "ev-esc");
+  mockEvaluateMany.mockResolvedValueOnce({ decisions: [escalate], batchId: "b1" });
+  mockWait.mockResolvedValueOnce(terminal);
+
+  const out = await runV21({ ...BASE_ENV, "INPUT_WAIT-FOR-ID": "ev-esc" }, FLAGS);
+
+  expect(mockWait).toHaveBeenCalledOnce();
+  expect(out.decisions[0].decision).toBe("deny");
+});
+
+it("skips wait when waitForId does not match any hold/escalate decision", async () => {
+  mockEvaluateMany.mockResolvedValueOnce({ decisions: [decision("allow", "ev-other")], batchId: "b1" });
+
+  await runV21({ ...BASE_ENV, "INPUT_WAIT-FOR-ID": "ev-not-found" }, FLAGS);
+
+  expect(mockWait).not.toHaveBeenCalled();
+});
+
+it("skips wait when no waitForId is set", async () => {
+  mockEvaluateMany.mockResolvedValueOnce({ decisions: [decision("hold")], batchId: "b1" });
+
+  await runV21(BASE_ENV, FLAGS);
+
+  expect(mockWait).not.toHaveBeenCalled();
+});

--- a/src/batch.ts
+++ b/src/batch.ts
@@ -1,10 +1,11 @@
-// Wave B.AC2 — batch fan-out helper.
+// Wave B.AC2 / B.AC4 — batch fan-out helper with per-decision verify-permit.
 //
-// When the per-tenant `v2_batch` flag is on, posts a single batch to
+// When the per-tenant `v2Batch` flag is on, posts a single batch to
 // /v1/evaluate/batch. Otherwise, per-item /v1/evaluate loop. Either
-// path returns the same `BatchResult` shape so the action's render
-// step does not branch on transport.
+// path then runs verify-permit for every allow decision, matching the
+// single-eval runGate() contract — the gate is fail-closed end-to-end.
 
+import { verifyOne } from "./gate";
 import type { Decision, EvaluateRequest } from "./types";
 
 export interface BatchResult {
@@ -23,6 +24,10 @@ export async function evaluateMany(
     "content-type": "application/json",
     authorization: `Bearer ${apiKey}`,
   };
+
+  let decisions: Decision[];
+  let batchId: string;
+
   if (v2Batch) {
     const r = await fetch(`${apiUrl}/v1/evaluate/batch`, {
       method: "POST",
@@ -36,19 +41,44 @@ export async function evaluateMany(
       results: Decision[];
       batchId: string;
     };
-    return { decisions: data.results, batchId: data.batchId };
-  }
-  const decisions: Decision[] = [];
-  for (const item of items) {
-    const r = await fetch(`${apiUrl}/v1/evaluate`, {
-      method: "POST",
-      headers,
-      body: JSON.stringify(item),
-    });
-    if (!r.ok) {
-      throw new Error(`atlasent /v1/evaluate ${r.status}`);
+    decisions = data.results;
+    batchId = data.batchId;
+  } else {
+    decisions = [];
+    for (const item of items) {
+      const r = await fetch(`${apiUrl}/v1/evaluate`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(item),
+      });
+      if (!r.ok) {
+        throw new Error(`atlasent /v1/evaluate ${r.status}`);
+      }
+      decisions.push((await r.json()) as Decision);
     }
-    decisions.push((await r.json()) as Decision);
+    batchId = `loop-${Date.now()}`;
   }
-  return { decisions, batchId: `loop-${Date.now()}` };
+
+  // Verify permits for every allow decision.
+  // Uses the REST-style path (/v1/verify-permit) matching the v2 API convention.
+  // Fail-closed: if any verify throws, the error propagates up.
+  const verified = await Promise.all(
+    decisions.map(async (d, i) => {
+      if (d.decision !== "allow" || !d.permitToken) {
+        return { ...d, verified: d.decision === "allow" ? false : undefined };
+      }
+      const item = items[i];
+      const result = await verifyOne({
+        apiUrl,
+        apiKey,
+        actionType: item.action,
+        actorId: item.actor,
+        permitToken: d.permitToken,
+        verifyPath: "/v1/verify-permit",
+      });
+      return { ...d, verified: result.verified, verifyOutcome: result.outcome };
+    }),
+  );
+
+  return { decisions: verified, batchId };
 }

--- a/src/gate.ts
+++ b/src/gate.ts
@@ -1,0 +1,203 @@
+// Core evaluate → verify-permit gate logic.
+// Uses fetch (Node 20+ built-in) so unit tests can stub it without real HTTP.
+// src/index.ts delegates all HTTP to this module; GH Actions I/O stays there.
+
+export interface GateParams {
+  apiUrl: string;
+  apiKey: string;
+  actionType: string;
+  actorId: string;
+  /** Full evaluate payload (action_type, actor_id, context, …). */
+  payload: Record<string, unknown>;
+}
+
+// Discriminated union: ok=true → evaluate=allow AND verify=true.
+// ok=false → any non-allow decision OR verify=false (replay/expired).
+export type GateResult =
+  | {
+      ok: true;
+      decision: "allow";
+      verified: true;
+      permitToken: string;
+      evaluationId: string;
+      proofHash: string;
+      riskScore: string;
+      verifyOutcome: string;
+    }
+  | {
+      ok: false;
+      decision: string;
+      verified: false;
+      permitToken: string;
+      evaluationId: string;
+      proofHash: string;
+      riskScore: string;
+      /** Human-readable reason (deny_reason / hold_reason / verify outcome). */
+      reason: string;
+      verifyOutcome?: string;
+    };
+
+// Thrown for infrastructure failures (network, 5xx, 401, 429, no permit_token).
+// Distinct from a policy decision so callers can always fail-closed on these.
+export class GateInfraError extends Error {
+  constructor(
+    message: string,
+    public readonly statusCode?: number,
+  ) {
+    super(message);
+    this.name = "GateInfraError";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main gate function
+// ---------------------------------------------------------------------------
+
+export async function runGate(params: GateParams): Promise<GateResult> {
+  // Step 1 — call /v1-evaluate
+  let evalRes: Response;
+  try {
+    evalRes = await fetch(`${params.apiUrl}/v1-evaluate`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${params.apiKey}`,
+      },
+      body: JSON.stringify(params.payload),
+    });
+  } catch (err) {
+    throw new GateInfraError(
+      `evaluate unreachable: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  // Infrastructure errors are always fail-closed — do not confuse with policy.
+  if (evalRes.status >= 500) {
+    throw new GateInfraError(
+      `evaluate HTTP ${evalRes.status} — infrastructure failure, not a policy decision`,
+      evalRes.status,
+    );
+  }
+  if (evalRes.status === 401 || evalRes.status === 403) {
+    throw new GateInfraError(
+      `evaluate auth failed (HTTP ${evalRes.status}). Check ATLASENT_API_KEY scopes.`,
+      evalRes.status,
+    );
+  }
+  if (evalRes.status === 429) {
+    throw new GateInfraError(
+      `evaluate rate-limited (HTTP 429). Retry or raise rate_limit_per_minute.`,
+      429,
+    );
+  }
+  if (!evalRes.ok) {
+    throw new GateInfraError(`evaluate HTTP ${evalRes.status}`, evalRes.status);
+  }
+
+  let evalBody: Record<string, unknown>;
+  try {
+    evalBody = (await evalRes.json()) as Record<string, unknown>;
+  } catch {
+    throw new GateInfraError("failed to parse evaluate response as JSON");
+  }
+
+  const decision = (evalBody["decision"] as string | undefined) ?? "unknown";
+  const permitToken = (evalBody["permit_token"] as string | undefined) ?? "";
+  const evaluationId = (evalBody["evaluation_id"] as string | undefined) ?? "";
+  const proofHash = (evalBody["proof_hash"] as string | undefined) ?? "";
+  const riskScore = extractRiskScore(evalBody);
+
+  // Non-allow decisions → no verify needed, return immediately.
+  if (decision !== "allow") {
+    const reason =
+      (evalBody["deny_reason"] as string | undefined) ??
+      (evalBody["hold_reason"] as string | undefined) ??
+      "";
+    return { ok: false, decision, verified: false, permitToken, evaluationId, proofHash, riskScore, reason };
+  }
+
+  // Step 2 — verify-permit (fail-closed: must succeed for gate to open).
+  // Without this round-trip the gate is evaluate-only: a tampered or replayed
+  // permit_token would still surface decision=allow. This matches the SDK's
+  // withPermit (TS) / with_permit (Python) contract.
+  if (!permitToken) {
+    throw new GateInfraError(
+      `evaluate=allow but no permit_token — refusing to gate-open without a verifiable permit (evaluation: ${evaluationId})`,
+    );
+  }
+
+  let verifyRes: Response;
+  try {
+    verifyRes = await fetch(`${params.apiUrl}/v1-verify-permit`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${params.apiKey}`,
+      },
+      body: JSON.stringify({
+        permit_token: permitToken,
+        action_type: params.actionType,
+        actor_id: params.actorId,
+      }),
+    });
+  } catch (err) {
+    throw new GateInfraError(
+      `verify-permit unreachable: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  if (!verifyRes.ok) {
+    throw new GateInfraError(
+      `verify-permit HTTP ${verifyRes.status}`,
+      verifyRes.status,
+    );
+  }
+
+  let verifyBody: { verified?: boolean; outcome?: string };
+  try {
+    verifyBody = (await verifyRes.json()) as { verified?: boolean; outcome?: string };
+  } catch {
+    throw new GateInfraError("failed to parse verify-permit response as JSON");
+  }
+
+  if (verifyBody.verified !== true) {
+    // outcome=permit_consumed (replay), permit_expired, etc.
+    return {
+      ok: false,
+      decision: "allow",
+      verified: false,
+      permitToken,
+      evaluationId,
+      proofHash,
+      riskScore,
+      reason: `permit verification failed (outcome=${verifyBody.outcome ?? "unknown"})`,
+      verifyOutcome: verifyBody.outcome,
+    };
+  }
+
+  return {
+    ok: true,
+    decision: "allow",
+    verified: true,
+    permitToken,
+    evaluationId,
+    proofHash,
+    riskScore,
+    verifyOutcome: verifyBody.outcome ?? "verified",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function extractRiskScore(result: Record<string, unknown>): string {
+  const risk = result["risk"];
+  if (risk && typeof risk === "object" && "score" in risk) {
+    const score = (risk as { score?: unknown }).score;
+    if (typeof score === "number") return String(score);
+  }
+  const flat = result["risk_score"];
+  if (typeof flat === "number") return String(flat);
+  return "";
+}

--- a/src/gate.ts
+++ b/src/gate.ts
@@ -1,44 +1,31 @@
-// Core evaluate → verify-permit gate logic.
-// Uses fetch (Node 20+ built-in) so unit tests can stub it without real HTTP.
-// src/index.ts delegates all HTTP to this module; GH Actions I/O stays there.
+// verify-permit helper for the v2.1 batch path.
+//
+// The single-eval path (src/index.ts) uses @atlasent/enforce as the canonical
+// enforcement wrapper. This module only exports verifyOne(), which is called
+// per-decision after evaluateMany() in src/batch.ts.
 
-export interface GateParams {
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface VerifyParams {
   apiUrl: string;
   apiKey: string;
   actionType: string;
   actorId: string;
-  /** Full evaluate payload (action_type, actor_id, context, …). */
-  payload: Record<string, unknown>;
+  permitToken: string;
+  /** Override the verify endpoint path. Defaults to /v1-verify-permit
+   *  (Supabase style). Pass "/v1/verify-permit" for the REST API. */
+  verifyPath?: string;
 }
 
-// Discriminated union: ok=true → evaluate=allow AND verify=true.
-// ok=false → any non-allow decision OR verify=false (replay/expired).
-export type GateResult =
-  | {
-      ok: true;
-      decision: "allow";
-      verified: true;
-      permitToken: string;
-      evaluationId: string;
-      proofHash: string;
-      riskScore: string;
-      verifyOutcome: string;
-    }
-  | {
-      ok: false;
-      decision: string;
-      verified: false;
-      permitToken: string;
-      evaluationId: string;
-      proofHash: string;
-      riskScore: string;
-      /** Human-readable reason (deny_reason / hold_reason / verify outcome). */
-      reason: string;
-      verifyOutcome?: string;
-    };
+export interface VerifyResult {
+  verified: boolean;
+  outcome?: string;
+}
 
-// Thrown for infrastructure failures (network, 5xx, 401, 429, no permit_token).
-// Distinct from a policy decision so callers can always fail-closed on these.
+// Thrown for infrastructure failures (network, !2xx, non-JSON).
+// Distinct from a policy decision so callers always fail-closed on these.
 export class GateInfraError extends Error {
   constructor(
     message: string,
@@ -50,27 +37,12 @@ export class GateInfraError extends Error {
 }
 
 // ---------------------------------------------------------------------------
-// Standalone verify step (used by both runGate and the v2.1 batch path)
+// verifyOne — single verify-permit round-trip
 // ---------------------------------------------------------------------------
-
-export interface VerifyParams {
-  apiUrl: string;
-  apiKey: string;
-  actionType: string;
-  actorId: string;
-  permitToken: string;
-  /** Override the default verify endpoint path. Defaults to /v1-verify-permit
-   *  (Supabase style). Pass "/v1/verify-permit" for the conventional REST API. */
-  verifyPath?: string;
-}
-
-export interface VerifyResult {
-  verified: boolean;
-  outcome?: string;
-}
 
 export async function verifyOne(params: VerifyParams): Promise<VerifyResult> {
   const path = params.verifyPath ?? "/v1-verify-permit";
+
   let res: Response;
   try {
     res = await fetch(`${params.apiUrl}${path}`, {
@@ -103,131 +75,4 @@ export async function verifyOne(params: VerifyParams): Promise<VerifyResult> {
   }
 
   return { verified: body.verified === true, outcome: body.outcome };
-}
-
-// ---------------------------------------------------------------------------
-// Main gate function
-// ---------------------------------------------------------------------------
-
-export async function runGate(params: GateParams): Promise<GateResult> {
-  // Step 1 — call /v1-evaluate
-  let evalRes: Response;
-  try {
-    evalRes = await fetch(`${params.apiUrl}/v1-evaluate`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${params.apiKey}`,
-      },
-      body: JSON.stringify(params.payload),
-    });
-  } catch (err) {
-    throw new GateInfraError(
-      `evaluate unreachable: ${err instanceof Error ? err.message : String(err)}`,
-    );
-  }
-
-  // Infrastructure errors are always fail-closed — do not confuse with policy.
-  if (evalRes.status >= 500) {
-    throw new GateInfraError(
-      `evaluate HTTP ${evalRes.status} — infrastructure failure, not a policy decision`,
-      evalRes.status,
-    );
-  }
-  if (evalRes.status === 401 || evalRes.status === 403) {
-    throw new GateInfraError(
-      `evaluate auth failed (HTTP ${evalRes.status}). Check ATLASENT_API_KEY scopes.`,
-      evalRes.status,
-    );
-  }
-  if (evalRes.status === 429) {
-    throw new GateInfraError(
-      `evaluate rate-limited (HTTP 429). Retry or raise rate_limit_per_minute.`,
-      429,
-    );
-  }
-  if (!evalRes.ok) {
-    throw new GateInfraError(`evaluate HTTP ${evalRes.status}`, evalRes.status);
-  }
-
-  let evalBody: Record<string, unknown>;
-  try {
-    evalBody = (await evalRes.json()) as Record<string, unknown>;
-  } catch {
-    throw new GateInfraError("failed to parse evaluate response as JSON");
-  }
-
-  const decision = (evalBody["decision"] as string | undefined) ?? "unknown";
-  const permitToken = (evalBody["permit_token"] as string | undefined) ?? "";
-  const evaluationId = (evalBody["evaluation_id"] as string | undefined) ?? "";
-  const proofHash = (evalBody["proof_hash"] as string | undefined) ?? "";
-  const riskScore = extractRiskScore(evalBody);
-
-  // Non-allow decisions → no verify needed, return immediately.
-  if (decision !== "allow") {
-    const reason =
-      (evalBody["deny_reason"] as string | undefined) ??
-      (evalBody["hold_reason"] as string | undefined) ??
-      "";
-    return { ok: false, decision, verified: false, permitToken, evaluationId, proofHash, riskScore, reason };
-  }
-
-  // Step 2 — verify-permit (fail-closed: must succeed for gate to open).
-  // Without this round-trip the gate is evaluate-only: a tampered or replayed
-  // permit_token would still surface decision=allow. This matches the SDK's
-  // withPermit (TS) / with_permit (Python) contract.
-  if (!permitToken) {
-    throw new GateInfraError(
-      `evaluate=allow but no permit_token — refusing to gate-open without a verifiable permit (evaluation: ${evaluationId})`,
-    );
-  }
-
-  const verify = await verifyOne({
-    apiUrl: params.apiUrl,
-    apiKey: params.apiKey,
-    actionType: params.actionType,
-    actorId: params.actorId,
-    permitToken,
-  });
-
-  if (!verify.verified) {
-    // outcome=permit_consumed (replay), permit_expired, etc.
-    return {
-      ok: false,
-      decision: "allow",
-      verified: false,
-      permitToken,
-      evaluationId,
-      proofHash,
-      riskScore,
-      reason: `permit verification failed (outcome=${verify.outcome ?? "unknown"})`,
-      verifyOutcome: verify.outcome,
-    };
-  }
-
-  return {
-    ok: true,
-    decision: "allow",
-    verified: true,
-    permitToken,
-    evaluationId,
-    proofHash,
-    riskScore,
-    verifyOutcome: verify.outcome ?? "verified",
-  };
-}
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function extractRiskScore(result: Record<string, unknown>): string {
-  const risk = result["risk"];
-  if (risk && typeof risk === "object" && "score" in risk) {
-    const score = (risk as { score?: unknown }).score;
-    if (typeof score === "number") return String(score);
-  }
-  const flat = result["risk_score"];
-  if (typeof flat === "number") return String(flat);
-  return "";
 }

--- a/src/gate.ts
+++ b/src/gate.ts
@@ -50,6 +50,62 @@ export class GateInfraError extends Error {
 }
 
 // ---------------------------------------------------------------------------
+// Standalone verify step (used by both runGate and the v2.1 batch path)
+// ---------------------------------------------------------------------------
+
+export interface VerifyParams {
+  apiUrl: string;
+  apiKey: string;
+  actionType: string;
+  actorId: string;
+  permitToken: string;
+  /** Override the default verify endpoint path. Defaults to /v1-verify-permit
+   *  (Supabase style). Pass "/v1/verify-permit" for the conventional REST API. */
+  verifyPath?: string;
+}
+
+export interface VerifyResult {
+  verified: boolean;
+  outcome?: string;
+}
+
+export async function verifyOne(params: VerifyParams): Promise<VerifyResult> {
+  const path = params.verifyPath ?? "/v1-verify-permit";
+  let res: Response;
+  try {
+    res = await fetch(`${params.apiUrl}${path}`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${params.apiKey}`,
+      },
+      body: JSON.stringify({
+        permit_token: params.permitToken,
+        action_type: params.actionType,
+        actor_id: params.actorId,
+      }),
+    });
+  } catch (err) {
+    throw new GateInfraError(
+      `verify-permit unreachable: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  if (!res.ok) {
+    throw new GateInfraError(`verify-permit HTTP ${res.status}`, res.status);
+  }
+
+  let body: { verified?: boolean; outcome?: string };
+  try {
+    body = (await res.json()) as { verified?: boolean; outcome?: string };
+  } catch {
+    throw new GateInfraError("failed to parse verify-permit response as JSON");
+  }
+
+  return { verified: body.verified === true, outcome: body.outcome };
+}
+
+// ---------------------------------------------------------------------------
 // Main gate function
 // ---------------------------------------------------------------------------
 
@@ -126,41 +182,15 @@ export async function runGate(params: GateParams): Promise<GateResult> {
     );
   }
 
-  let verifyRes: Response;
-  try {
-    verifyRes = await fetch(`${params.apiUrl}/v1-verify-permit`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${params.apiKey}`,
-      },
-      body: JSON.stringify({
-        permit_token: permitToken,
-        action_type: params.actionType,
-        actor_id: params.actorId,
-      }),
-    });
-  } catch (err) {
-    throw new GateInfraError(
-      `verify-permit unreachable: ${err instanceof Error ? err.message : String(err)}`,
-    );
-  }
+  const verify = await verifyOne({
+    apiUrl: params.apiUrl,
+    apiKey: params.apiKey,
+    actionType: params.actionType,
+    actorId: params.actorId,
+    permitToken,
+  });
 
-  if (!verifyRes.ok) {
-    throw new GateInfraError(
-      `verify-permit HTTP ${verifyRes.status}`,
-      verifyRes.status,
-    );
-  }
-
-  let verifyBody: { verified?: boolean; outcome?: string };
-  try {
-    verifyBody = (await verifyRes.json()) as { verified?: boolean; outcome?: string };
-  } catch {
-    throw new GateInfraError("failed to parse verify-permit response as JSON");
-  }
-
-  if (verifyBody.verified !== true) {
+  if (!verify.verified) {
     // outcome=permit_consumed (replay), permit_expired, etc.
     return {
       ok: false,
@@ -170,8 +200,8 @@ export async function runGate(params: GateParams): Promise<GateResult> {
       evaluationId,
       proofHash,
       riskScore,
-      reason: `permit verification failed (outcome=${verifyBody.outcome ?? "unknown"})`,
-      verifyOutcome: verifyBody.outcome,
+      reason: `permit verification failed (outcome=${verify.outcome ?? "unknown"})`,
+      verifyOutcome: verify.outcome,
     };
   }
 
@@ -183,7 +213,7 @@ export async function runGate(params: GateParams): Promise<GateResult> {
     evaluationId,
     proofHash,
     riskScore,
-    verifyOutcome: verifyBody.outcome ?? "verified",
+    verifyOutcome: verify.outcome ?? "verified",
   };
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,13 @@
 // AtlaSent Gate Action — GitHub Actions entry point.
-// HTTP logic lives in src/gate.ts (evaluate → v1-verify-permit, fail-closed).
-// This file handles GH Actions I/O: reading inputs, masking secrets, and
-// translating GateResult / GateInfraError into step outputs and exit codes.
+//
+// Routing:
+//   evaluations input set → v2.1 batch path via runV21()
+//   single action input   → v1 single path via runGate()
+//
+// Both paths call verify-permit for every allow decision (fail-closed).
 
 import { GateInfraError, runGate } from "./gate";
+import { runV21 } from "./v21";
 
 // ---------------------------------------------------------------------------
 // GitHub Actions helpers
@@ -89,21 +93,93 @@ function resolveEnvironment(explicit: string, ref: string, apiKey: string): stri
 async function run(): Promise<void> {
   // 1. Read inputs
   const apiKey = getInput("api-key", true);
+  const apiUrl =
+    getInput("api-url") || "https://ihghhasvxtltlbizvkqy.supabase.co/functions/v1";
+  const failOnDeny = getInput("fail-on-deny") !== "false";
+
+  maskValue(apiKey);
+
+  // ── v2.1 batch path ────────────────────────────────────────────────────────
+  // When the `evaluations` input is set, fan out via runV21 (batch or loop).
+  // Each allow decision is automatically verified via verifyOne() in batch.ts.
+  const evaluationsRaw = getInput("evaluations");
+  if (evaluationsRaw) {
+    const waitForId = getInput("wait-for-id") || undefined;
+    const waitTimeoutMs = parseInt(getInput("wait-timeout-ms") || "600000", 10);
+    const v2Batch = getInput("v2-batch") === "true";
+    const v2Streaming = getInput("v2-streaming") === "true";
+
+    let result;
+    try {
+      result = await runV21(
+        {
+          "INPUT_API-KEY": apiKey,
+          "INPUT_API-URL": apiUrl,
+          "INPUT_FAIL-ON-DENY": failOnDeny ? "true" : "false",
+          INPUT_EVALUATIONS: evaluationsRaw,
+          "INPUT_WAIT-FOR-ID": waitForId,
+          "INPUT_WAIT-TIMEOUT-MS": String(waitTimeoutMs),
+        },
+        { v2Batch, v2Streaming },
+      );
+    } catch (err) {
+      const msg =
+        err instanceof GateInfraError
+          ? err.message
+          : `Unexpected error: ${err instanceof Error ? err.message : String(err)}`;
+      setOutput("verified", "false");
+      setFailed(`AtlaSent Gate (batch): ${msg}. Deploy blocked (fail-closed).`);
+      return;
+    }
+
+    const decisionsJson = JSON.stringify(
+      result.decisions.map((d) => ({
+        decision: d.decision,
+        verified: d.verified ?? false,
+        evaluationId: d.id ?? "",
+        permitToken: d.permitToken ? "(masked)" : "",
+        reasons: d.reasons ?? [],
+        verifyOutcome: d.verifyOutcome ?? "",
+      })),
+    );
+
+    const allVerified = result.decisions.every(
+      (d) => d.decision !== "allow" || d.verified === true,
+    );
+
+    setOutput("batch-id", result.batchId);
+    setOutput("decisions", decisionsJson);
+    setOutput("verified", allVerified ? "true" : "false");
+
+    if (result.failed) {
+      setFailed(
+        `AtlaSent Gate: one or more evaluations denied. See 'decisions' output for details.`,
+      );
+      return;
+    }
+    if (!allVerified) {
+      setFailed(
+        `AtlaSent Gate: one or more allow decisions failed permit verification. Deploy blocked.`,
+      );
+      return;
+    }
+
+    info(`AtlaSent Gate: all ${result.decisions.length} evaluation(s) allowed and verified`);
+    info(`  Batch ID: ${result.batchId}`);
+    return;
+  }
+
+  // ── v1 single-eval path ────────────────────────────────────────────────────
   const actionType = getInput("action", true);
   const actor = getInput("actor") || "unknown";
   const targetId = getInput("target-id");
   const explicitEnv = getInput("environment");
-  const apiUrl =
-    getInput("api-url") || "https://ihghhasvxtltlbizvkqy.supabase.co/functions/v1";
-  const failOnDeny = getInput("fail-on-deny") !== "false";
   let extraContext: Record<string, unknown> = {};
   try {
     extraContext = JSON.parse(getInput("context") || "{}");
   } catch {
     warning("Could not parse 'context' input as JSON — ignoring");
   }
-
-  maskValue(apiKey);
 
   // 2. Build evaluate payload
   const gh = getGitHubContext();

--- a/src/index.ts
+++ b/src/index.ts
@@ -145,6 +145,8 @@ async function run(): Promise<void> {
           ? err.message
           : `Unexpected error: ${err instanceof Error ? err.message : String(err)}`;
       setOutput("verified", "false");
+      setOutput("decisions", "[]");
+      setOutput("batch-id", "");
       setFailed(`AtlaSent Gate (batch): ${msg}. Deploy blocked (fail-closed).`);
       return;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,11 +2,15 @@
 //
 // Routing:
 //   evaluations input set → v2.1 batch path via runV21()
-//   single action input   → v1 single path via runGate()
+//   single action input   → @atlasent/enforce (canonical enforcement wrapper)
 //
-// Both paths call verify-permit for every allow decision (fail-closed).
+// The enforcement contract (evaluate → verify → verifyPermit) lives entirely
+// in @atlasent/enforce. This file handles GH Actions I/O: reading inputs,
+// masking secrets, and translating EnforceResult / EnforceError into step
+// outputs and exit codes.
 
-import { GateInfraError, runGate } from "./gate";
+import { enforce, EnforceError } from "@atlasent/enforce";
+import type { Decision, EnforceConfig } from "@atlasent/enforce";
 import { runV21 } from "./v21";
 
 // ---------------------------------------------------------------------------
@@ -87,21 +91,33 @@ function resolveEnvironment(explicit: string, ref: string, apiKey: string): stri
 }
 
 // ---------------------------------------------------------------------------
+// Output helpers — translate a Decision object into GH Actions outputs.
+// Must be called BEFORE setFailed/warning so outputs are visible on failure.
+// ---------------------------------------------------------------------------
+
+function setDecisionOutputs(d: Decision): void {
+  if (d.permitToken) maskValue(d.permitToken);
+  if (d.proofHash) maskValue(d.proofHash);
+  setOutput("decision", d.decision);
+  setOutput("permit-token", d.permitToken ?? "");
+  setOutput("evaluation-id", d.evaluationId ?? "");
+  setOutput("proof-hash", d.proofHash ?? "");
+  setOutput("risk-score", d.riskScore !== undefined ? String(d.riskScore) : "");
+}
+
+// ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
 
 async function run(): Promise<void> {
-  // 1. Read inputs
+  // 1. Read shared inputs
   const apiKey = getInput("api-key", true);
-  const apiUrl =
-    getInput("api-url") || "https://ihghhasvxtltlbizvkqy.supabase.co/functions/v1";
+  const apiUrl = getInput("api-url") || "https://api.atlasent.io";
   const failOnDeny = getInput("fail-on-deny") !== "false";
 
   maskValue(apiKey);
 
-  // ── v2.1 batch path ────────────────────────────────────────────────────────
-  // When the `evaluations` input is set, fan out via runV21 (batch or loop).
-  // Each allow decision is automatically verified via verifyOne() in batch.ts.
+  // ── v2.1 batch path (scope-excluded from this unification) ─────────────────
   const evaluationsRaw = getInput("evaluations");
   if (evaluationsRaw) {
     const waitForId = getInput("wait-for-id") || undefined;
@@ -124,7 +140,7 @@ async function run(): Promise<void> {
       );
     } catch (err) {
       const msg =
-        err instanceof GateInfraError
+        err instanceof EnforceError
           ? err.message
           : `Unexpected error: ${err instanceof Error ? err.message : String(err)}`;
       setOutput("verified", "false");
@@ -169,10 +185,10 @@ async function run(): Promise<void> {
     return;
   }
 
-  // ── v1 single-eval path ────────────────────────────────────────────────────
+  // ── Single-eval path via @atlasent/enforce ─────────────────────────────────
   const actionType = getInput("action", true);
   const actor = getInput("actor") || "unknown";
-  const targetId = getInput("target-id");
+  const targetId = getInput("target-id") || undefined;
   const explicitEnv = getInput("environment");
   let extraContext: Record<string, unknown> = {};
   try {
@@ -181,15 +197,25 @@ async function run(): Promise<void> {
     warning("Could not parse 'context' input as JSON — ignoring");
   }
 
-  // 2. Build evaluate payload
   const gh = getGitHubContext();
   const environment = resolveEnvironment(explicitEnv, gh.ref, apiKey);
 
-  const payload: Record<string, unknown> = {
-    action_type: actionType,
-    actor_id: `github:${actor}`,
+  info(
+    `AtlaSent Gate: evaluating "${actionType}" for actor "github:${actor}" in ${environment} environment` +
+      (targetId ? ` (target=${targetId})` : ""),
+  );
+
+  // @atlasent/enforce is the canonical enforcement wrapper.
+  // enforce() runs evaluate → verify (decision check) → verifyPermit (API call).
+  // fn is a no-op: the action's job is to gate, not execute app logic.
+  const config: EnforceConfig = {
+    apiKey,
+    apiUrl,
+    action: actionType,
+    actor: `github:${actor}`,
+    environment,
+    targetId,
     context: {
-      environment,
       source: "github-action",
       repository: gh.repository,
       ref: gh.ref,
@@ -200,107 +226,107 @@ async function run(): Promise<void> {
       event_name: gh.event_name,
       pr_number: gh.pr_number ?? null,
       run_url: `${gh.server_url}/${gh.repository}/actions/runs/${gh.run_id}`,
-      ...(targetId ? { target_id: targetId } : {}),
       ...extraContext,
     },
   };
-  if (targetId) payload["target_id"] = targetId;
 
-  info(
-    `AtlaSent Gate: evaluating "${actionType}" for actor "${actor}" in ${environment} environment` +
-      (targetId ? ` (target=${targetId})` : ""),
-  );
-
-  // 3. Run gate (v1-evaluate → v1-verify-permit, fail-closed end-to-end).
-  //    Infrastructure errors (network, 5xx, 401, 429, no permit_token) always
-  //    throw GateInfraError and are never mistaken for policy decisions.
-  let result;
+  let enforceResult: Awaited<ReturnType<typeof enforce>>;
   try {
-    result = await runGate({
-      apiUrl,
-      apiKey,
-      actionType,
-      actorId: `github:${actor}`,
-      payload,
-    });
+    enforceResult = await enforce(config, async () => {});
   } catch (err) {
-    const msg =
-      err instanceof GateInfraError
-        ? err.message
-        : `Unexpected error: ${err instanceof Error ? err.message : String(err)}`;
+    if (err instanceof EnforceError) {
+      // Set decision outputs before failing so they're visible in the step.
+      if (err.decision) {
+        setDecisionOutputs(err.decision);
+      } else {
+        setOutput("decision", "error");
+        setOutput("permit-token", "");
+        setOutput("evaluation-id", "");
+        setOutput("proof-hash", "");
+        setOutput("risk-score", "");
+      }
+      setOutput("verified", "false");
+
+      // phase="verify" is a policy decision; respect fail-on-deny.
+      // All other phases are infrastructure/security failures: always fail-closed.
+      if (err.phase === "verify" && !failOnDeny) {
+        switch (err.decision?.decision) {
+          case "deny":
+            warning(`Authorization DENIED: ${err.decision.denyReason ?? "no reason provided"}`);
+            break;
+          case "hold":
+            warning(`Authorization on HOLD: ${err.decision.holdReason ?? "awaiting approval"}`);
+            break;
+          case "escalate":
+            warning("Authorization ESCALATED — manual review required");
+            break;
+          default:
+            warning(`Authorization ${err.decision?.decision ?? "unknown"}`);
+        }
+        return;
+      }
+
+      // Fail-closed for evaluate + verify-permit phases, and verify when failOnDeny=true.
+      switch (err.phase) {
+        case "evaluate":
+          setFailed(
+            `AtlaSent Gate: ${err.message}. Deploy blocked — the gate cannot confirm authorization (fail-closed).`,
+          );
+          break;
+        case "verify":
+          switch (err.decision?.decision) {
+            case "deny":
+              setFailed(
+                `Authorization DENIED: ${err.decision.denyReason ?? "no reason provided"}`,
+              );
+              break;
+            case "hold":
+              setFailed(
+                `Authorization on HOLD: ${err.decision.holdReason ?? "awaiting approval"}`,
+              );
+              break;
+            case "escalate":
+              setFailed("Authorization ESCALATED — manual review required");
+              break;
+            default:
+              setFailed(`Unexpected decision from AtlaSent: ${err.decision?.decision ?? "unknown"}`);
+          }
+          break;
+        case "verify-permit":
+          setFailed(
+            `AtlaSent Gate: ${err.message}. Deploy blocked (fail-closed).`,
+          );
+          break;
+        default:
+          setFailed(`AtlaSent Gate: ${err.message}`);
+      }
+      return;
+    }
+
+    // Non-EnforceError: unexpected
     setOutput("decision", "error");
+    setOutput("permit-token", "");
+    setOutput("evaluation-id", "");
+    setOutput("proof-hash", "");
+    setOutput("risk-score", "");
     setOutput("verified", "false");
     setFailed(
-      `AtlaSent Gate: ${msg}. Deploy blocked — the gate cannot confirm authorization (fail-closed).`,
+      `AtlaSent Gate: Unexpected error: ${err instanceof Error ? err.message : String(err)}`,
     );
     return;
   }
 
-  // Mask sensitive outputs before they touch logs
-  if (result.permitToken) maskValue(result.permitToken);
-  if (result.proofHash) maskValue(result.proofHash);
+  // enforce() returned — decision=allow, verify=passed, verifyPermit=passed.
+  const { decision: d, verifyOutcome } = enforceResult;
+  setDecisionOutputs(d);
+  setOutput("verified", "true");
 
-  // 4. Set outputs
-  setOutput("decision", result.decision);
-  setOutput("permit-token", result.permitToken);
-  setOutput("evaluation-id", result.evaluationId);
-  setOutput("proof-hash", result.proofHash);
-  setOutput("risk-score", result.riskScore);
-  setOutput("verified", result.verified ? "true" : "false");
-
-  // 5. Handle result
-  if (result.ok) {
-    info(`Authorization GRANTED (evaluate + verify)`);
-    info(`  Permit token: (set as 'permit-token' output, masked in logs)`);
-    info(`  Proof hash:   (set as 'proof-hash' output, masked in logs)`);
-    info(`  Evaluation:   ${result.evaluationId}`);
-    if (result.riskScore) info(`  Risk score:   ${result.riskScore}`);
-    info(`  Verify:       ${result.verifyOutcome}`);
-    return;
-  }
-
-  // Non-allow decisions or verify=false
-  if (result.decision === "allow") {
-    // verify returned verified=false (replay / expired permit)
-    setFailed(
-      `Permit verification failed (outcome=${result.verifyOutcome ?? "unknown"}). ` +
-        `Deploy blocked. This typically means the permit was already consumed ` +
-        `by an earlier verify, or it expired.`,
-    );
-    return;
-  }
-
-  switch (result.decision) {
-    case "deny":
-      if (failOnDeny) {
-        setFailed(`Authorization DENIED: ${result.reason || "no reason provided"}`);
-      } else {
-        warning(`Authorization DENIED: ${result.reason || "no reason provided"}`);
-      }
-      break;
-
-    case "hold":
-      if (failOnDeny) {
-        setFailed(`Authorization on HOLD: ${result.reason || "awaiting approval"}`);
-      } else {
-        warning(`Authorization on HOLD: ${result.reason || "awaiting approval"}`);
-      }
-      break;
-
-    case "escalate":
-      if (failOnDeny) {
-        setFailed("Authorization ESCALATED — manual review required");
-      } else {
-        warning("Authorization ESCALATED — manual review required");
-      }
-      break;
-
-    default:
-      warning(`Unexpected decision: ${result.decision}`);
-      if (failOnDeny) {
-        setFailed(`Unexpected decision from AtlaSent: ${result.decision}`);
-      }
-  }
+  info(`Authorization GRANTED (evaluate + verify)`);
+  info(`  Permit token: (set as 'permit-token' output, masked in logs)`);
+  info(`  Proof hash:   (set as 'proof-hash' output, masked in logs)`);
+  info(`  Evaluation:   ${d.evaluationId ?? ""}`);
+  if (d.riskScore !== undefined) info(`  Risk score:   ${d.riskScore}`);
+  info(`  Verify:       ${verifyOutcome ?? "verified"}`);
 }
 
 run().catch((err) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,15 +1,15 @@
-// AtlaSent Gate Action — Zero-dependency GitHub Action entry point
-// Reads GitHub Actions inputs via INPUT_* env vars and calls the AtlaSent evaluate endpoint.
+// AtlaSent Gate Action — GitHub Actions entry point.
+// HTTP logic lives in src/gate.ts (evaluate → v1-verify-permit, fail-closed).
+// This file handles GH Actions I/O: reading inputs, masking secrets, and
+// translating GateResult / GateInfraError into step outputs and exit codes.
 
-import https from "node:https";
-import http from "node:http";
+import { GateInfraError, runGate } from "./gate";
 
 // ---------------------------------------------------------------------------
-// Helpers
+// GitHub Actions helpers
 // ---------------------------------------------------------------------------
 
 function getInput(name: string, required = false): string {
-  // GitHub Actions sets inputs as env vars: INPUT_<UPPER_NAME> with hyphens replaced by underscores
   const envKey = `INPUT_${name.replace(/-/g, "_").toUpperCase()}`;
   const val = (process.env[envKey] ?? "").trim();
   if (required && !val) {
@@ -24,7 +24,6 @@ function setOutput(name: string, value: string): void {
     const fs = require("node:fs");
     fs.appendFileSync(outputFile, `${name}=${value}\n`);
   }
-  // Also log for older runners
   console.log(`::set-output name=${name}::${value}`);
 }
 
@@ -46,57 +45,7 @@ function maskValue(value: string): void {
 }
 
 // ---------------------------------------------------------------------------
-// HTTP helper — zero-dependency POST using Node built-ins
-// ---------------------------------------------------------------------------
-
-interface HttpResponse {
-  status: number;
-  body: string;
-}
-
-function post(url: string, body: string, headers: Record<string, string>): Promise<HttpResponse> {
-  return new Promise((resolve, reject) => {
-    const parsed = new URL(url);
-    const transport = parsed.protocol === "https:" ? https : http;
-
-    const req = transport.request(
-      {
-        hostname: parsed.hostname,
-        port: parsed.port || (parsed.protocol === "https:" ? 443 : 80),
-        path: parsed.pathname + parsed.search,
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "Content-Length": Buffer.byteLength(body),
-          ...headers,
-        },
-        timeout: 30_000,
-      },
-      (res) => {
-        const chunks: Buffer[] = [];
-        res.on("data", (chunk: Buffer) => chunks.push(chunk));
-        res.on("end", () => {
-          resolve({
-            status: res.statusCode ?? 0,
-            body: Buffer.concat(chunks).toString("utf-8"),
-          });
-        });
-      },
-    );
-
-    req.on("error", reject);
-    req.on("timeout", () => {
-      req.destroy();
-      reject(new Error("Request timed out after 30 seconds"));
-    });
-
-    req.write(body);
-    req.end();
-  });
-}
-
-// ---------------------------------------------------------------------------
-// GitHub context from environment
+// GitHub context
 // ---------------------------------------------------------------------------
 
 interface GitHubContext {
@@ -125,42 +74,12 @@ function getGitHubContext(): GitHubContext {
   };
 }
 
-// ---------------------------------------------------------------------------
-// Determine environment
-// ---------------------------------------------------------------------------
-
 function resolveEnvironment(explicit: string, ref: string, apiKey: string): string {
   if (explicit) return explicit;
-  // Infer from API key prefix
   if (apiKey.startsWith("ask_test_")) return "test";
   if (apiKey.startsWith("ask_live_")) return "live";
-  // Infer from branch
   const branch = ref.replace("refs/heads/", "");
   return branch === "main" || branch === "master" ? "live" : "test";
-}
-
-// ---------------------------------------------------------------------------
-// Risk-score extraction
-// ---------------------------------------------------------------------------
-
-// The v1-evaluate response carries risk in two shapes depending on how
-// the rule engine was wired:
-//   - Canonical (per atlasent-api openapi `Decision.risk`):
-//       { risk: { level, score, reasons, ... } }
-//   - Flat (older / minimal evaluator):
-//       { risk_score: number }
-// Try canonical first, fall back to flat. Returns "" when neither is
-// present so the GitHub output is still set (callers can branch on
-// empty string).
-function extractRiskScore(result: Record<string, unknown>): string {
-  const risk = result["risk"];
-  if (risk && typeof risk === "object" && "score" in risk) {
-    const score = (risk as { score?: unknown }).score;
-    if (typeof score === "number") return String(score);
-  }
-  const flat = result["risk_score"];
-  if (typeof flat === "number") return String(flat);
-  return "";
 }
 
 // ---------------------------------------------------------------------------
@@ -174,7 +93,8 @@ async function run(): Promise<void> {
   const actor = getInput("actor") || "unknown";
   const targetId = getInput("target-id");
   const explicitEnv = getInput("environment");
-  const apiUrl = getInput("api-url") || "https://ihghhasvxtltlbizvkqy.supabase.co/functions/v1";
+  const apiUrl =
+    getInput("api-url") || "https://ihghhasvxtltlbizvkqy.supabase.co/functions/v1";
   const failOnDeny = getInput("fail-on-deny") !== "false";
   let extraContext: Record<string, unknown> = {};
   try {
@@ -183,10 +103,9 @@ async function run(): Promise<void> {
     warning("Could not parse 'context' input as JSON — ignoring");
   }
 
-  // Mask the API key so it never appears in logs
   maskValue(apiKey);
 
-  // 2. Build context
+  // 2. Build evaluate payload
   const gh = getGitHubContext();
   const environment = resolveEnvironment(explicitEnv, gh.ref, apiKey);
 
@@ -205,147 +124,90 @@ async function run(): Promise<void> {
       event_name: gh.event_name,
       pr_number: gh.pr_number ?? null,
       run_url: `${gh.server_url}/${gh.repository}/actions/runs/${gh.run_id}`,
-      // target_id is also threaded into context so policies that read
-      // context.target_id (rather than the top-level target_id) match.
       ...(targetId ? { target_id: targetId } : {}),
       ...extraContext,
     },
   };
-
-  // Top-level target_id matches the canonical EvaluationParams shape
-  // used by `@atlasent/sdk` and atlasent-console. Older evaluators
-  // that only inspect context will still see it via the context
-  // mirror above.
   if (targetId) payload["target_id"] = targetId;
 
-  info(`AtlaSent Gate: evaluating "${actionType}" for actor "${actor}" in ${environment} environment${targetId ? ` (target=${targetId})` : ""}`);
+  info(
+    `AtlaSent Gate: evaluating "${actionType}" for actor "${actor}" in ${environment} environment` +
+      (targetId ? ` (target=${targetId})` : ""),
+  );
 
-  // 3. Call the evaluate endpoint.
-  // Infrastructure errors (network, timeout, 5xx, 401/403, 429) are
-  // distinct from policy decisions. `fail-on-deny` governs whether a
-  // legitimate deny/hold/escalate fails the job; it does NOT mean
-  // "fail open on missing authorization." A security gate that
-  // silently lets deploys through when its authority source is
-  // unreachable is worse than no gate.
-  let response: HttpResponse;
+  // 3. Run gate (v1-evaluate → v1-verify-permit, fail-closed end-to-end).
+  //    Infrastructure errors (network, 5xx, 401, 429, no permit_token) always
+  //    throw GateInfraError and are never mistaken for policy decisions.
+  let result;
   try {
-    response = await post(`${apiUrl}/v1-evaluate`, JSON.stringify(payload), {
-      Authorization: `Bearer ${apiKey}`,
+    result = await runGate({
+      apiUrl,
+      apiKey,
+      actionType,
+      actorId: `github:${actor}`,
+      payload,
     });
-  } catch (err: unknown) {
-    const message = err instanceof Error ? err.message : String(err);
+  } catch (err) {
+    const msg =
+      err instanceof GateInfraError
+        ? err.message
+        : `Unexpected error: ${err instanceof Error ? err.message : String(err)}`;
     setOutput("decision", "error");
+    setOutput("verified", "false");
     setFailed(
-      `AtlaSent API unreachable: ${message}. The deploy is blocked because ` +
-        `the authorization gate could not confirm a policy decision. ` +
-        `Set ATLASENT_ALLOW_INFRA_BYPASS=1 to deliberately fail-open on ` +
-        `transport errors (not recommended for production gates).`,
+      `AtlaSent Gate: ${msg}. Deploy blocked — the gate cannot confirm authorization (fail-closed).`,
     );
     return;
   }
 
-  // 4. Classify the HTTP status. Only 2xx is a policy decision; every
-  // other class is an infrastructure state we must not confuse with
-  // a decision.
-  if (response.status >= 500) {
-    setOutput("decision", "error");
+  // Mask sensitive outputs before they touch logs
+  if (result.permitToken) maskValue(result.permitToken);
+  if (result.proofHash) maskValue(result.proofHash);
+
+  // 4. Set outputs
+  setOutput("decision", result.decision);
+  setOutput("permit-token", result.permitToken);
+  setOutput("evaluation-id", result.evaluationId);
+  setOutput("proof-hash", result.proofHash);
+  setOutput("risk-score", result.riskScore);
+  setOutput("verified", result.verified ? "true" : "false");
+
+  // 5. Handle result
+  if (result.ok) {
+    info(`Authorization GRANTED (evaluate + verify)`);
+    info(`  Permit token: (set as 'permit-token' output, masked in logs)`);
+    info(`  Proof hash:   (set as 'proof-hash' output, masked in logs)`);
+    info(`  Evaluation:   ${result.evaluationId}`);
+    if (result.riskScore) info(`  Risk score:   ${result.riskScore}`);
+    info(`  Verify:       ${result.verifyOutcome}`);
+    return;
+  }
+
+  // Non-allow decisions or verify=false
+  if (result.decision === "allow") {
+    // verify returned verified=false (replay / expired permit)
     setFailed(
-      `AtlaSent API returned HTTP ${response.status} — infrastructure failure, ` +
-        `not a policy decision. Deploy blocked. Body: ${response.body.slice(0, 300)}`,
+      `Permit verification failed (outcome=${result.verifyOutcome ?? "unknown"}). ` +
+        `Deploy blocked. This typically means the permit was already consumed ` +
+        `by an earlier verify, or it expired.`,
     );
     return;
   }
-  if (response.status === 401 || response.status === 403) {
-    setOutput("decision", "error");
-    setFailed(
-      `AtlaSent API auth failed (HTTP ${response.status}). Check your ` +
-        `ATLASENT_API_KEY and the key's scopes. Body: ${response.body.slice(0, 300)}`,
-    );
-    return;
-  }
-  if (response.status === 429) {
-    // Rate-limited — transient, but safer to block than silently
-    // allow. Retries should be a caller-controlled workflow decision,
-    // not an action-level fail-open.
-    setOutput("decision", "error");
-    setFailed(
-      `AtlaSent API rate-limited this gate (HTTP 429). Deploy blocked. ` +
-        `Retry the job or raise the key's rate_limit_per_minute.`,
-    );
-    return;
-  }
-  if (response.status < 200 || response.status >= 300) {
-    const msg = `AtlaSent API returned HTTP ${response.status}: ${response.body.slice(0, 300)}`;
-    if (failOnDeny) {
-      setFailed(msg);
-      return;
-    }
-    warning(msg);
-    setOutput("decision", "error");
-    return;
-  }
 
-  let result: {
-    decision?: string;
-    permit_token?: string;
-    evaluation_id?: string;
-    proof_hash?: string;
-    deny_reason?: string;
-    hold_reason?: string;
-  };
-
-  try {
-    result = JSON.parse(response.body);
-  } catch {
-    setFailed(`Failed to parse AtlaSent response: ${response.body.slice(0, 300)}`);
-    return;
-  }
-
-  const decision = result.decision ?? "unknown";
-  const permitToken = result.permit_token ?? "";
-  const evaluationId = result.evaluation_id ?? "";
-  const proofHash = result.proof_hash ?? "";
-  const riskScore = extractRiskScore(result as Record<string, unknown>);
-
-  // Mask the permit token + proof hash so they don't appear verbatim
-  // in action logs. The API key already gets masked at line 162;
-  // extend the same treatment to derived secrets. Permit tokens are
-  // short-lived and single-use but customer CI log retention can be
-  // long — treat as sensitive at rest.
-  if (permitToken) maskValue(permitToken);
-  if (proofHash) maskValue(proofHash);
-
-  // 5. Set outputs (GitHub masks them in console echoes because of
-  // the maskValue() calls above).
-  setOutput("decision", decision);
-  setOutput("permit-token", permitToken);
-  setOutput("evaluation-id", evaluationId);
-  setOutput("proof-hash", proofHash);
-  setOutput("risk-score", riskScore);
-
-  // 6. Handle decision
-  switch (decision) {
-    case "allow":
-      info(`Authorization GRANTED`);
-      info(`  Permit token: (set as 'permit-token' output, masked in logs)`);
-      info(`  Proof hash:   (set as 'proof-hash' output, masked in logs)`);
-      info(`  Evaluation:   ${evaluationId}`);
-      if (riskScore) info(`  Risk score:   ${riskScore}`);
-      break;
-
+  switch (result.decision) {
     case "deny":
       if (failOnDeny) {
-        setFailed(`Authorization DENIED: ${result!.deny_reason ?? "no reason provided"}`);
+        setFailed(`Authorization DENIED: ${result.reason || "no reason provided"}`);
       } else {
-        warning(`Authorization DENIED: ${result!.deny_reason ?? "no reason provided"}`);
+        warning(`Authorization DENIED: ${result.reason || "no reason provided"}`);
       }
       break;
 
     case "hold":
       if (failOnDeny) {
-        setFailed(`Authorization on HOLD: ${result!.hold_reason ?? "awaiting approval"}`);
+        setFailed(`Authorization on HOLD: ${result.reason || "awaiting approval"}`);
       } else {
-        warning(`Authorization on HOLD: ${result!.hold_reason ?? "awaiting approval"}`);
+        warning(`Authorization on HOLD: ${result.reason || "awaiting approval"}`);
       }
       break;
 
@@ -358,9 +220,9 @@ async function run(): Promise<void> {
       break;
 
     default:
-      warning(`Unexpected decision: ${decision}`);
+      warning(`Unexpected decision: ${result.decision}`);
       if (failOnDeny) {
-        setFailed(`Unexpected decision from AtlaSent: ${decision}`);
+        setFailed(`Unexpected decision from AtlaSent: ${result.decision}`);
       }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@
 
 import { enforce, EnforceError } from "@atlasent/enforce";
 import type { Decision, EnforceConfig } from "@atlasent/enforce";
+import { GateInfraError } from "./gate";
 import { runV21 } from "./v21";
 
 // ---------------------------------------------------------------------------
@@ -140,7 +141,7 @@ async function run(): Promise<void> {
       );
     } catch (err) {
       const msg =
-        err instanceof EnforceError
+        err instanceof EnforceError || err instanceof GateInfraError
           ? err.message
           : `Unexpected error: ${err instanceof Error ? err.message : String(err)}`;
       setOutput("verified", "false");

--- a/src/index.ts
+++ b/src/index.ts
@@ -172,7 +172,7 @@ async function run(): Promise<void> {
 
     if (result.failed) {
       setFailed(
-        `AtlaSent Gate: one or more evaluations denied. See 'decisions' output for details.`,
+        `AtlaSent Gate: one or more evaluations were not allowed (deny/hold/escalate). See 'decisions' output for details.`,
       );
       return;
     }

--- a/src/inputs.ts
+++ b/src/inputs.ts
@@ -29,7 +29,12 @@ export function parseInputs(env: Record<string, string | undefined>): ActionInpu
 
   const evaluationsRaw = env["INPUT_EVALUATIONS"];
   if (evaluationsRaw && evaluationsRaw.trim()) {
-    const parsed = JSON.parse(evaluationsRaw) as EvaluateRequest[];
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(evaluationsRaw);
+    } catch {
+      throw new Error("`evaluations` is not valid JSON — expected a JSON array of evaluation requests");
+    }
     if (!Array.isArray(parsed) || parsed.length === 0) {
       throw new Error(
         "`evaluations` must be a non-empty JSON array of evaluation requests",
@@ -39,7 +44,7 @@ export function parseInputs(env: Record<string, string | undefined>): ActionInpu
       apiKey,
       apiUrl,
       failOnDeny,
-      evaluations: parsed,
+      evaluations: parsed as EvaluateRequest[],
       waitForId: env["INPUT_WAIT-FOR-ID"] || undefined,
       waitTimeoutMs: parseInt(env["INPUT_WAIT-TIMEOUT-MS"] || "600000", 10),
     };
@@ -49,7 +54,12 @@ export function parseInputs(env: Record<string, string | undefined>): ActionInpu
   const actor = env["INPUT_ACTOR"] || env["GITHUB_ACTOR"] || "unknown";
   const environment = env["INPUT_ENVIRONMENT"];
   const contextRaw = env["INPUT_CONTEXT"] || "{}";
-  const context = JSON.parse(contextRaw) as Record<string, unknown>;
+  let context: Record<string, unknown> = {};
+  try {
+    context = JSON.parse(contextRaw) as Record<string, unknown>;
+  } catch {
+    throw new Error("`context` is not valid JSON — expected a JSON object");
+  }
 
   return {
     apiKey,

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -74,18 +74,24 @@ async function waitViaStream(opts: WaitOptions): Promise<Decision> {
 async function waitViaPolling(opts: WaitOptions): Promise<Decision> {
   const deadline = Date.now() + opts.timeoutMs;
   while (Date.now() < deadline) {
-    const r = await fetch(
-      `${opts.apiUrl}/v1/evaluate/${encodeURIComponent(opts.evaluationId)}`,
-      {
-        headers: { authorization: `Bearer ${opts.apiKey}` },
-        signal: opts.signal,
-      },
-    );
-    if (r.ok) {
-      const decision = (await r.json()) as Decision;
-      if (decision.decision === "allow" || decision.decision === "deny") {
-        return decision;
+    try {
+      const r = await fetch(
+        `${opts.apiUrl}/v1/evaluate/${encodeURIComponent(opts.evaluationId)}`,
+        {
+          headers: { authorization: `Bearer ${opts.apiKey}` },
+          signal: opts.signal,
+        },
+      );
+      if (r.ok) {
+        const decision = (await r.json()) as Decision;
+        if (decision.decision === "allow" || decision.decision === "deny") {
+          return decision;
+        }
       }
+    } catch (err) {
+      // Re-throw AbortError (caller cancelled); swallow transient network /
+      // parse errors and let the next poll attempt handle them.
+      if (err instanceof Error && err.name === "AbortError") throw err;
     }
     await new Promise((res) => setTimeout(res, POLL_INTERVAL_MS));
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,4 +17,7 @@ export interface Decision {
   proofHash?: string;
   reasons?: string[];
   evaluatedAt: string;
+  /** Set after verify-permit round-trip. True only when evaluate=allow AND verify=true. */
+  verified?: boolean;
+  verifyOutcome?: string;
 }

--- a/src/v21.ts
+++ b/src/v21.ts
@@ -77,7 +77,8 @@ export async function runV21(
   }
 
   const failed =
-    inputs.failOnDeny && decisions.some((d) => d.decision === "deny");
+    inputs.failOnDeny &&
+    decisions.some((d) => d.decision === "deny" || d.decision === "hold" || d.decision === "escalate");
 
   return { decisions, failed, batchId: batch.batchId };
 }

--- a/src/v21.ts
+++ b/src/v21.ts
@@ -14,6 +14,7 @@
 //   4. Job summary is rendered per evaluation.
 
 import { evaluateMany } from "./batch";
+import { verifyOne } from "./gate";
 import { parseInputs } from "./inputs";
 import { waitForTerminalDecision } from "./stream";
 import type { Decision } from "./types";
@@ -55,7 +56,23 @@ export async function runV21(
         v2Streaming: flags.v2Streaming,
       });
       decisions = [...decisions];
-      decisions[idx] = terminal;
+      if (terminal.decision === "allow") {
+        // Terminal allow must be verified — same fail-closed contract as evaluateMany.
+        const item = items[idx];
+        const vr = terminal.permitToken
+          ? await verifyOne({
+              apiUrl: inputs.apiUrl,
+              apiKey: inputs.apiKey,
+              actionType: item.action,
+              actorId: item.actor,
+              permitToken: terminal.permitToken,
+              verifyPath: "/v1/verify-permit",
+            })
+          : { verified: false as const, outcome: undefined };
+        decisions[idx] = { ...terminal, verified: vr.verified, verifyOutcome: vr.outcome };
+      } else {
+        decisions[idx] = terminal;
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Lands the full v1.3.0 feature set on top of main's v1.2.0 baseline. Supersedes open PRs #21 and #22 (both addressed the same gaps from an earlier baseline).

- **Verify-permit contract (A5)** — action now calls `/v1/verify-permit` after every allow decision. `verified=true` only when evaluate=allow AND the server confirms the permit token. Replay/expired/revoked tokens are fail-closed.
- **v2.1 batch path (B.AC4)** — `evaluations` input accepts a JSON array; `runV21 → evaluateMany → per-decision verifyOne` with parallel verify calls. `decisions` + `batch-id` outputs.
- **Streaming wait** — `wait-for-id` blocks on hold/escalate via SSE or HTTP polling; `wait-timeout-ms`, `v2-batch`, `v2-streaming` flags.
- **`@atlasent/enforce` unification** — single-eval path now delegates entirely to `@atlasent/enforce` (evaluate → verify → verifyPermit → execute). `runGate()` dead code removed.
- **`@atlasent/enforce` v0.2.0** — `verifyPermit()` step added; `enforce()` now runs all four phases; new `EnforcePhase "verify-permit"`.
- **87 SIM tests** across 9 test files — full coverage of gate, batch, stream, v21, inputs, evaluate, verify, verify-permit, and enforce.
- **Workflow fixes** — `deploy.yaml` inputs/outputs corrected; `test.yml` grep targets updated and build/typecheck/test steps added.
- **README** — updated for v2.1 batch inputs/outputs, `verified` output, batch mode example, corrected API paths.
- **api-url default** changed from Supabase function base to `https://api.atlasent.io`.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run build` — 24 KB `dist/index.js`
- [x] `npm test` — 87 tests, 9 files, 0 failures
- [x] `packages/enforce` dist rebuilt (`tsc`)
- [x] CHANGELOG `[1.3.0] — 2026-04-30` stamped
- [x] `package.json` 1.2.0 → 1.3.0; `@atlasent/enforce` 0.1.0 → 0.2.0

https://claude.ai/code/session_01YJJfZGywVbBwT1rmgA9xzC

---
_Generated by [Claude Code](https://claude.ai/code/session_01YJJfZGywVbBwT1rmgA9xzC)_