### PR TITLE
chore(release): consolidate to v0.1.0 — first marketplace-ready release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,163 +2,125 @@
 
 All notable changes to `atlasent-action` are documented here.
 
-## [Unreleased]
+## [0.1.0] — 2026-05-01 — initial public release
 
-## [1.3.0] — 2026-04-30
+This is the first version-stable release. Earlier internal tags
+(`v1.0.0` 2026-04-17, plus the source-only `v1.2.0` and `v1.3.0`
+milestones) are superseded — they were aspirational version markers
+during pre-release development and were never adopted by external
+consumers. Resetting to `0.1.0` aligns the version contract with
+SemVer (`0.x` while the public surface is still settling) and gives
+us room to stabilise inputs/outputs before committing to the
+SemVer-1.0 promise.
 
-### Bug fixes
-- **`wait-for-id` allow path was permanently broken** — when
-  `waitForTerminalDecision` resolved a hold/escalate to `allow`,
-  `v21.ts` assigned the terminal decision without calling `verifyOne`.
-  `verified` was always `undefined`, so `allVerified` was always
-  `false`. The hold → allow path now calls `verifyOne` on the terminal
-  permit (no `permitToken` → `verified=false`, fail-closed).
-- **`decisions` and `batch-id` outputs unset on batch error** —
-  the `runV21()` catch block only wrote `verified=false` before
-  `setFailed`. Downstream steps using `if: always()` got unset values.
-  Now emits `decisions=[]` and `batch-id=""` before failing.
-- **Transport ECONNRESET crash** — `packages/enforce/src/transport.ts`
-  had no `res.on("error")` handler. A mid-response connection reset
-  fired an unhandled EventEmitter error and crashed Node.js. Fixed by
-  adding `res.on("error", reject)` alongside `req.on("error", reject)`.
-- **Polling retried 5xx but not network errors** — `waitViaPolling`
-  swallowed non-2xx responses but let `fetch` throws (network errors,
-  malformed-JSON 200s) propagate immediately, breaking the retry
-  contract. Both cases now swallowed and retried; `AbortError` is
-  re-thrown so caller cancellation still works.
-- **Raw `SyntaxError` leaked on bad `evaluations`/`context` JSON** —
-  `parseInputs` called `JSON.parse` without try/catch; invalid JSON
-  surfaced as `Unexpected error: SyntaxError: ...`. Now reports
-  `` `evaluations` is not valid JSON `` and `` `context` is not valid
-  JSON ``.
-- **`GateInfraError` labelled "Unexpected error"** — the batch catch
-  block in `index.ts` only recognised `EnforceError` for clean message
-  formatting. `GateInfraError` from `verifyOne` on a 5xx appeared as
-  `Unexpected error: verify-permit HTTP 500`. Now detected alongside
-  `EnforceError`.
+### Action
 
-### Action — v1-verify-permit wiring (A5 end-to-end)
-- `verified` output: `"true"` only when evaluate returned `decision=allow`
-  AND `/v1/verify-permit` confirmed `verified=true`; `"false"` in every
-  other case. Downstream steps must branch on `verified`, not re-derive
-  from `decision`.
-- `src/gate.ts`: `verifyOne()` and `GateInfraError` for the verify-permit
-  round-trip; infrastructure failures (network, 5xx, 401, 429, no
-  permit_token) are always fail-closed. Single-eval enforcement delegated
-  to `@atlasent/enforce`; `verifyOne()` is used by the v2.1 batch path.
-- 9 SIM tests (`src/__tests__/gate.test.ts`) for `verifyOne()`.
-- `permit-token` output is an audit reference (single-use, already consumed).
-- Replay protection: stale or consumed `permit_token` → `verified=false`.
+- **`evaluate` step** — calls `POST /v1-evaluate` before any
+  deployment step executes. Threads `actor`, `action`, `target-id`,
+  `bundle-id`, `change_window`, `approvals`, and arbitrary `context`
+  into the request.
+- **`verify-permit` step (A5)** — calls `POST /v1/verify-permit`
+  after evaluate returns `decision: allow`. Closes the audit record
+  and confirms the permit hasn't been revoked or already consumed.
+  `verified` output is `"true"` only when both gates pass; `"false"`
+  otherwise. Downstream steps must branch on `verified`, not
+  re-derive from `decision`.
+- **v2.1 batch entry point (B.AC4)** — `evaluations` input accepts
+  a JSON array; the v2.1 path (`runV21` → `evaluateMany` →
+  per-decision `verifyOne`) is used in place of single-eval when set.
+- **`wait-for-id` / `wait-timeout-ms`** — block on a hold/escalate
+  decision until the upstream approver flips it (SSE stream or
+  polling fallback).
+- **`v2-batch` / `v2-streaming` flags** — opt in to
+  `/v1/evaluate/batch` and SSE streaming respectively.
 
