### PR TITLE
Mask API key immediately and add least-privilege permissions

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -22,6 +22,9 @@ on:
           - staging
         default: prod
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,9 @@ on:
     branches: [main, 'claude/**']
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test-action-syntax:
     runs-on: ubuntu-latest

--- a/dist/index.js
+++ b/dist/index.js
@@ -557,6 +557,7 @@ function setDecisionOutputs(d) {
 }
 async function run() {
   const apiKey = getInput("api-key", true);
+  maskValue(apiKey);
   const apiUrl = getInput("api-url") || "https://api.atlasent.io";
   const failOnDeny = getInput("fail-on-deny") !== "false";
   maskValue(apiKey);

--- a/src/index.ts
+++ b/src/index.ts
@@ -113,6 +113,12 @@ function setDecisionOutputs(d: Decision): void {
 async function run(): Promise<void> {
   // 1. Read shared inputs
   const apiKey = getInput("api-key", true);
+  // Mask immediately on the literal next line so any code path that
+  // logs / reflects this value before the explicit mask call below has
+  // no chance to print the plaintext key. The maskValue() call below
+  // is kept as defense-in-depth (idempotent).
+  maskValue(apiKey);
+
   const apiUrl = getInput("api-url") || "https://api.atlasent.io";
   const failOnDeny = getInput("fail-on-deny") !== "false";
 


### PR DESCRIPTION
## Summary

This PR improves security in two ways:

1. **Mask API key immediately**: The `apiKey` is now masked on the line immediately after retrieval in the `run()` function. This ensures that any code path logging or reflecting the value before the explicit mask call below has no chance to print the plaintext key. The explicit mask call is retained as defense-in-depth (since `maskValue()` is idempotent).

2. **Add least-privilege permissions**: Both GitHub Actions workflows (`deploy.yaml` and `test.yml`) now explicitly declare `permissions: contents: read`, following the principle of least privilege. This restricts the workflows to only the minimum permissions needed.

## Test plan

- Existing CI tests pass
- No functional changes to action behavior

https://claude.ai/code/session_01Mbwfd7bu8ebEuX49xS9CaB