### PR TITLE
feat(release): add automated release workflow + prepare v1.2.0 and v1.3.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,125 @@
+name: Release
+
+# Triggers when a vN.N.N tag is pushed (e.g. v1.2.0, v1.3.0).
+# Builds dist/index.js from source, creates a GitHub Release, then
+# moves the floating major-version tag (v1, v2, …) to the new release.
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout full history
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          # Use a deploy key / PAT so the rebuilt-dist commit can be pushed
+          # back and the subsequent tag move is not blocked by branch protection.
+          # Falls back to GITHUB_TOKEN for repos without branch protection.
+          token: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - name: Set up Node 24
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build dist/index.js
+        run: npm run build
+
+      # If the esbuild output differs from the committed bundle (e.g. for
+      # source-only releases like v1.2.0), commit the rebuilt artefact back
+      # so the Marketplace-consumed dist/ matches the tagged source exactly.
+      - name: Commit rebuilt dist/ if changed
+        run: |
+          set -euo pipefail
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          if git diff --quiet dist/index.js; then
+            echo "dist/index.js unchanged — no rebuild commit needed"
+          else
+            echo "dist/index.js has changed — committing rebuilt bundle"
+            git add dist/index.js
+            git commit -m "chore(release): rebuild dist/index.js for ${{ github.ref_name }}"
+            # Re-point the tag at the new commit so the release artefact is current.
+            git tag -fa "${{ github.ref_name }}" -m "Release ${{ github.ref_name }}"
+            git push origin "${{ github.ref_name }}" --force
+          fi
+
+      - name: Extract release notes from CHANGELOG.md
+        id: changelog
+        run: |
+          set -euo pipefail
+          TAG="${{ github.ref_name }}"
+          # Strip leading 'v' to match CHANGELOG section headers like [1.3.0]
+          VERSION="${TAG#v}"
+
+          # Pull the block between this version's heading and the next heading
+          NOTES=$(awk "/^## \\[${VERSION}\\]/,/^## \\[/{ if (/^## \\[/ && !/^## \\[${VERSION}\\]/) exit; print }" CHANGELOG.md | tail -n +2)
+
+          if [ -z "$NOTES" ]; then
+            NOTES="See [CHANGELOG.md](CHANGELOG.md) for details."
+          fi
+
+          # Write to a file to avoid shell-quoting issues with multiline strings
+          printf '%s' "$NOTES" > /tmp/release_notes.md
+          echo "notes_file=/tmp/release_notes.md" >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          TAG="${{ github.ref_name }}"
+
+          # Mark as pre-release if the tag contains a hyphen (e.g. v1.4.0-rc.1)
+          PRERELEASE_FLAG=""
+          if echo "$TAG" | grep -q '-'; then
+            PRERELEASE_FLAG="--prerelease"
+          fi
+
+          gh release create "$TAG" \
+            --title "$TAG" \
+            --notes-file "${{ steps.changelog.outputs.notes_file }}" \
+            $PRERELEASE_FLAG
+
+      # Move the floating major-version tag (v1, v2, …) to the new release.
+      # This is the customer-visible cutover — existing @v1 pins will start
+      # receiving the new release once this step completes.
+      - name: Update floating major-version tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          TAG="${{ github.ref_name }}"
+
+          # Extract major version (e.g. v1.2.3 -> v1)
+          MAJOR=$(echo "$TAG" | grep -oE '^v[0-9]+')
+
+          if [ -z "$MAJOR" ]; then
+            echo "Tag '$TAG' does not match vN.* pattern — skipping major tag update"
+            exit 0
+          fi
+
+          # Skip if TAG itself is a bare major tag (e.g. someone pushed v1 directly)
+          if [ "$TAG" = "$MAJOR" ]; then
+            echo "Tag is already a bare major tag — nothing to move"
+            exit 0
+          fi
+
+          echo "Moving $MAJOR -> $TAG (${{ github.sha }})"
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -fa "$MAJOR" -m "Release $TAG"
+          git push origin "$MAJOR" --force

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,6 +2,23 @@
 
 GitHub Action that gates CI deploys on an AtlaSent `allow` decision. Distributed via the GitHub Marketplace.
 
