### PR TITLE
Tighten workflow permissions and mask api-key earlier

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -22,6 +22,9 @@ on:
           - staging
         default: prod
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,9 @@ on:
     branches: [main, 'claude/**']
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test-action-syntax:
     runs-on: ubuntu-latest

--- a/dist/index.js
+++ b/dist/index.js
@@ -557,6 +557,7 @@ function setDecisionOutputs(d) {
 }
 async function run() {
   const apiKey = getInput("api-key", true);
+  maskValue(apiKey);
   const apiUrl = getInput("api-url") || "https://api.atlasent.io";
   const failOnDeny = getInput("fail-on-deny") !== "false";
   maskValue(apiKey);

--- a/src/index.ts
+++ b/src/index.ts
@@ -113,6 +113,12 @@ function setDecisionOutputs(d: Decision): void {
 async function run(): Promise<void> {
   // 1. Read shared inputs
   const apiKey = getInput("api-key", true);
+  // Mask immediately on the literal next line so any code path that
+  // logs / reflects this value before the explicit mask call below has
+  // no chance to print the plaintext key. The maskValue() call below
+  // is kept as defense-in-depth (idempotent).
+  maskValue(apiKey);
+
   const apiUrl = getInput("api-url") || "https://api.atlasent.io";
   const failOnDeny = getInput("fail-on-deny") !== "false";
 


### PR DESCRIPTION
## Summary

Phase C of the cross-repo security audit (SECURITY_PLAN.md):

- Add explicit `permissions: { contents: read }` to `test.yml` and `deploy.yaml` so they no longer inherit the repo-default `write-all` GITHUB_TOKEN. `release.yaml` already declares per-job permissions.
- Move `maskValue(apiKey)` to the literal next line after `getInput("api-key")` so any future log line in the intervening block (or a thrown-error path that reflects its own arguments) cannot expose the plaintext key. Existing call below the URL/flag reads is kept as idempotent defense-in-depth.
- Rebuild `dist/index.js` so the published action picks up the change — without this commit the bundle would still ship the old ordering.

## Test plan

- [x] 99/99 unit tests pass (`npm test`)
- [x] `npm run build` regenerates `dist/index.js` cleanly
- [ ] Verify a manual workflow_dispatch run shows `***` masking in logs
- [ ] Confirm `permissions:` blocks don't break any existing CI job

https://claude.ai/code/session_01Mbwfd7bu8ebEuX49xS9CaB

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mbwfd7bu8ebEuX49xS9CaB)_