### PR TITLE
Clarify OIDC docs; lockfile drift check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,9 +34,25 @@ jobs:
         with:
           node-version: '20'
 
-      - name: Build and typecheck
+      - name: Install dependencies (lockfile-strict)
+        # `npm ci` refuses to drift package-lock.json from package.json,
+        # so a pull request that touches one without the other fails
+        # here rather than installing whatever the latest registry has.
+        run: npm ci
+
+      - name: Lockfile integrity check
+        # Defense-in-depth: even with `npm ci`, an install hook or a
+        # postinstall script in a transitive dep could mutate the
+        # lockfile in place. Refuse to proceed if the file changed.
         run: |
-          npm install
+          if ! git diff --quiet -- package-lock.json; then
+            echo "::error::package-lock.json drifted during install — a transitive dep may be rewriting it. Investigate before merging."
+            git --no-pager diff -- package-lock.json | head -200
+            exit 1
+          fi
+
+      - name: Typecheck and build
+        run: |
           npm run typecheck
           npm run build
 

--- a/README.md
+++ b/README.md
@@ -115,11 +115,13 @@ For long-running approvals such as change-window gates, enable `v2-streaming` to
 
 When `v2-streaming` is `false` (the default) the action falls back to 5-second HTTP polling — behaviour is identical, only the transport differs.
 
-## OIDC / keyless identity
+## GitHub identity in the policy context
 
 The `actor` input defaults to `${{ github.actor }}`, so no additional identity setup is needed. The action automatically embeds the GitHub username in the evaluation context sent to AtlaSent.
 
-To use keyless policies, ensure your AtlaSent policy references GitHub usernames or teams directly (e.g. `actor == "github:octocat"` or `actor in team:"github:platform-eng"`). No extra OIDC token exchange is required — the `api-key` authenticates the workflow, and `actor` carries the human identity for policy evaluation.
+> **Not OIDC.** Earlier versions of this README described the flow as "OIDC / keyless identity," which was misleading. There is no OIDC token exchange happening. The `api-key` is what authenticates the workflow against the AtlaSent API; the GitHub `actor` value is just a string that the action embeds in the evaluation context so policies can branch on the human identity. If you want a true OIDC trust between GitHub and AtlaSent (no long-lived API key), file a feature request — the wire today does not support it.
+
+To branch on GitHub identity, write your AtlaSent policy against the `actor` field directly (e.g. `actor == "github:octocat"` or `actor in team:"github:platform-eng"`).
 
 ```yaml
 - uses: AtlaSent-Systems-Inc/atlasent-action@v1


### PR DESCRIPTION
## Summary

Two LOW findings from the cross-repo audit (SECURITY_PLAN.md / atlasent-action):

1. **README "OIDC / keyless identity" wording was misleading** — there is no OIDC token exchange in this action. The `api-key` still authenticates; the GitHub `actor` is just a string embedded in the evaluation context so policies can branch on human identity. Section heading is now **"GitHub identity in the policy context"** with an explicit "Not OIDC" callout.

2. **`test.yml` lockfile integrity** — the workflow ran `npm install` rather than `npm ci`, so a PR that touched `package.json` without updating `package-lock.json` would silently install whatever the latest registry had instead of the pinned tree. Switched to `npm ci` and added a follow-up `git diff --quiet -- package-lock.json` step that fails the run if a transitive dep's install hook rewrote the lockfile in place.

## Test plan

- [x] 99/99 unit tests still pass (no source changes)
- [ ] Confirm CI on this PR passes the new lockfile-drift step
- [ ] Visual check: README renders cleanly with the updated section

https://claude.ai/code/session_01Mbwfd7bu8ebEuX49xS9CaB

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mbwfd7bu8ebEuX49xS9CaB)_