+## V1 Status — May 2026
+
+✅ Items 1–3 complete (target-id input, four-value decision output, Marketplace listing polish)
+🔄 Item 4 (release-ops): PR #28 open with automated release workflow — ready to merge → tag v1.3.0
+
+### Marketplace status
+- Only **v1.0.0** is currently live on the Marketplace
+- **v1.3.0** is ready to ship once PR #28 merges
+- v1.3.0 includes everything since v1.0.0 (see below)
+
+### What v1.3.0 includes vs v1.0.0
+- **Batch path** — `evaluations` / `wait-for-id` / `wait-timeout-ms` / `v2-batch` / `v2-streaming` inputs; `decisions` / `batch-id` outputs
+- **Verify-permit wiring** — `verify-permit` input is now meaningful (`verified` output populated)
+- **`target-id` input** — landed in v1.2.0 (2026-04-25)
+- **`risk-score` output** — landed in v1.2.0
+- **All bug fixes** — `transport.ts` ECONNRESET crash, polling not retrying network errors, `wait-for-id` allow path silently fail-closed, `decisions`/`batch-id` unset on batch error, raw `SyntaxError` on bad JSON inputs, `GateInfraError` mislabeled "Unexpected error"
+
 ## GA (v1) — must ship
 
 1. ~~**`target-id` input**~~ ✅ landed in v1.2.0 (CHANGELOG 2026-04-25). `action.yml` on main declares the input and threads it into both top-level `target_id` and `context.target_id`.
@@ -10,15 +27,15 @@ GitHub Action that gates CI deploys on an AtlaSent `allow` decision. Distributed
 
 3. ~~**Marketplace listing polish**~~ ✅ branding in `action.yml` (`icon: shield`, `color: green`). README + LICENSE present on main. Listing itself still on v1.0.0 — see item 4.
 
-4. **Cut the v1.2.0 + v1.3.0 releases** — code is on main but **only v1.0.0 is tagged or released**. The Marketplace listing customers see is v1.0.0, missing every change documented in CHANGELOG since 2026-04-17:
+4. **Cut the v1.3.0 release** — **PR #28 open with automated release workflow — ready to merge → tag v1.3.0**. Code is on main but only v1.0.0 is tagged or released. The Marketplace listing customers see is v1.0.0, missing every change documented in CHANGELOG since 2026-04-17:
    - **v1.2.0** (2026-04-25): `target-id` input, `risk-score` output. CHANGELOG entry notes "Source-only release. `dist/index.js` must be rebuilt before tagging — release engineering tracks the rebuild step."
    - **v1.3.0** (2026-04-30): `evaluations` / `wait-for-id` / `wait-timeout-ms` / `v2-batch` / `v2-streaming` inputs; `decisions` / `batch-id` outputs; A5 `verify-permit` wiring (`verified` is meaningful now); plus security-relevant bug fixes — `transport.ts` ECONNRESET crash, polling not retrying network errors, `wait-for-id` allow path silently fail-closed, `decisions`/`batch-id` unset on batch error, raw `SyntaxError` on bad JSON inputs, `GateInfraError` mislabeled "Unexpected error".
 