-### Action — v2.1 batch entry point (B.AC4)
-- `evaluations` input: JSON array of evaluation requests for batch
-  mode. When set, `action` / `actor` / `context` are ignored and the
-  v2.1 path (`runV21` → `evaluateMany` → per-decision `verifyOne`) is
-  used instead of the single-eval path.
-- `wait-for-id`, `wait-timeout-ms` inputs: block on a hold/escalate
-  decision until the upstream approver flips it (SSE stream or polling).
-- `v2-batch`, `v2-streaming` flags: opt in to `/v1/evaluate/batch` and
-  SSE streaming respectively.
-- `decisions` output: JSON array of per-item results for the batch path.
-- `batch-id` output: server-assigned batch ID (or `loop-<ts>` for the
-  sequential fallback).
-- `verified` on the batch path: `"true"` only when every allow decision
-  verified; `"false"` otherwise.
-- 6 batch SIM tests (`src/__tests__/batch.test.ts`).
+### Outputs
 
-### `@atlasent/enforce` — verifyPermit step
-- `verifyPermit(config, decision)`: calls POST `/v1/verify-permit`;
+- `decision` — `allow` / `deny` / `hold` / `escalate`.
+- `permit-token` — single-use, audit reference (already consumed by
+  the verify-permit step).
+- `decision-id` — UUID for audit-trail correlation.
+- `audit-hash` — tamper-evident context hash.
+- `verified` — `"true"` only when verify-permit succeeded.
+- `risk-score` — numeric risk score from the Decision response.
+  Probes `result.risk.score` first (atlasent-api openapi
+  `Decision.risk` shape), falls back to `result.risk_score` for
+  older evaluators. Empty string when neither is present so
+  `if: steps.gate.outputs.risk-score` doesn't see `undefined`.
+- `decisions` (batch path) — JSON array of per-item results.
+- `batch-id` (batch path) — server-assigned batch ID, or
+  `loop-<ts>` for the sequential fallback.
+
+### Inputs
+
+- `api-key`, `agent`, `action`, `bundle-id`, `target-id`,
+  `change_window`, `approvals`, `context`, `evaluations`,
+  `wait-for-id`, `wait-timeout-ms`, `v2-batch`, `v2-streaming`.
+
+### `@atlasent/enforce` (workspace package, v0.1.0)
+
+- `enforce()` — orchestrator: `evaluate → verify → verifyPermit →
+  execute`. The user-supplied `fn` never runs unless all three
+  gates pass.
+- `verifyPermit(config, decision)` — `POST /v1-verify-permit`;
   throws `EnforceError(phase="verify-permit")` for replay, expired
-  tokens, no permit_token, network errors, and `!2xx` responses.
-- `enforce()` updated: `evaluate → verify → verifyPermit → execute`.
-  `fn` never runs unless all three gates pass. Return gains
-  `verifyOutcome`.
-- New `EnforcePhase` value: `"verify-permit"`.
-- 14 SIM tests (`verify-permit.test.ts`); `enforce.test.ts` updated to
-  mock both evaluate and verify-permit calls.
-- 5 socket-level tests (`transport.test.ts`) covering success, request
-  error, response-stream error (ECONNRESET), timeout, and header forwarding.
-- Built `packages/enforce/dist/` (`index.js`, `index.d.ts`, `transport.js`).
+  tokens, missing `permit_token`, network errors, and `!2xx`
+  responses.
+- `EnforcePhase` enum: `evaluate | verify | verify-permit | execute`.
 
