### PR TITLE
docs(roadmap): mark items 1-3 done; reframe item 4 as release-ops gap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -22,7 +22,7 @@ GitHub Action that gates CI deploys on an AtlaSent `allow` decision. Distributed
    - Move the floating `v1` major tag to `v1.3.0`.
    - Verify the Marketplace listing reflects v1.3.0.
 
-   Tracking issue: <link once filed>.
+   Tracking issue: [#25](https://github.com/AtlaSent-Systems-Inc/atlasent-action/issues/25).
 
 ## Post-GA — ordered by impact
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,31 +4,37 @@ GitHub Action that gates CI deploys on an AtlaSent `allow` decision. Distributed
 
 ## GA (v1) — must ship
 
-1. **`target-id` input** — `src/index.ts` already reads `core.getInput('target-id')` with a `GITHUB_REPOSITORY` fallback, but `action.yml` never declared it. This is the content of the now-closed PR #10 and must be re-landed:
-   ```yaml
-   inputs:
-     target-id:
-       description: Target resource identifier (defaults to GITHUB_REPOSITORY)
-       required: false
-   outputs:
-     risk-score:
-       description: Numeric risk score 0-100
-   ```
-2. **Four-value `decision` output** — align with `atlasent-api`'s enum: `allow | deny | hold | escalate`. The existing `action.yml` mentions only `allow`.
-3. **Marketplace listing polish** — icon, color, branding in `action.yml`; README with a one-paragraph quickstart; LICENSE.
-4. **Pinned SDK version** — the action bundles `@atlasent/sdk` at build time; pin to the v1 release once `atlasent-sdk` cuts its tag.
+1. ~~**`target-id` input**~~ ✅ landed in v1.2.0 (CHANGELOG 2026-04-25). `action.yml` on main declares the input and threads it into both top-level `target_id` and `context.target_id`.
+
+2. ~~**Four-value `decision` output**~~ ✅ landed. `action.yml` declares `decision: 'allow/deny/hold/escalate'`; the v2.1 batch path (`runV21`) and the `wait-for-id` poller surface hold/escalate end-to-end.
+
+3. ~~**Marketplace listing polish**~~ ✅ branding in `action.yml` (`icon: shield`, `color: green`). README + LICENSE present on main. Listing itself still on v1.0.0 — see item 4.
+
+4. **Cut the v1.2.0 + v1.3.0 releases** — code is on main but **only v1.0.0 is tagged or released**. The Marketplace listing customers see is v1.0.0, missing every change documented in CHANGELOG since 2026-04-17:
+   - **v1.2.0** (2026-04-25): `target-id` input, `risk-score` output. CHANGELOG entry notes "Source-only release. `dist/index.js` must be rebuilt before tagging — release engineering tracks the rebuild step."
+   - **v1.3.0** (2026-04-30): `evaluations` / `wait-for-id` / `wait-timeout-ms` / `v2-batch` / `v2-streaming` inputs; `decisions` / `batch-id` outputs; A5 `verify-permit` wiring (`verified` is meaningful now); plus security-relevant bug fixes — `transport.ts` ECONNRESET crash, polling not retrying network errors, `wait-for-id` allow path silently fail-closed, `decisions`/`batch-id` unset on batch error, raw `SyntaxError` on bad JSON inputs, `GateInfraError` mislabeled "Unexpected error".
+
+   Required steps (release-ops, not code):
+   - `npm run build` to refresh `dist/index.js` (`@atlasent/enforce` is bundled via esbuild — there is no runtime SDK pin to chase).
+   - Commit the rebuilt `dist/` if it has drifted.
+   - Tag `v1.2.0` at the matching commit and `v1.3.0` at HEAD.
+   - Cut GitHub Releases for both, with the existing CHANGELOG entries as release notes.
+   - Move the floating `v1` major tag to `v1.3.0`.
+   - Verify the Marketplace listing reflects v1.3.0.
+
+   Tracking issue: <link once filed>.
 
 ## Post-GA — ordered by impact
 
 5. **Check-run mode** — in addition to exit-code pass/fail, create a GitHub Check with risk bullets and a link to the evaluation in the console.
 6. **Auto-comment on PRs** — summary comment when the action blocks.
 7. **Self-hosted runner compat** — document egress requirements (api.atlasent.io), IP allowlist considerations.
-8. **Matrix job support** — today one evaluation per job; allow batch eval for matrix fans.
+8. **Matrix job support** — today one evaluation per job; allow batch eval for matrix fans. (Partially addressed by the v1.3.0 batch path, but the matrix-fan ergonomics aren't documented.)
 
 ## Cross-repo dependencies
 
-- **atlasent-sdk**: provides the TS client used here. v1 release must land first.
-- **atlasent-api**: the `decision` enum change (hold/escalate) is already on `main`; make sure the action surfaces both.
+- **atlasent-api**: the `decision` enum (`allow|deny|hold|escalate`) and the `/v1/verify-permit` endpoint are on `main` and surfaced here.
+- **atlasent-sdk**: no longer a runtime dep — `@atlasent/enforce` is a workspace package bundled into `dist/index.js` at build time. The pre-v1.3.0 "pin SDK version" item is moot.
 - **atlasent-docs**: needs a "CI gate" page pointing at Marketplace.
 
 ## Open questions


### PR DESCRIPTION
## Summary

`atlasent-action/ROADMAP.md` was stale. `action.yml` on `main` already declares everything items 1-3 said was missing:

- `target-id` input is declared and threaded into top-level `target_id` + `context.target_id` (added v1.2.0 per CHANGELOG).
- `decision` output is declared as `allow/deny/hold/escalate`; the v2.1 batch path + `wait-for-id` poller surface hold/escalate end-to-end (v1.3.0).
- Branding is set (`icon: shield`, `color: green`); README + LICENSE present.

The actual outstanding gap is **release-ops, not code**: only `v1.0.0` is tagged or released. v1.2.0 and v1.3.0 are documented in `CHANGELOG.md` but were never tagged, never released, and the floating `v1` major tag still points at v1.0.0. Marketplace consumers pinning `@v1` get an action that is missing `target-id`, `risk-score`, hold/escalate semantics, the entire batch path, A5 `verify-permit` closure (so `verified` is loose), and a half-dozen bug fixes — including the `transport.ts` ECONNRESET crash and the polling not retrying network errors.

This PR rewrites item 4 to reflect that gap and links the new tracking issue [#25](https://github.com/AtlaSent-Systems-Inc/atlasent-action/issues/25). It also drops the "pin SDK version" cross-repo dep — `@atlasent/enforce` is a workspace package bundled by esbuild at build time, so there's no runtime SDK pin to chase.

No code changes, no behaviour changes — docs only.

## Test plan
- [x] Read of updated ROADMAP.md confirms items 1-3 strikethrough with landed-in-version notes.
- [x] Item 4 lists the concrete release-ops steps (rebuild `dist/`, tag, release, move `v1`).
- [x] Tracking issue link resolves to atlasent-action#25.
- [ ] Reviewer confirms the version assertions match what's in `CHANGELOG.md` and `git tag`.

---
_Generated by [Claude Code](https://claude.ai/code/session_0145ya8VSsxDwSGMqs67xSHv)_