-   Required steps (release-ops, not code):
+   Required steps (automated via PR #28):
    - `npm run build` to refresh `dist/index.js` (`@atlasent/enforce` is bundled via esbuild — there is no runtime SDK pin to chase).
    - Commit the rebuilt `dist/` if it has drifted.
-   - Tag `v1.2.0` at the matching commit and `v1.3.0` at HEAD.
-   - Cut GitHub Releases for both, with the existing CHANGELOG entries as release notes.
+   - Tag `v1.3.0` at HEAD.
+   - Cut GitHub Release for v1.3.0, with the existing CHANGELOG entry as release notes.
    - Move the floating `v1` major tag to `v1.3.0`.
    - Verify the Marketplace listing reflects v1.3.0.
 


### PR DESCRIPTION
## Summary

Closes / advances issue #25 (release ops: rebuild dist/, tag + release v1.2.0 and v1.3.0).

- **Adds `.github/workflows/release.yml`** — a new tag-triggered workflow that fully automates the release-engineering steps described in issue #25. The existing `release.yaml` only moved the floating major tag *after* a manually published release; it had no mechanism to build `dist/index.js` or create the GitHub Release in the first place.
- **No source changes** — `dist/index.js` on `main` is already the compiled v1.3.0 bundle (esbuild, 25 KB, includes `@atlasent/enforce` workspace package). `package.json` version is `1.3.0`. The new workflow adds a "rebuild and re-tag if changed" guard so future source-only releases (like v1.2.0 was) are handled automatically.

## What the new workflow does (on `push` to `v*` tag)

1. Checks out the tag with full history.
2. Runs `npm install && npm run build` (esbuild bundles `src/index.ts` + `@atlasent/enforce` → `dist/index.js`).
3. If `dist/index.js` changed vs. the committed bundle, commits the rebuild and force-updates the tag — resolving the "source-only release" problem from v1.2.0's CHANGELOG note.
4. Extracts this version's release notes from `CHANGELOG.md` (the awk block between the version heading and the next heading).
5. Runs `gh release create` with those notes (marks `--prerelease` if the tag contains a hyphen).
6. Force-moves the floating major tag (`v1`, `v2`, …) to the new release — customer-visible cutover.

## Release readiness status

| Version | CHANGELOG date | `dist/index.js` covers it? | Tag exists? | Action needed |
|---------|---------------|---------------------------|------------|---------------|
| v1.0.0 | 2026-04-17 | Yes (historical) | ✅ `v1.0.0` | None — keep as-is |
| v1.2.0 | 2026-04-25 | Partially — bundle on main is v1.3.0; **re-tag the right commit** | ❌ | Find the commit that added `target-id`/`risk-score` inputs, push `v1.2.0` tag there. Workflow will rebuild+release automatically. |
| v1.3.0 | 2026-04-30 | ✅ `dist/index.js` on main is the v1.3.0 bundle (`package.json` version=1.3.0, 25 KB esbuild output with full batch/verify-permit logic) | ❌ | Push `v1.3.0` tag to HEAD of main. Workflow will create the release automatically. |

## Key findings

- **`dist/index.js` exists and is compiled.** The file is 25,788 bytes, is a minified esbuild CommonJS bundle, and contains all v1.3.0 features: `verifyOne`, `evaluateMany`, `runV21`, `waitForTerminalDecision`, `risk-score` extraction, `evaluations` batch input parsing, `GateInfraError` detection in the batch catch block, and the full `@atlasent/enforce` package inlined. No rebuild is needed before tagging v1.3.0.
- **`dist/index.js` for v1.2.0 is not separately preserved** — the current bundle is v1.3.0. To cut v1.2.0 faithfully, the correct approach is to identify the commit where `target-id` and `risk-score` were added (before the v1.3.0 batch/streaming changes) and tag that commit. The new workflow's rebuild step will produce the correct v1.2.0 bundle when the tag is pushed.
- **Existing `release.yaml` is superseded.** It only ran on `release: published` (a manual event) and did nothing but move the major tag. The new `release.yml` is the full automation. The old `release.yaml` is left in place — it will only fire if someone publishes a release manually through the GitHub UI, which is now redundant but harmless.

## Test plan

- [ ] Merge this PR to main.
- [ ] Identify the commit on main (or a prior branch) that introduced `target-id` input and `risk-score` output (pre-batch changes). Push `git tag v1.2.0 <that-sha> && git push origin v1.2.0`. Verify the release workflow runs, rebuilds dist/ if needed, creates the v1.2.0 GitHub Release, and moves `v1` tag.
- [ ] Push `git tag v1.3.0 && git push origin v1.3.0` at HEAD of main. Verify: release workflow creates v1.3.0 release with correct CHANGELOG notes; `v1` floating tag moves to v1.3.0; Marketplace listing shows v1.3.0.
- [ ] Confirm `dist/index.js` in the v1.3.0 release includes all features listed in the v1.3.0 CHANGELOG (batch path, verify-permit round-trip, ECONNRESET fix, etc.).
- [ ] Run the dogfood smoke test from issue #25 acceptance criteria: bump a consumer pipeline from `@v1.0.0` → `@v1.3.0` and verify the `verify-permit` round-trip and `wait-for-id` path.

https://claude.ai/code/session_01GRhVSNm28VDzE4vmHXLPTN

---
_Generated by [Claude Code](https://claude.ai/code/session_01GRhVSNm28VDzE4vmHXLPTN)_