-### Action — v21 + stream SIM tests
-- 10 SIM tests for `runV21()` (`src/__tests__/v21.test.ts`): items passed
-  to `evaluateMany`, single action wrapped into a 1-item batch, batchId
-  forwarded, `failed` flag respects `failOnDeny`, `waitForTerminalDecision`
-  called/skipped based on `waitForId` matching a hold/escalate id.
-  Dependencies mocked via `vi.mock()`.
-- 8 SIM tests for `waitForTerminalDecision()` (`src/__tests__/stream.test.ts`),
-  covering the polling path (immediate allow/deny, non-terminal retry,
-  timeout) and the SSE streaming path (terminal event, non-terminal skip,
-  body shape, non-2xx error).
-- Timeout test uses `vi.useFakeTimers()` / `vi.advanceTimersByTimeAsync()`
-  to avoid real 5-second poll intervals in CI.
+### Fail-closed behaviour
 
-### CI
-- `test.yml`: `Check evaluate step present` updated to grep `src/batch.ts`
-  for `v1/evaluate` instead of the removed `runGate()` path in `src/gate.ts`.
+Every error path blocks the workflow:
 
-### Action — enforce unification
-- Single-eval path now uses `@atlasent/enforce` as the canonical
-  enforcement wrapper; `runGate()` (parallel fetch-based implementation)
-  removed from production code. `src/gate.ts` now only exports
-  `verifyOne()` and `GateInfraError` for the v2.1 batch path.
-- `@atlasent/enforce` added as a workspace dependency; esbuild bundles
-  it into `dist/index.js`.
-- Default `api-url` changed from the Supabase function base to
-  `https://api.atlasent.io` to match the enforce package's default and
-  the current REST API.
-- `fail-on-deny=false` behaviour preserved: only `phase="verify"` errors
-  (policy decisions) respect the flag; all other phases remain
-  fail-closed.
-- Gate SIM tests retargeted: 18 `runGate()` tests replaced with 9
-  focused `verifyOne()` tests (`src/__tests__/gate.test.ts`).
+- API unreachable, request timeout, or 5xx → step fails.
+- Evaluator returns no `permit_token` for an `allow` → step fails.
+- Verify-permit returns `verified: false` → `verified` output is
+  `"false"`, step continues if `failOnDeny=false`, fails otherwise.
+- Replay or consumed permit → `verified: false`, fail-closed.
+- Malformed JSON in `evaluations` / `context` inputs → typed error
+  message (no raw `SyntaxError` leakage).
+- Hold / escalate → step fails when `failOnDeny=true`; gates
+  downstream steps via `decision != "allow"` regardless.
 
-### Workflows
-- `deploy.yaml`: fixed stale inputs (`atlasent_api_key` → `api-key`,
-  removed `atlasent_anon_key`/`approvals`/`change_window`) and stale
-  outputs (`decision_id` → `evaluation-id`, `audit_hash` →
-  `proof-hash`) to match current `action.yml`.
-- `test.yml`: grep targets corrected to `src/gate.ts`; build,
-  typecheck, and test steps added to CI.
+### Reliability fixes baked in
 
-## [1.2.0] — 2026-04-25
+- `transport.ts` handles mid-response `ECONNRESET` cleanly
+  (`res.on("error", reject)` alongside `req.on("error", reject)`).
+  Earlier internal builds crashed Node.js on the unhandled emitter.
+- `waitViaPolling` retries both 5xx and `fetch` throws (network
+  errors, malformed-JSON 200s); `AbortError` is re-thrown so
+  caller cancellation still works.
+- Batch error path emits `decisions=[]` and `batch-id=""` before
+  failing so downstream `if: always()` steps see defined values.
+- `wait-for-id` allow path: when polling resolves a hold/escalate
+  to `allow`, `verifyOne` is called on the terminal permit (no
+  `permitToken` → `verified=false`, fail-closed).
 
-### Added
-- `target-id` input — identifies the resource being acted on (service
-  name, artifact id, etc). Threaded into both top-level `target_id`
-  and `context.target_id` in the evaluate request so policies can
-  gate on _what_ is being deployed in addition to _who_ is deploying.
-- `risk-score` output — exposes the numeric risk score from the
-  Decision response. Probes the canonical `result.risk.score` shape
-  first (matches atlasent-api openapi `Decision.risk`) and falls back
-  to a flat `result.risk_score` for older evaluators. Empty string
-  when neither is present so downstream `if: steps.gate.outputs.risk-score`
-  branches don't see `undefined`.
+### Test surface (99 unit tests)
 
-### Notes
-- Source-only release. `dist/index.js` must be rebuilt
-  (`npm run build`) before tagging — release engineering tracks the
-  rebuild step.
+- `src/__tests__/gate.test.ts` — 9 SIM tests for `verifyOne()`.
+- `src/__tests__/batch.test.ts` — 6 batch SIM tests.
+- `src/__tests__/inputs.test.ts` — JSON parsing + error message tests.
+- `packages/enforce/src/__tests__/verify-permit.test.ts` — 14 SIM tests.
+- `packages/enforce/src/__tests__/transport.test.ts` — 5 socket-level tests.
+- `packages/enforce/src/__tests__/enforce.test.ts` — orchestrator tests.
 
-## [1.0.0] — 2026-04-17
+### GitHub Actions job summary
 
-### Added
-- `evaluate` step: calls `/v1-evaluate` before any deployment step executes
-- `verify` step: calls `/v1-verify-permit` after execution to close the audit record
-- `permit_token` output: single-use token passed from evaluate to verify
-- `decision_id` output: UUID for audit trail correlation
-- `audit_hash` output: tamper-evident context hash
-- `verified` output: boolean confirming execution-time permit validation
-- Fail-closed behavior: any API error, network timeout, or missing decision blocks the workflow
-- GitHub Actions job summary table with decision, actor, SHA, branch, and reason
-- Support for `change_window` and `approvals` context inputs for GxP environments
-- `atlasent_base_url` input for self-hosted AtlaSent deployments
+Renders a markdown table with decision, actor, SHA, branch, reason,
+permit-token, audit-hash for every run (success or failure).
 
-### Security
-- Permit tokens are single-use and expire after 5 minutes
-- All API calls use `--max-time 30` to prevent indefinite hangs
-- Fail-closed: missing or malformed responses block the workflow
+### GxP support
+
+`change_window` and `approvals` context inputs ride through to the
+evaluator without modification, enabling deny-on-out-of-window and
+deny-on-missing-approval policies in regulated environments.
 
 ## [0.x] — Pre-release
 
-Internal development and beta testing.
+The repository's earlier `v1.0.0` (2026-04-17), source-only
+`v1.2.0` (2026-04-25), and source-only `v1.3.0` (2026-04-30)
+milestones predate this release. They were not adopted by external
+consumers and are not represented as separate Marketplace releases.
+All shipped behaviour from those milestones is documented under
+`[0.1.0]` above.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "atlasent-action",
-  "version": "1.3.0",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "atlasent-action",
-      "version": "1.3.0",
+      "version": "0.1.0",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -2284,7 +2284,7 @@
     },
     "packages/enforce": {
       "name": "@atlasent/enforce",
-      "version": "0.2.0",
+      "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atlasent-action",
-  "version": "1.3.0",
+  "version": "0.1.0",
   "description": "GitHub Action for AtlaSent authorization gates — require a permit before critical CI/CD actions execute",
   "main": "dist/index.js",
   "workspaces": ["packages/*"],

--- a/packages/enforce/package.json
+++ b/packages/enforce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atlasent/enforce",
-  "version": "0.2.0",
+  "version": "0.1.0",
   "description": "Fail-closed execution wrapper enforcing the AtlaSent evaluate → verify → execute contract",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Resets the version contract to start at `0.1.0` and consolidates the CHANGELOG so the eventual `v0.1.0` git tag points at a commit whose code, lockfile, and CHANGELOG all read `0.1.0`.

## Why

Confirmed on 2026-05-01: the existing `v1.0.0` (2026-04-17), source-only `v1.2.0` (2026-04-25), and source-only `v1.3.0` (2026-04-30) milestones were aspirational version markers during pre-release development and were **not** adopted by external consumers. We're treating this commit as the actual first marketplace-ready release.

Resetting to `0.x`:
- Matches the SemVer convention that the wire/input/output surface is still settling — we don't owe consumers the SemVer-1.0 stability promise yet.
- Eliminates the historical-ambiguity problem (no SHA on `main` had `package.json = 1.2.0` AND a built `dist/index.js` that bundled v1.2.0 source — the v1.2.0 CHANGELOG entry literally said "Source-only release. dist/index.js must be rebuilt before tagging — release engineering tracks the rebuild step", and the rebuild never happened).
- Lets us delete the old `v1.0.0` tag entirely so it doesn't dangle as a misleading reference.

## Changes

- `package.json`: `1.3.0 → 0.1.0`
- `packages/enforce/package.json`: `0.2.0 → 0.1.0`
- `package-lock.json`: regenerated
- `CHANGELOG.md`: collapsed `[Unreleased]` / `[1.3.0]` / `[1.2.0]` / `[1.0.0]` blocks into a single `[0.1.0] — 2026-05-01` entry crediting all shipped behaviour (A5 verify-permit wiring, B.AC4 v2.1 batch path, transport ECONNRESET fix, `wait-for-id` allow-path fix, `decisions`/`batch-id` defined-on-error, JSON error message hardening, `GateInfraError` labelling, `target-id` input, `risk-score` output). A `[0.x] — Pre-release` block summarises the earlier internal milestones and points back at `[0.1.0]` as the source of truth.
- `dist/index.js`: rebuilt for parity. **Byte-identical** to the pre-bump bundle (version isn't compiled into the runtime), so no behaviour change ships in this PR.

## Test plan

- [x] `npm install` succeeds, lockfile regenerates clean
- [x] `npm run build` produces `dist/index.js` matching the committed bundle
- [x] `npm run typecheck` — clean (`atlasent-action@0.1.0`)
- [x] `npm test` — 99/99 pass
- [ ] CI green on this PR

## After merge — tag operations (run from your workstation; the proxy here blocks tag pushes)

The `v1.0.0` tag is on origin from 2026-04-17 with a matching GitHub Release. The plan you confirmed: zero real consumers, so deletion is safe.

```bash
# Get to the merge SHA on main
git fetch origin
git checkout main
git pull --ff-only origin main

# Delete the old aspirational tag from local + remote.
git push origin :refs/tags/v1.0.0
git tag -d v1.0.0
# Then delete the v1.0.0 GitHub Release in the UI (Releases → v1.0.0 → Delete).

# Tag this PR's merge commit as the real v0.1.0.
git tag -a v0.1.0 HEAD -m "v0.1.0 — initial public release"
git push origin v0.1.0
```

Then cut a `v0.1.0` GitHub Release using the body I drafted earlier this session (under the v1.3.0 release-notes draft — same content, retitled).

## What this PR does NOT do

- **Does not push or delete any tags** (proxy gate; you run those locally).
- **Does not move any floating tag.** No `v1` will exist after this — consumers pin `@v0.1.0` until the SemVer-1.0 promise is committed.
- **Does not change runtime behaviour.** `dist/index.js` is byte-identical; the only diff anyone consuming this code sees is the version metadata.

https://claude.ai/code/session_01Qfvx7yHLm8xi76Gvfc6Pxz

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qfvx7yHLm8xi76Gvfc6Pxz)_