### PR TITLE
feat: add index tests, remove duplicate verify-permit, drop ::set-output

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -81,6 +81,15 @@ outputs:
     description: 'Batch identifier for the v2.1 batch path (either the server-assigned batchId or loop-<ts> for the sequential fallback).'
   financial-governance-advice:
     description: 'JSON advisory output from financial governance assessment'
+  chain-entry:
+    description: 'v1.1 immutable audit chain entry (JSON)'
+    value: ${{ steps.gate.outputs.chain-entry }}
+  snapshot:
+    description: 'Decision snapshot (JSON)'
+    value: ${{ steps.gate.outputs.snapshot }}
+  audit-hash:
+    description: 'SHA-256 audit chain hash'
+    value: ${{ steps.gate.outputs.audit-hash }}
 runs:
   using: 'node24'
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,22 +1,233 @@
 "use strict";
+var __create = Object.create;
+var __defProp = Object.defineProperty;
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+var __getOwnPropNames = Object.getOwnPropertyNames;
+var __getProtoOf = Object.getPrototypeOf;
+var __hasOwnProp = Object.prototype.hasOwnProperty;
+var __commonJS = (cb, mod) => function __require() {
+  return mod || (0, cb[__getOwnPropNames(cb)[0]])((mod = { exports: {} }).exports, mod), mod.exports;
+};
+var __copyProps = (to, from, except, desc) => {
+  if (from && typeof from === "object" || typeof from === "function") {
+    for (let key of __getOwnPropNames(from))
+      if (!__hasOwnProp.call(to, key) && key !== except)
+        __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+  }
+  return to;
+};
+var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__getProtoOf(mod)) : {}, __copyProps(
+  // If the importer is in node compatibility mode or this is not an ESM
+  // file that has been converted to a CommonJS file using a Babel-
+  // compatible transform (i.e. "__esModule" has not been set), then set
+  // "default" to the CommonJS "module.exports" for node compatibility.
+  isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", { value: mod, enumerable: true }) : target,
+  mod
+));
 
-// dist/index.js — self-contained CommonJS bundle for atlasent-action.
-// Generated from src/index.ts, src/gate.ts, src/batch.ts, src/stream.ts,
-// src/inputs.ts, src/types.ts, src/v21.ts.
-// Regenerate with: npm run build
+// packages/enforce/dist/transport.js
+var require_transport = __commonJS({
+  "packages/enforce/dist/transport.js"(exports2) {
+    "use strict";
+    var __importDefault = exports2 && exports2.__importDefault || function(mod) {
+      return mod && mod.__esModule ? mod : { "default": mod };
+    };
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    exports2.post = post;
+    var node_https_1 = __importDefault(require("node:https"));
+    var node_http_1 = __importDefault(require("node:http"));
+    function post(url, body, headers) {
+      return new Promise((resolve, reject) => {
+        const parsed = new URL(url);
+        const transport = parsed.protocol === "https:" ? node_https_1.default : node_http_1.default;
+        const req = transport.request({
+          hostname: parsed.hostname,
+          port: parsed.port || (parsed.protocol === "https:" ? 443 : 80),
+          path: parsed.pathname + parsed.search,
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "Content-Length": Buffer.byteLength(body),
+            ...headers
+          },
+          timeout: 3e4
+        }, (res) => {
+          const chunks = [];
+          res.on("data", (chunk) => chunks.push(chunk));
+          res.on("end", () => resolve({ status: res.statusCode ?? 0, body: Buffer.concat(chunks).toString("utf-8") }));
+          res.on("error", reject);
+        });
+        req.on("error", reject);
+        req.on("timeout", () => {
+          req.destroy();
+          reject(new Error("Request timed out after 30s"));
+        });
+        req.write(body);
+        req.end();
+      });
+    }
+  }
+});
 
-// ---------------------------------------------------------------------------
-// src/gate.ts — verify-permit helper
-// ---------------------------------------------------------------------------
+// packages/enforce/dist/index.js
+var require_dist = __commonJS({
+  "packages/enforce/dist/index.js"(exports2) {
+    "use strict";
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    exports2.EnforceError = void 0;
+    exports2.evaluate = evaluate;
+    exports2.verify = verify;
+    exports2.verifyPermit = verifyPermit;
+    exports2.enforce = enforce2;
+    var transport_1 = require_transport();
+    var DEFAULT_API_URL = "https://api.atlasent.io";
+    var EnforceError2 = class extends Error {
+      phase;
+      decision;
+      constructor(message, phase, decision = null) {
+        super(message);
+        this.name = "EnforceError";
+        this.phase = phase;
+        this.decision = decision;
+      }
+    };
+    exports2.EnforceError = EnforceError2;
+    async function evaluate(config) {
+      const apiUrl = (config.apiUrl ?? DEFAULT_API_URL).replace(/\/$/, "");
+      const payload = {
+        action_type: config.action,
+        actor_id: config.actor,
+        context: {
+          ...config.environment ? { environment: config.environment } : {},
+          ...config.targetId ? { target_id: config.targetId } : {},
+          ...config.context
+        }
+      };
+      if (config.targetId)
+        payload["target_id"] = config.targetId;
+      let status;
+      let body;
+      try {
+        ({ status, body } = await (0, transport_1.post)(`${apiUrl}/v1/evaluate`, JSON.stringify(payload), {
+          Authorization: `Bearer ${config.apiKey}`
+        }));
+      } catch (err) {
+        throw new EnforceError2(`AtlaSent API unreachable: ${err instanceof Error ? err.message : String(err)}`, "evaluate");
+      }
+      if (status >= 500) {
+        throw new EnforceError2(`Infrastructure failure (HTTP ${status})`, "evaluate");
+      }
+      if (status === 401 || status === 403) {
+        throw new EnforceError2(`Authentication failed (HTTP ${status})`, "evaluate");
+      }
+      if (status === 429) {
+        throw new EnforceError2("Rate limited (HTTP 429)", "evaluate");
+      }
+      if (status < 200 || status >= 300) {
+        throw new EnforceError2(`Unexpected response (HTTP ${status})`, "evaluate");
+      }
+      let raw;
+      try {
+        raw = JSON.parse(body);
+      } catch {
+        throw new EnforceError2("Non-JSON response from AtlaSent API", "evaluate");
+      }
+      return mapDecision(raw);
+    }
+    function verify(decision) {
+      switch (decision.decision) {
+        case "allow":
+          return;
+        case "deny":
+          throw new EnforceError2(`Denied: ${decision.denyReason ?? "no reason provided"}`, "verify", decision);
+        case "hold":
+          throw new EnforceError2(`On hold: ${decision.holdReason ?? "awaiting approval"}`, "verify", decision);
+        case "escalate":
+          throw new EnforceError2("Escalated \u2014 manual review required", "verify", decision);
+        default:
+          throw new EnforceError2(`Unknown decision: ${String(decision.decision)}`, "verify", decision);
+      }
+    }
+    async function verifyPermit(config, decision) {
+      if (!decision.permitToken) {
+        throw new EnforceError2("evaluate returned allow but no permit_token \u2014 refusing to execute without verifiable permit", "verify-permit", decision);
+      }
+      const apiUrl = (config.apiUrl ?? DEFAULT_API_URL).replace(/\/$/, "");
+      let status;
+      let body;
+      try {
+        ({ status, body } = await (0, transport_1.post)(`${apiUrl}/v1/verify-permit`, JSON.stringify({
+          permit_token: decision.permitToken,
+          action_type: config.action,
+          actor_id: config.actor
+        }), { Authorization: `Bearer ${config.apiKey}` }));
+      } catch (err) {
+        throw new EnforceError2(`verify-permit unreachable: ${err instanceof Error ? err.message : String(err)}`, "verify-permit", decision);
+      }
+      if (status >= 500) {
+        throw new EnforceError2(`verify-permit infrastructure failure (HTTP ${status})`, "verify-permit", decision);
+      }
+      if (status < 200 || status >= 300) {
+        throw new EnforceError2(`verify-permit failed (HTTP ${status})`, "verify-permit", decision);
+      }
+      let raw;
+      try {
+        raw = JSON.parse(body);
+      } catch {
+        throw new EnforceError2("Non-JSON response from verify-permit", "verify-permit", decision);
+      }
+      if (raw.verified !== true) {
+        throw new EnforceError2(`Permit verification failed (outcome=${raw.outcome ?? "unknown"})`, "verify-permit", decision);
+      }
+      return { verified: true, outcome: raw.outcome };
+    }
+    async function enforce2(config, fn) {
+      const decision = await evaluate(config);
+      verify(decision);
+      const vp = await verifyPermit(config, decision);
+      const result = await fn();
+      return { result, decision, verifyOutcome: vp.outcome };
+    }
+    function mapDecision(raw) {
+      return {
+        decision: raw["decision"],
+        evaluationId: raw["evaluation_id"],
+        permitToken: raw["permit_token"],
+        proofHash: raw["proof_hash"],
+        riskScore: extractRiskScore(raw),
+        denyReason: raw["deny_reason"],
+        holdReason: raw["hold_reason"],
+        chainEntry: raw["chain_entry"] ?? null,
+        snapshot: raw["snapshot"] ?? null,
+        auditHash: raw["audit_hash"]
+      };
+    }
+    function extractRiskScore(raw) {
+      const risk = raw["risk"];
+      if (risk && typeof risk === "object" && "score" in risk) {
+        const score = risk.score;
+        if (typeof score === "number")
+          return score;
+      }
+      const flat = raw["risk_score"];
+      if (typeof flat === "number")
+        return flat;
+      return void 0;
+    }
+  }
+});
 
-class GateInfraError extends Error {
+// src/index.ts
+var import_enforce = __toESM(require_dist());
+
+// src/gate.ts
+var GateInfraError = class extends Error {
   constructor(message, statusCode) {
     super(message);
-    this.name = "GateInfraError";
     this.statusCode = statusCode;
+    this.name = "GateInfraError";
   }
-}
-
+};
 async function verifyOne(params) {
   const path = params.verifyPath ?? "/v1-verify-permit";
   let res;
@@ -25,17 +236,17 @@ async function verifyOne(params) {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `Bearer ${params.apiKey}`,
+        Authorization: `Bearer ${params.apiKey}`
       },
       body: JSON.stringify({
         permit_token: params.permitToken,
         action_type: params.actionType,
-        actor_id: params.actorId,
-      }),
+        actor_id: params.actorId
+      })
     });
   } catch (err) {
     throw new GateInfraError(
-      `verify-permit unreachable: ${err instanceof Error ? err.message : String(err)}`,
+      `verify-permit unreachable: ${err instanceof Error ? err.message : String(err)}`
     );
   }
   if (!res.ok) {
@@ -50,24 +261,19 @@ async function verifyOne(params) {
   return { verified: body.verified === true, outcome: body.outcome };
 }
 
-// ---------------------------------------------------------------------------
-// src/batch.ts — batch fan-out helper
-// ---------------------------------------------------------------------------
-
+// src/batch.ts
 async function evaluateMany(apiUrl, apiKey, items, v2Batch) {
   const headers = {
     "content-type": "application/json",
-    authorization: `Bearer ${apiKey}`,
+    authorization: `Bearer ${apiKey}`
   };
-
   let decisions;
   let batchId;
-
   if (v2Batch) {
     const r = await fetch(`${apiUrl}/v1/evaluate/batch`, {
       method: "POST",
       headers,
-      body: JSON.stringify({ items }),
+      body: JSON.stringify({ items })
     });
     if (!r.ok) {
       throw new Error(`atlasent /v1/evaluate/batch ${r.status}`);
@@ -81,7 +287,7 @@ async function evaluateMany(apiUrl, apiKey, items, v2Batch) {
       const r = await fetch(`${apiUrl}/v1/evaluate`, {
         method: "POST",
         headers,
-        body: JSON.stringify(item),
+        body: JSON.stringify(item)
       });
       if (!r.ok) {
         throw new Error(`atlasent /v1/evaluate ${r.status}`);
@@ -90,11 +296,10 @@ async function evaluateMany(apiUrl, apiKey, items, v2Batch) {
     }
     batchId = `loop-${Date.now()}`;
   }
-
   const verified = await Promise.all(
     decisions.map(async (d, i) => {
       if (d.decision !== "allow" || !d.permitToken) {
-        return { ...d, verified: d.decision === "allow" ? false : undefined };
+        return { ...d, verified: d.decision === "allow" ? false : void 0 };
       }
       const item = items[i];
       const result = await verifyOne({
@@ -103,39 +308,87 @@ async function evaluateMany(apiUrl, apiKey, items, v2Batch) {
         actionType: item.action,
         actorId: item.actor,
         permitToken: d.permitToken,
-        verifyPath: "/v1/verify-permit",
+        verifyPath: "/v1/verify-permit"
       });
       return { ...d, verified: result.verified, verifyOutcome: result.outcome };
-    }),
+    })
   );
-
   return { decisions: verified, batchId };
 }
 
-// ---------------------------------------------------------------------------
-// src/stream.ts — streaming-wait helper
-// ---------------------------------------------------------------------------
+// src/inputs.ts
+function parseInputs(env) {
+  const apiKey = required(env, "INPUT_API-KEY");
+  const apiUrl = env["INPUT_API-URL"] || "https://api.atlasent.io";
+  const failOnDeny = (env["INPUT_FAIL-ON-DENY"] || "true") === "true";
+  const evaluationsRaw = env["INPUT_EVALUATIONS"];
+  if (evaluationsRaw && evaluationsRaw.trim()) {
+    let parsed;
+    try {
+      parsed = JSON.parse(evaluationsRaw);
+    } catch {
+      throw new Error("`evaluations` is not valid JSON \u2014 expected a JSON array of evaluation requests");
+    }
+    if (!Array.isArray(parsed) || parsed.length === 0) {
+      throw new Error(
+        "`evaluations` must be a non-empty JSON array of evaluation requests"
+      );
+    }
+    return {
+      apiKey,
+      apiUrl,
+      failOnDeny,
+      evaluations: parsed,
+      waitForId: env["INPUT_WAIT-FOR-ID"] || void 0,
+      waitTimeoutMs: parseInt(env["INPUT_WAIT-TIMEOUT-MS"] || "600000", 10)
+    };
+  }
+  const action = required(env, "INPUT_ACTION");
+  const actor = env["INPUT_ACTOR"] || env["GITHUB_ACTOR"] || "unknown";
+  const environment = env["INPUT_ENVIRONMENT"];
+  const contextRaw = env["INPUT_CONTEXT"] || "{}";
+  let context = {};
+  try {
+    context = JSON.parse(contextRaw);
+  } catch {
+    throw new Error("`context` is not valid JSON \u2014 expected a JSON object");
+  }
+  return {
+    apiKey,
+    apiUrl,
+    failOnDeny,
+    single: { action, actor, environment, context },
+    waitForId: env["INPUT_WAIT-FOR-ID"] || void 0,
+    waitTimeoutMs: parseInt(env["INPUT_WAIT-TIMEOUT-MS"] || "600000", 10)
+  };
+}
+function required(env, key) {
+  const v = env[key];
+  if (!v) {
+    throw new Error(`Missing required input: ${key.replace("INPUT_", "").toLowerCase()}`);
+  }
+  return v;
+}
 
-const POLL_INTERVAL_MS = 5_000;
-const SSE_LINE = /^data: (.+)$/;
-
+// src/stream.ts
+var POLL_INTERVAL_MS = 5e3;
+var SSE_LINE = /^data: (.+)$/;
 async function waitForTerminalDecision(opts) {
   if (opts.v2Streaming) {
     return waitViaStream(opts);
   }
   return waitViaPolling(opts);
 }
-
 async function waitViaStream(opts) {
   const r = await fetch(`${opts.apiUrl}/v1/evaluate/stream`, {
     method: "POST",
     headers: {
       "content-type": "application/json",
       authorization: `Bearer ${opts.apiKey}`,
-      accept: "text/event-stream",
+      accept: "text/event-stream"
     },
     body: JSON.stringify({ evaluationId: opts.evaluationId }),
-    signal: opts.signal,
+    signal: opts.signal
   });
   if (!r.ok || !r.body) {
     throw new Error(`atlasent /v1/evaluate/stream ${r.status}`);
@@ -146,7 +399,8 @@ async function waitViaStream(opts) {
   let buf = "";
   while (Date.now() < deadline) {
     const { value, done } = await reader.read();
-    if (done) break;
+    if (done)
+      break;
     buf += decoder.decode(value, { stream: true });
     let idx;
     while ((idx = buf.indexOf("\n\n")) !== -1) {
@@ -154,7 +408,8 @@ async function waitViaStream(opts) {
       buf = buf.slice(idx + 2);
       for (const line of block.split("\n")) {
         const m = SSE_LINE.exec(line);
-        if (!m) continue;
+        if (!m)
+          continue;
         const event = JSON.parse(m[1]);
         if (event.decision === "allow" || event.decision === "deny") {
           return event;
@@ -163,10 +418,9 @@ async function waitViaStream(opts) {
     }
   }
   throw new Error(
-    `atlasent stream timeout after ${opts.timeoutMs}ms for ${opts.evaluationId}`,
+    `atlasent stream timeout after ${opts.timeoutMs}ms for ${opts.evaluationId}`
   );
 }
-
 async function waitViaPolling(opts) {
   const deadline = Date.now() + opts.timeoutMs;
   while (Date.now() < deadline) {
@@ -175,8 +429,8 @@ async function waitViaPolling(opts) {
         `${opts.apiUrl}/v1/evaluate/${encodeURIComponent(opts.evaluationId)}`,
         {
           headers: { authorization: `Bearer ${opts.apiKey}` },
-          signal: opts.signal,
-        },
+          signal: opts.signal
+        }
       );
       if (r.ok) {
         const decision = await r.json();
@@ -185,175 +439,161 @@ async function waitViaPolling(opts) {
         }
       }
     } catch (err) {
-      if (err instanceof Error && err.name === "AbortError") throw err;
+      if (err instanceof Error && err.name === "AbortError")
+        throw err;
     }
     await new Promise((res) => setTimeout(res, POLL_INTERVAL_MS));
   }
   throw new Error(
-    `atlasent poll timeout after ${opts.timeoutMs}ms for ${opts.evaluationId}`,
+    `atlasent poll timeout after ${opts.timeoutMs}ms for ${opts.evaluationId}`
   );
 }
 
-// ---------------------------------------------------------------------------
-// src/inputs.ts — input parser
-// ---------------------------------------------------------------------------
-
-function parseInputs(env) {
-  const apiKey = requiredInput(env, "INPUT_API-KEY");
-  const apiUrl = env["INPUT_API-URL"] || "https://api.atlasent.io";
-  const failOnDeny = (env["INPUT_FAIL-ON-DENY"] || "true") === "true";
-
-  const evaluationsRaw = env["INPUT_EVALUATIONS"];
-  if (evaluationsRaw && evaluationsRaw.trim()) {
-    let parsed;
-    try {
-      parsed = JSON.parse(evaluationsRaw);
-    } catch {
-      throw new Error("`evaluations` is not valid JSON — expected a JSON array of evaluation requests");
-    }
-    if (!Array.isArray(parsed) || parsed.length === 0) {
-      throw new Error("`evaluations` must be a non-empty JSON array of evaluation requests");
-    }
-    return {
-      apiKey,
-      apiUrl,
-      failOnDeny,
-      evaluations: parsed,
-      waitForId: env["INPUT_WAIT-FOR-ID"] || undefined,
-      waitTimeoutMs: parseInt(env["INPUT_WAIT-TIMEOUT-MS"] || "600000", 10),
-    };
-  }
-
-  const action = requiredInput(env, "INPUT_ACTION");
-  const actor = env["INPUT_ACTOR"] || env["GITHUB_ACTOR"] || "unknown";
-  const environment = env["INPUT_ENVIRONMENT"];
-  const contextRaw = env["INPUT_CONTEXT"] || "{}";
-  let context = {};
-  try {
-    context = JSON.parse(contextRaw);
-  } catch {
-    throw new Error("`context` is not valid JSON — expected a JSON object");
-  }
-
-  return {
-    apiKey,
-    apiUrl,
-    failOnDeny,
-    single: { action, actor, environment, context },
-    waitForId: env["INPUT_WAIT-FOR-ID"] || undefined,
-    waitTimeoutMs: parseInt(env["INPUT_WAIT-TIMEOUT-MS"] || "600000", 10),
-  };
-}
-
-function requiredInput(env, key) {
-  const v = env[key];
-  if (!v) {
-    throw new Error(`Missing required input: ${key.replace("INPUT_", "").toLowerCase()}`);
-  }
-  return v;
-}
-
-// ---------------------------------------------------------------------------
-// src/v21.ts — v2.1 entry point
-// ---------------------------------------------------------------------------
-
+// src/v21.ts
 async function runV21(env, flags) {
   const inputs = parseInputs(env);
   const items = inputs.evaluations ?? [inputs.single];
-
   const batch = await evaluateMany(
     inputs.apiUrl,
     inputs.apiKey,
     items,
-    flags.v2Batch,
+    flags.v2Batch
   );
-
   let decisions = batch.decisions;
-
   if (inputs.waitForId) {
     const idx = decisions.findIndex(
-      (d) =>
-        d.id === inputs.waitForId &&
-        (d.decision === "hold" || d.decision === "escalate"),
+      (d) => d.id === inputs.waitForId && (d.decision === "hold" || d.decision === "escalate")
     );
     if (idx >= 0) {
       const terminal = await waitForTerminalDecision({
         apiUrl: inputs.apiUrl,
         apiKey: inputs.apiKey,
         evaluationId: inputs.waitForId,
-        timeoutMs: inputs.waitTimeoutMs ?? 600_000,
-        v2Streaming: flags.v2Streaming,
+        timeoutMs: inputs.waitTimeoutMs ?? 6e5,
+        v2Streaming: flags.v2Streaming
       });
       decisions = [...decisions];
       if (terminal.decision === "allow") {
         const item = items[idx];
-        const vr = terminal.permitToken
-          ? await verifyOne({
-              apiUrl: inputs.apiUrl,
-              apiKey: inputs.apiKey,
-              actionType: item.action,
-              actorId: item.actor,
-              permitToken: terminal.permitToken,
-              verifyPath: "/v1/verify-permit",
-            })
-          : { verified: false, outcome: undefined };
+        const vr = terminal.permitToken ? await verifyOne({
+          apiUrl: inputs.apiUrl,
+          apiKey: inputs.apiKey,
+          actionType: item.action,
+          actorId: item.actor,
+          permitToken: terminal.permitToken,
+          verifyPath: "/v1/verify-permit"
+        }) : { verified: false, outcome: void 0 };
         decisions[idx] = { ...terminal, verified: vr.verified, verifyOutcome: vr.outcome };
       } else {
         decisions[idx] = terminal;
       }
     }
   }
-
-  const failed =
-    inputs.failOnDeny &&
-    decisions.some(
-      (d) => d.decision === "deny" || d.decision === "hold" || d.decision === "escalate",
-    );
-
+  const failed = inputs.failOnDeny && decisions.some((d) => d.decision === "deny" || d.decision === "hold" || d.decision === "escalate");
   return { decisions, failed, batchId: batch.batchId };
 }
 
-// ---------------------------------------------------------------------------
-// src/index.ts — GitHub Actions entry point
-// ---------------------------------------------------------------------------
+// src/financialGovernanceAdvisory.ts
+var USD_EQUIVALENT_CURRENCIES = /* @__PURE__ */ new Set(["USD", "USDC", "USDT", "DAI"]);
+var REGULATORY_ACTION_TYPES = /* @__PURE__ */ new Set(["wire_transfer", "trading_execution"]);
+var TIER_LOW_MAX = 1e3;
+var TIER_MEDIUM_MAX = 5e4;
+var TIER_HIGH_MAX = 1e6;
+function computeRiskScore(value, tier) {
+  switch (tier) {
+    case "non_financial":
+      return 0;
+    case "low":
+      return Math.min(19, Math.round(value / TIER_LOW_MAX * 19));
+    case "medium":
+      return Math.min(49, 20 + Math.round((value - TIER_LOW_MAX) / (TIER_MEDIUM_MAX - TIER_LOW_MAX) * 29));
+    case "high":
+      return Math.min(79, 50 + Math.round((value - TIER_MEDIUM_MAX) / (TIER_HIGH_MAX - TIER_MEDIUM_MAX) * 29));
+    case "critical":
+      return Math.min(100, 80 + Math.round(Math.log10(value / TIER_HIGH_MAX) * 10));
+  }
+}
+function assessFinancialGovernance(input) {
+  const { actionType, actionValue, currency, actorId } = input;
+  const isUsdEquivalent = USD_EQUIVALENT_CURRENCIES.has(currency.toUpperCase());
+  if (!actionValue || actionValue <= 0 || !isUsdEquivalent) {
+    return {
+      adviceMode: "advisory",
+      riskTier: "non_financial",
+      riskScore: 0,
+      evidenceRequired: false,
+      signals: [],
+      summary: `Financial governance advisory: no financial action detected (actor=${actorId})`
+    };
+  }
+  let riskTier;
+  if (actionValue < TIER_LOW_MAX) {
+    riskTier = "low";
+  } else if (actionValue < TIER_MEDIUM_MAX) {
+    riskTier = "medium";
+  } else if (actionValue < TIER_HIGH_MAX) {
+    riskTier = "high";
+  } else {
+    riskTier = "critical";
+  }
+  const evidenceRequired = riskTier === "high" || riskTier === "critical";
+  const riskScore = computeRiskScore(actionValue, riskTier);
+  const signals = [];
+  if (riskTier === "high" || riskTier === "critical") {
+    signals.push(
+      `High-value financial action ($${actionValue.toLocaleString("en-US", { maximumFractionDigits: 2 })}) \u2014 quorum approval recommended`
+    );
+  }
+  if (evidenceRequired) {
+    signals.push("Evidence bundle required for audit trail");
+  }
+  if (REGULATORY_ACTION_TYPES.has(actionType)) {
+    signals.push(
+      `Action type '${actionType}' has regulatory reporting implications`
+    );
+  }
+  const summary = `Financial governance advisory: ${riskTier.toUpperCase()} risk | $${actionValue.toLocaleString("en-US", { maximumFractionDigits: 2 })} ${currency} | score=${riskScore} | evidenceRequired=${evidenceRequired} | actor=${actorId}`;
+  return {
+    adviceMode: "advisory",
+    riskTier,
+    riskScore,
+    evidenceRequired,
+    signals,
+    summary
+  };
+}
 
-const { enforce, EnforceError } = require("@atlasent/enforce");
-
-function getInput(name, required = false) {
+// src/index.ts
+function getInput(name, required2 = false) {
   const envKey = `INPUT_${name.replace(/-/g, "_").toUpperCase()}`;
   const val = (process.env[envKey] ?? "").trim();
-  if (required && !val) {
+  if (required2 && !val) {
     setFailed(`Input required and not supplied: ${name}`);
   }
   return val;
 }
-
 function setOutput(name, value) {
   const outputFile = process.env["GITHUB_OUTPUT"];
   if (outputFile) {
     const fs = require("node:fs");
-    fs.appendFileSync(outputFile, `${name}=${value}\n`);
+    fs.appendFileSync(outputFile, `${name}=${value}
+`);
   }
   console.log(`::set-output name=${name}::${value}`);
 }
-
 function setFailed(message) {
   console.log(`::error::${message}`);
   process.exit(1);
 }
-
 function warning(message) {
   console.log(`::warning::${message}`);
 }
-
 function info(message) {
   console.log(message);
 }
-
 function maskValue(value) {
   console.log(`::add-mask::${value}`);
 }
-
 function getGitHubContext() {
   return {
     repository: process.env["GITHUB_REPOSITORY"] ?? "",
@@ -364,45 +604,114 @@ function getGitHubContext() {
     workflow: process.env["GITHUB_WORKFLOW"] ?? "",
     event_name: process.env["GITHUB_EVENT_NAME"] ?? "",
     pr_number: process.env["GITHUB_REF"]?.match(/^\/refs\/pull\/(\d+)\//)?.[1],
-    server_url: process.env["GITHUB_SERVER_URL"] ?? "https://github.com",
+    server_url: process.env["GITHUB_SERVER_URL"] ?? "https://github.com"
   };
 }
-
 function resolveEnvironment(explicit, ref, apiKey) {
-  if (explicit) return explicit;
-  if (apiKey.startsWith("ask_test_")) return "test";
-  if (apiKey.startsWith("ask_live_")) return "live";
+  if (explicit)
+    return explicit;
+  if (apiKey.startsWith("ask_test_"))
+    return "test";
+  if (apiKey.startsWith("ask_live_"))
+    return "live";
   const branch = ref.replace("refs/heads/", "");
   return branch === "main" || branch === "master" ? "live" : "test";
 }
-
 function setDecisionOutputs(d) {
-  if (d.permitToken) maskValue(d.permitToken);
-  if (d.proofHash) maskValue(d.proofHash);
+  if (d.permitToken)
+    maskValue(d.permitToken);
+  if (d.proofHash)
+    maskValue(d.proofHash);
   setOutput("decision", d.decision);
   setOutput("permit-token", d.permitToken ?? "");
   setOutput("evaluation-id", d.evaluationId ?? "");
   setOutput("proof-hash", d.proofHash ?? "");
-  setOutput("risk-score", d.riskScore !== undefined ? String(d.riskScore) : "");
+  setOutput("risk-score", d.riskScore !== void 0 ? String(d.riskScore) : "");
+  setOutput("chain-entry", JSON.stringify(d.chainEntry ?? null));
+  setOutput("snapshot", JSON.stringify(d.snapshot ?? null));
+  setOutput("audit-hash", d.auditHash ?? "");
 }
-
+function appendToStepSummary(content) {
+  const summaryFile = process.env["GITHUB_STEP_SUMMARY"];
+  if (summaryFile) {
+    try {
+      const fs = require("node:fs");
+      fs.appendFileSync(summaryFile, content);
+    } catch {
+    }
+  }
+}
+function emitFinancialGovernanceAdvisory(actionType, actor, orgId) {
+  const governanceMode = getInput("financial-governance");
+  if (governanceMode !== "advisory")
+    return;
+  const rawValue = getInput("financial-action-value");
+  const currency = getInput("financial-action-currency") || "USD";
+  const actionValue = rawValue ? parseFloat(rawValue) : null;
+  const advisoryInput = {
+    actionType,
+    actionValue: actionValue !== null && !isNaN(actionValue) ? actionValue : null,
+    currency,
+    actorId: actor,
+    orgId
+  };
+  let advisory;
+  try {
+    advisory = assessFinancialGovernance(advisoryInput);
+  } catch {
+    warning("Financial governance advisory: assessment failed (non-fatal)");
+    return;
+  }
+  setOutput("financial-governance-advice", JSON.stringify(advisory));
+  info(`[Financial Governance Advisory] ${advisory.summary}`);
+  for (const signal of advisory.signals) {
+    info(`  \u2022 ${signal}`);
+  }
+  const tierEmoji = {
+    non_financial: "\u26AA",
+    low: "\u{1F7E2}",
+    medium: "\u{1F7E1}",
+    high: "\u{1F7E0}",
+    critical: "\u{1F534}"
+  };
+  const emoji = tierEmoji[advisory.riskTier] ?? "\u26AA";
+  const signalLines = advisory.signals.length > 0 ? advisory.signals.map((s) => `- ${s}`).join("\n") : "- No advisory signals";
+  const summaryBlock = [
+    "",
+    "---",
+    `## ${emoji} Financial Governance Advisory`,
+    "",
+    `| Field | Value |`,
+    `|---|---|`,
+    `| Risk Tier | \`${advisory.riskTier}\` |`,
+    `| Risk Score | ${advisory.riskScore} / 100 |`,
+    `| Evidence Required | ${advisory.evidenceRequired ? "**Yes**" : "No"} |`,
+    `| Action Type | \`${actionType}\` |`,
+    `| Actor | \`${actor}\` |`,
+    `| Currency | ${currency} |`,
+    actionValue !== null ? `| Action Value | $${actionValue.toLocaleString("en-US", { maximumFractionDigits: 2 })} |` : `| Action Value | N/A |`,
+    "",
+    "### Advisory Signals",
+    "",
+    signalLines,
+    "",
+    "> **Advisory only** \u2014 this assessment is non-blocking and does not affect enforcement decisions.",
+    ""
+  ].join("\n");
+  appendToStepSummary(summaryBlock);
+}
 async function run() {
   const apiKey = getInput("api-key", true);
   maskValue(apiKey);
-
   const apiUrl = getInput("api-url") || "https://api.atlasent.io";
   const failOnDeny = getInput("fail-on-deny") !== "false";
-
   maskValue(apiKey);
-
-  // v2.1 batch path
   const evaluationsRaw = getInput("evaluations");
   if (evaluationsRaw) {
-    const waitForId = getInput("wait-for-id") || undefined;
+    const waitForId = getInput("wait-for-id") || void 0;
     const waitTimeoutMs = parseInt(getInput("wait-timeout-ms") || "600000", 10);
     const v2Batch = getInput("v2-batch") === "true";
     const v2Streaming = getInput("v2-streaming") === "true";
-
     let result;
     try {
       result = await runV21(
@@ -412,79 +721,66 @@ async function run() {
           "INPUT_FAIL-ON-DENY": failOnDeny ? "true" : "false",
           INPUT_EVALUATIONS: evaluationsRaw,
           "INPUT_WAIT-FOR-ID": waitForId,
-          "INPUT_WAIT-TIMEOUT-MS": String(waitTimeoutMs),
+          "INPUT_WAIT-TIMEOUT-MS": String(waitTimeoutMs)
         },
-        { v2Batch, v2Streaming },
+        { v2Batch, v2Streaming }
       );
     } catch (err) {
-      const msg =
-        err instanceof EnforceError || err instanceof GateInfraError
-          ? err.message
-          : `Unexpected error: ${err instanceof Error ? err.message : String(err)}`;
+      const msg = err instanceof import_enforce.EnforceError || err instanceof GateInfraError ? err.message : `Unexpected error: ${err instanceof Error ? err.message : String(err)}`;
       setOutput("verified", "false");
       setOutput("decisions", "[]");
       setOutput("batch-id", "");
       setFailed(`AtlaSent Gate (batch): ${msg}. Deploy blocked (fail-closed).`);
       return;
     }
-
     const decisionsJson = JSON.stringify(
-      result.decisions.map((d) => ({
-        decision: d.decision,
-        verified: d.verified ?? false,
-        evaluationId: d.id ?? "",
-        permitToken: d.permitToken ? "(masked)" : "",
-        reasons: d.reasons ?? [],
-        verifyOutcome: d.verifyOutcome ?? "",
-      })),
+      result.decisions.map((d2) => ({
+        decision: d2.decision,
+        verified: d2.verified ?? false,
+        evaluationId: d2.id ?? "",
+        permitToken: d2.permitToken ? "(masked)" : "",
+        reasons: d2.reasons ?? [],
+        verifyOutcome: d2.verifyOutcome ?? ""
+      }))
     );
-
     const allVerified = result.decisions.every(
-      (d) => d.decision !== "allow" || d.verified === true,
+      (d2) => d2.decision !== "allow" || d2.verified === true
     );
-
     setOutput("batch-id", result.batchId);
     setOutput("decisions", decisionsJson);
     setOutput("verified", allVerified ? "true" : "false");
-
     if (result.failed) {
       setFailed(
-        `AtlaSent Gate: one or more evaluations were not allowed (deny/hold/escalate). See 'decisions' output for details.`,
+        `AtlaSent Gate: one or more evaluations were not allowed (deny/hold/escalate). See 'decisions' output for details.`
       );
       return;
     }
     if (!allVerified) {
       setFailed(
-        `AtlaSent Gate: one or more allow decisions failed permit verification. Deploy blocked.`,
+        `AtlaSent Gate: one or more allow decisions failed permit verification. Deploy blocked.`
       );
       return;
     }
-
     info(`AtlaSent Gate: all ${result.decisions.length} evaluation(s) allowed and verified`);
     info(`  Batch ID: ${result.batchId}`);
     return;
   }
-
-  // Single-eval path via @atlasent/enforce
   const actionType = getInput("action", true);
   const actor = getInput("actor") || "unknown";
-  const targetId = getInput("target-id") || undefined;
+  const targetId = getInput("target-id") || void 0;
   const explicitEnv = getInput("environment");
   let extraContext = {};
   try {
     extraContext = JSON.parse(getInput("context") || "{}");
   } catch {
-    warning("Could not parse 'context' input as JSON — ignoring");
+    warning("Could not parse 'context' input as JSON \u2014 ignoring");
   }
-
   const gh = getGitHubContext();
   const environment = resolveEnvironment(explicitEnv, gh.ref, apiKey);
-
+  const orgId = gh.repository.split("/")[0] ?? "unknown";
   info(
-    `AtlaSent Gate: evaluating "${actionType}" for actor "github:${actor}" in ${environment} environment` +
-      (targetId ? ` (target=${targetId})` : ""),
+    `AtlaSent Gate: evaluating "${actionType}" for actor "github:${actor}" in ${environment} environment` + (targetId ? ` (target=${targetId})` : "")
   );
-
   const config = {
     apiKey,
     apiUrl,
@@ -503,15 +799,15 @@ async function run() {
       event_name: gh.event_name,
       pr_number: gh.pr_number ?? null,
       run_url: `${gh.server_url}/${gh.repository}/actions/runs/${gh.run_id}`,
-      ...extraContext,
-    },
+      ...extraContext
+    }
   };
-
   let enforceResult;
   try {
-    enforceResult = await enforce(config, async () => {});
+    enforceResult = await (0, import_enforce.enforce)(config, async () => {
+    });
   } catch (err) {
-    if (err instanceof EnforceError) {
+    if (err instanceof import_enforce.EnforceError) {
       if (err.decision) {
         setDecisionOutputs(err.decision);
       } else {
@@ -520,9 +816,12 @@ async function run() {
         setOutput("evaluation-id", "");
         setOutput("proof-hash", "");
         setOutput("risk-score", "");
+        setOutput("chain-entry", JSON.stringify(null));
+        setOutput("snapshot", JSON.stringify(null));
+        setOutput("audit-hash", "");
       }
       setOutput("verified", "false");
-
+      emitFinancialGovernanceAdvisory(actionType, actor, orgId);
       if (err.phase === "verify" && !failOnDeny) {
         switch (err.decision?.decision) {
           case "deny":
@@ -532,34 +831,33 @@ async function run() {
             warning(`Authorization on HOLD: ${err.decision.holdReason ?? "awaiting approval"}`);
             break;
           case "escalate":
-            warning("Authorization ESCALATED — manual review required");
+            warning("Authorization ESCALATED \u2014 manual review required");
             break;
           default:
             warning(`Authorization ${err.decision?.decision ?? "unknown"}`);
         }
         return;
       }
-
       switch (err.phase) {
         case "evaluate":
           setFailed(
-            `AtlaSent Gate: ${err.message}. Deploy blocked — the gate cannot confirm authorization (fail-closed).`,
+            `AtlaSent Gate: ${err.message}. Deploy blocked \u2014 the gate cannot confirm authorization (fail-closed).`
           );
           break;
         case "verify":
           switch (err.decision?.decision) {
             case "deny":
               setFailed(
-                `Authorization DENIED: ${err.decision.denyReason ?? "no reason provided"}`,
+                `Authorization DENIED: ${err.decision.denyReason ?? "no reason provided"}`
               );
               break;
             case "hold":
               setFailed(
-                `Authorization on HOLD: ${err.decision.holdReason ?? "awaiting approval"}`,
+                `Authorization on HOLD: ${err.decision.holdReason ?? "awaiting approval"}`
               );
               break;
             case "escalate":
-              setFailed("Authorization ESCALATED — manual review required");
+              setFailed("Authorization ESCALATED \u2014 manual review required");
               break;
             default:
               setFailed(`Unexpected decision from AtlaSent: ${err.decision?.decision ?? "unknown"}`);
@@ -567,7 +865,7 @@ async function run() {
           break;
         case "verify-permit":
           setFailed(
-            `AtlaSent Gate: ${err.message}. Deploy blocked (fail-closed).`,
+            `AtlaSent Gate: ${err.message}. Deploy blocked (fail-closed).`
           );
           break;
         default:
@@ -575,31 +873,33 @@ async function run() {
       }
       return;
     }
-
     setOutput("decision", "error");
     setOutput("permit-token", "");
     setOutput("evaluation-id", "");
     setOutput("proof-hash", "");
     setOutput("risk-score", "");
+    setOutput("chain-entry", JSON.stringify(null));
+    setOutput("snapshot", JSON.stringify(null));
+    setOutput("audit-hash", "");
     setOutput("verified", "false");
+    emitFinancialGovernanceAdvisory(actionType, actor, orgId);
     setFailed(
-      `AtlaSent Gate: Unexpected error: ${err instanceof Error ? err.message : String(err)}`,
+      `AtlaSent Gate: Unexpected error: ${err instanceof Error ? err.message : String(err)}`
     );
     return;
   }
-
   const { decision: d, verifyOutcome } = enforceResult;
   setDecisionOutputs(d);
   setOutput("verified", "true");
-
   info(`Authorization GRANTED (evaluate + verify)`);
   info(`  Permit token: (set as 'permit-token' output, masked in logs)`);
   info(`  Proof hash:   (set as 'proof-hash' output, masked in logs)`);
   info(`  Evaluation:   ${d.evaluationId ?? ""}`);
-  if (d.riskScore !== undefined) info(`  Risk score:   ${d.riskScore}`);
+  if (d.riskScore !== void 0)
+    info(`  Risk score:   ${d.riskScore}`);
   info(`  Verify:       ${verifyOutcome ?? "verified"}`);
+  emitFinancialGovernanceAdvisory(actionType, actor, orgId);
 }
-
 run().catch((err) => {
   console.log(`::error::Unexpected error: ${err instanceof Error ? err.message : String(err)}`);
   process.exit(1);

--- a/packages/enforce/dist/index.d.ts
+++ b/packages/enforce/dist/index.d.ts
@@ -15,6 +15,10 @@ export interface Decision {
     riskScore?: number;
     denyReason?: string;
     holdReason?: string;
+    /** v1.1 audit chain fields — present when the API returns them. */
+    chainEntry?: Record<string, unknown> | null;
+    snapshot?: Record<string, unknown> | null;
+    auditHash?: string;
 }
 export interface VerifyPermitResult {
     verified: boolean;

--- a/packages/enforce/dist/index.js
+++ b/packages/enforce/dist/index.js
@@ -154,6 +154,9 @@ function mapDecision(raw) {
         riskScore: extractRiskScore(raw),
         denyReason: raw["deny_reason"],
         holdReason: raw["hold_reason"],
+        chainEntry: raw["chain_entry"] ?? null,
+        snapshot: raw["snapshot"] ?? null,
+        auditHash: raw["audit_hash"],
     };
 }
 function extractRiskScore(raw) {

--- a/packages/enforce/src/index.ts
+++ b/packages/enforce/src/index.ts
@@ -32,6 +32,10 @@ export interface Decision {
   riskScore?: number;
   denyReason?: string;
   holdReason?: string;
+  /** v1.1 audit chain fields — present when the API returns them. */
+  chainEntry?: Record<string, unknown> | null;
+  snapshot?: Record<string, unknown> | null;
+  auditHash?: string;
 }
 
 export interface VerifyPermitResult {
@@ -246,6 +250,9 @@ function mapDecision(raw: Record<string, unknown>): Decision {
     riskScore: extractRiskScore(raw),
     denyReason: raw["deny_reason"] as string | undefined,
     holdReason: raw["hold_reason"] as string | undefined,
+    chainEntry: (raw["chain_entry"] as Record<string, unknown> | null | undefined) ?? null,
+    snapshot: (raw["snapshot"] as Record<string, unknown> | null | undefined) ?? null,
+    auditHash: raw["audit_hash"] as string | undefined,
   };
 }
 

--- a/src/__tests__/batch.test.ts
+++ b/src/__tests__/batch.test.ts
@@ -1,11 +1,19 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { evaluateMany } from "../batch";
 
+// Mock @atlasent/enforce so verifyPermit uses a test double rather than the
+// real HTTP transport. fetch is still needed for the evaluate calls.
+vi.mock("@atlasent/enforce", () => ({ verifyPermit: vi.fn() }));
+
+import { verifyPermit } from "@atlasent/enforce";
+const mockVerifyPermit = verifyPermit as ReturnType<typeof vi.fn>;
+
 describe("evaluateMany", () => {
   const fetchMock = vi.fn();
 
   beforeEach(() => {
     fetchMock.mockReset();
+    mockVerifyPermit.mockReset();
     vi.stubGlobal("fetch", fetchMock);
   });
 
@@ -19,22 +27,16 @@ describe("evaluateMany", () => {
     );
   }
 
-  function verifyResp(verified = true, outcome = "ok") {
-    return new Response(JSON.stringify({ verified, outcome }));
-  }
-
   it("hits /v1/evaluate/batch when v2Batch=true and verifies allow decisions", async () => {
-    fetchMock
-      .mockResolvedValueOnce(
-        new Response(
-          JSON.stringify({
-            results: [{ decision: "allow", evaluatedAt: "2026-04-25T00:00:00Z", permitToken: "tok1" }],
-            batchId: "b1",
-          }),
-        ),
-      )
-      // verify call for the allow decision
-      .mockResolvedValueOnce(verifyResp(true, "ok"));
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          results: [{ decision: "allow", evaluatedAt: "2026-04-25T00:00:00Z", permitToken: "tok1" }],
+          batchId: "b1",
+        }),
+      ),
+    );
+    mockVerifyPermit.mockResolvedValueOnce({ verified: true, outcome: "ok" });
 
     const out = await evaluateMany(
       "https://api.test",
@@ -49,23 +51,17 @@ describe("evaluateMany", () => {
       "https://api.test/v1/evaluate/batch",
       expect.anything(),
     );
-    expect(fetchMock).toHaveBeenCalledWith(
-      "https://api.test/v1/verify-permit",
-      expect.anything(),
-    );
+    expect(mockVerifyPermit).toHaveBeenCalledOnce();
   });
 
   it("loops /v1/evaluate when v2Batch=false and verifies each allow decision", async () => {
-    fetchMock
-      .mockImplementation((url: string) => {
-        if (url.endsWith("/v1/evaluate")) {
-          return Promise.resolve(evalResp("allow", "tok1"));
-        }
-        if (url.endsWith("/v1/verify-permit")) {
-          return Promise.resolve(verifyResp(true));
-        }
-        return Promise.reject(new Error(`unexpected url: ${url}`));
-      });
+    fetchMock.mockImplementation((url: string) => {
+      if (url.endsWith("/v1/evaluate")) {
+        return Promise.resolve(evalResp("allow", "tok1"));
+      }
+      return Promise.reject(new Error(`unexpected url: ${url}`));
+    });
+    mockVerifyPermit.mockResolvedValue({ verified: true, outcome: "ok" });
 
     const out = await evaluateMany(
       "https://api.test",
@@ -83,7 +79,7 @@ describe("evaluateMany", () => {
     expect(out.batchId).toMatch(/^loop-/);
   });
 
-  it("deny decisions are not verified (no verify call)", async () => {
+  it("deny decisions are not verified (no verifyPermit call)", async () => {
     fetchMock.mockImplementation(() =>
       Promise.resolve(new Response(JSON.stringify({ decision: "deny", evaluatedAt: "2026-04-25T00:00:00Z" }))),
     );
@@ -95,13 +91,14 @@ describe("evaluateMany", () => {
       false,
     );
 
-    // only the evaluate call — no verify call for deny
+    // only the evaluate call — no verifyPermit call for deny
     expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(mockVerifyPermit).not.toHaveBeenCalled();
     expect(out.decisions[0].decision).toBe("deny");
     expect(out.decisions[0].verified).toBeUndefined();
   });
 
-  it("allow with no permitToken → verified=false (no verify call)", async () => {
+  it("allow with no permitToken → verified=false (no verifyPermit call)", async () => {
     fetchMock.mockResolvedValueOnce(
       new Response(JSON.stringify({ decision: "allow", evaluatedAt: "2026-04-25T00:00:00Z" })),
     );
@@ -114,7 +111,8 @@ describe("evaluateMany", () => {
     );
 
     expect(out.decisions[0].verified).toBe(false);
-    // no verify call
+    expect(mockVerifyPermit).not.toHaveBeenCalled();
+    // only the evaluate call
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
@@ -125,13 +123,37 @@ describe("evaluateMany", () => {
     ).rejects.toThrow(/500/);
   });
 
-  it("throws on verify 5xx (fail-closed)", async () => {
-    fetchMock
-      .mockResolvedValueOnce(evalResp("allow", "tok1"))
-      .mockResolvedValueOnce(new Response("err", { status: 500 }));
+  it("throws on verifyPermit failure (fail-closed)", async () => {
+    fetchMock.mockResolvedValueOnce(evalResp("allow", "tok1"));
+    mockVerifyPermit.mockRejectedValueOnce(new Error("verify-permit infrastructure failure (HTTP 500)"));
 
     await expect(
       evaluateMany("https://api.test", "k", [{ action: "a", actor: "u" }], false),
-    ).rejects.toThrow(/verify-permit HTTP 500/);
+    ).rejects.toThrow(/verify-permit infrastructure failure/);
+  });
+
+  it("passes correct config and decision to verifyPermit", async () => {
+    fetchMock.mockResolvedValueOnce(evalResp("allow", "tok-xyz"));
+    mockVerifyPermit.mockResolvedValueOnce({ verified: true, outcome: "ok" });
+
+    await evaluateMany(
+      "https://api.test",
+      "api-key-123",
+      [{ action: "deploy.prod", actor: "alice" }],
+      false,
+    );
+
+    expect(mockVerifyPermit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiKey: "api-key-123",
+        apiUrl: "https://api.test",
+        action: "deploy.prod",
+        actor: "alice",
+      }),
+      expect.objectContaining({
+        decision: "allow",
+        permitToken: "tok-xyz",
+      }),
+    );
   });
 });

--- a/src/__tests__/gate.test.ts
+++ b/src/__tests__/gate.test.ts
@@ -1,103 +1,25 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { GateInfraError, verifyOne } from "../gate";
+import { describe, expect, it } from "vitest";
+import { GateInfraError } from "../gate";
 
-// SIM tests for verifyOne() — the verify-permit helper used by the v2.1
-// batch path (src/batch.ts). The single-eval path uses @atlasent/enforce
-// which has its own verify-permit test suite (packages/enforce).
+// The verifyOne() function was removed in favour of the canonical
+// verifyPermit() from @atlasent/enforce. Its tests live in
+// packages/enforce/src/__tests__/verify-permit.test.ts.
 
-describe("verifyOne", () => {
-  const fetchMock = vi.fn();
-
-  const PARAMS = {
-    apiUrl: "https://api.test",
-    apiKey: "ask_test_key",
-    actionType: "production_deploy",
-    actorId: "github:alice",
-    permitToken: "pt-abc",
-  };
-
-  beforeEach(() => {
-    fetchMock.mockReset();
-    vi.stubGlobal("fetch", fetchMock);
+describe("GateInfraError", () => {
+  it("is an instance of Error", () => {
+    const err = new GateInfraError("something went wrong");
+    expect(err).toBeInstanceOf(Error);
+    expect(err.message).toBe("something went wrong");
+    expect(err.name).toBe("GateInfraError");
   });
 
-  afterEach(() => {
-    vi.unstubAllGlobals();
+  it("stores an optional statusCode", () => {
+    const err = new GateInfraError("HTTP 500", 500);
+    expect(err.statusCode).toBe(500);
   });
 
-  function jsonResp(body: unknown, status = 200): Response {
-    return new Response(JSON.stringify(body), {
-      status,
-      headers: { "Content-Type": "application/json" },
-    });
-  }
-
-  // ── Happy path ──────────────────────────────────────────────────────────────
-
-  it("returns { verified: true, outcome } on success", async () => {
-    fetchMock.mockResolvedValueOnce(jsonResp({ verified: true, outcome: "ok" }));
-    const r = await verifyOne(PARAMS);
-    expect(r.verified).toBe(true);
-    expect(r.outcome).toBe("ok");
-  });
-
-  it("returns { verified: false } when server returns verified=false", async () => {
-    fetchMock.mockResolvedValueOnce(jsonResp({ verified: false, outcome: "permit_consumed" }));
-    const r = await verifyOne(PARAMS);
-    expect(r.verified).toBe(false);
-    expect(r.outcome).toBe("permit_consumed");
-  });
-
-  // ── Request shape ───────────────────────────────────────────────────────────
-
-  it("uses /v1-verify-permit by default", async () => {
-    fetchMock.mockResolvedValueOnce(jsonResp({ verified: true }));
-    await verifyOne(PARAMS);
-    expect(fetchMock.mock.calls[0][0]).toBe("https://api.test/v1-verify-permit");
-  });
-
-  it("uses custom verifyPath when provided", async () => {
-    fetchMock.mockResolvedValueOnce(jsonResp({ verified: true }));
-    await verifyOne({ ...PARAMS, verifyPath: "/v1/verify-permit" });
-    expect(fetchMock.mock.calls[0][0]).toBe("https://api.test/v1/verify-permit");
-  });
-
-  it("sends permit_token, action_type, actor_id in the request body", async () => {
-    fetchMock.mockResolvedValueOnce(jsonResp({ verified: true }));
-    await verifyOne(PARAMS);
-    const body = JSON.parse(fetchMock.mock.calls[0][1].body as string) as Record<string, unknown>;
-    expect(body.permit_token).toBe("pt-abc");
-    expect(body.action_type).toBe("production_deploy");
-    expect(body.actor_id).toBe("github:alice");
-  });
-
-  it("sends Authorization header with the api key", async () => {
-    fetchMock.mockResolvedValueOnce(jsonResp({ verified: true }));
-    await verifyOne(PARAMS);
-    const headers = fetchMock.mock.calls[0][1].headers as Record<string, string>;
-    expect(headers["Authorization"]).toBe("Bearer ask_test_key");
-  });
-
-  // ── Infrastructure errors ───────────────────────────────────────────────────
-
-  it("throws GateInfraError on transport error", async () => {
-    fetchMock.mockRejectedValueOnce(new Error("ECONNREFUSED"));
-    let caught: unknown;
-    await verifyOne(PARAMS).catch((e) => { caught = e; });
-    expect(caught).toBeInstanceOf(GateInfraError);
-    expect((caught as GateInfraError).message).toMatch(/verify-permit unreachable/);
-  });
-
-  it("throws GateInfraError on 5xx", async () => {
-    fetchMock.mockResolvedValueOnce(jsonResp({ error: "internal" }, 500));
-    let caught: unknown;
-    await verifyOne(PARAMS).catch((e) => { caught = e; });
-    expect(caught).toBeInstanceOf(GateInfraError);
-    expect((caught as GateInfraError).statusCode).toBe(500);
-  });
-
-  it("throws GateInfraError on non-JSON body", async () => {
-    fetchMock.mockResolvedValueOnce(new Response("not-json", { status: 200 }));
-    await expect(verifyOne(PARAMS)).rejects.toThrow(GateInfraError);
+  it("statusCode is undefined when not provided", () => {
+    const err = new GateInfraError("network error");
+    expect(err.statusCode).toBeUndefined();
   });
 });

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1,0 +1,299 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as os from "node:os";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+// Mock @atlasent/enforce before importing index so that enforce() is
+// intercepted. EnforceError must still be the real class so instanceof checks
+// in run() work correctly.
+vi.mock("@atlasent/enforce", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@atlasent/enforce")>();
+  return {
+    ...original,
+    enforce: vi.fn(),
+  };
+});
+
+import { enforce, EnforceError } from "@atlasent/enforce";
+import type { Decision } from "@atlasent/enforce";
+
+// Import run() after mocking to ensure the mock is in place.
+import { run } from "../index";
+
+const mockEnforce = enforce as unknown as ReturnType<typeof vi.fn>;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeDecision(overrides: Partial<Decision> = {}): Decision {
+  return {
+    decision: "allow",
+    evaluationId: "ev-test-1",
+    permitToken: "pt-test",
+    proofHash: "ph-test",
+    riskScore: 10,
+    ...overrides,
+  };
+}
+
+function makeAllowResult(decisionOverrides: Partial<Decision> = {}) {
+  return {
+    result: undefined,
+    decision: makeDecision(decisionOverrides),
+    verifyOutcome: "ok",
+  };
+}
+
+/** Reads the GITHUB_OUTPUT file and returns a map of name→value pairs. */
+function readOutputs(outputFile: string): Record<string, string> {
+  if (!fs.existsSync(outputFile)) return {};
+  const lines = fs.readFileSync(outputFile, "utf-8").split("\n").filter(Boolean);
+  const result: Record<string, string> = {};
+  for (const line of lines) {
+    const eqIdx = line.indexOf("=");
+    if (eqIdx !== -1) {
+      result[line.slice(0, eqIdx)] = line.slice(eqIdx + 1);
+    }
+  }
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Test setup
+// ---------------------------------------------------------------------------
+
+// Sentinel error thrown by mocked process.exit so run() is interrupted.
+class ProcessExitError extends Error {
+  constructor(public readonly code: number | string | null | undefined) {
+    super(`process.exit(${code})`);
+    this.name = "ProcessExitError";
+  }
+}
+
+let outputFile: string;
+let exitSpy: { mock: { calls: Array<Array<unknown>> }; mockClear: () => void };
+let consoleSpy: { mock: { calls: Array<Array<unknown>> }; mockClear: () => void };
+let savedEnv: NodeJS.ProcessEnv;
+
+beforeEach(() => {
+  // Use a fresh temp file for GITHUB_OUTPUT each test.
+  outputFile = path.join(os.tmpdir(), `gha-output-${Date.now()}-${Math.random()}.txt`);
+  savedEnv = { ...process.env };
+
+  // Clear action-related env vars.
+  for (const key of Object.keys(process.env)) {
+    if (key.startsWith("INPUT_") || key === "GITHUB_OUTPUT" || key.startsWith("GITHUB_")) {
+      delete process.env[key];
+    }
+  }
+
+  // Set GITHUB_OUTPUT so setOutput() writes to our temp file.
+  process.env["GITHUB_OUTPUT"] = outputFile;
+
+  // Mock process.exit to throw a sentinel so run() stops without ending the process.
+  exitSpy = vi.spyOn(process, "exit").mockImplementation(
+    (code?: number | string | null) => { throw new ProcessExitError(code); },
+  ) as unknown as typeof exitSpy;
+
+  consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {}) as unknown as typeof consoleSpy;
+
+  mockEnforce.mockReset();
+});
+
+afterEach(() => {
+  // Restore env.
+  for (const key of Object.keys(process.env)) {
+    if (!(key in savedEnv)) delete process.env[key];
+  }
+  Object.assign(process.env, savedEnv);
+
+  // Clean up temp file.
+  try { fs.unlinkSync(outputFile); } catch { /* ignore */ }
+
+  vi.restoreAllMocks();
+});
+
+function setInput(name: string, value: string) {
+  process.env[`INPUT_${name.replace(/-/g, "_").toUpperCase()}`] = value;
+}
+
+function getConsoleLogs(): string[] {
+  return (consoleSpy as unknown as { mock: { calls: Array<Array<unknown>> } })
+    .mock.calls.map((c) => String(c[0]));
+}
+
+function getExitCalls(): Array<number | string | null | undefined> {
+  return (exitSpy as unknown as { mock: { calls: Array<Array<unknown>> } })
+    .mock.calls.map((c) => c[0] as number | string | null | undefined);
+}
+
+// ---------------------------------------------------------------------------
+// 1. Missing required inputs
+// ---------------------------------------------------------------------------
+
+describe("missing required inputs", () => {
+  it("calls process.exit(1) when api-key is missing", async () => {
+    setInput("action", "deploy.prod");
+    // api-key is NOT set
+
+    await expect(run()).rejects.toBeInstanceOf(ProcessExitError);
+    expect(getExitCalls()).toContain(1);
+    expect(getConsoleLogs().some((l) => l.includes("Input required and not supplied: api-key"))).toBe(true);
+  });
+
+  it("calls process.exit(1) when action is missing on the single-eval path", async () => {
+    setInput("api-key", "ask_test_key");
+    // action is NOT set, evaluations also not set
+
+    await expect(run()).rejects.toBeInstanceOf(ProcessExitError);
+    expect(getExitCalls()).toContain(1);
+    expect(getConsoleLogs().some((l) => l.includes("Input required and not supplied: action"))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Allow decision → setOutput('decision', 'allow')
+// ---------------------------------------------------------------------------
+
+describe("allow response", () => {
+  it("sets decision=allow output and does NOT call process.exit", async () => {
+    setInput("api-key", "ask_test_key");
+    setInput("action", "production_deploy");
+
+    mockEnforce.mockResolvedValueOnce(makeAllowResult());
+
+    await run();
+
+    expect(getExitCalls()).toHaveLength(0);
+    const outputs = readOutputs(outputFile);
+    expect(outputs["decision"]).toBe("allow");
+    expect(outputs["verified"]).toBe("true");
+  });
+
+  it("sets permit-token, evaluation-id, proof-hash, risk-score outputs on allow", async () => {
+    setInput("api-key", "ask_test_key");
+    setInput("action", "deploy.prod");
+
+    mockEnforce.mockResolvedValueOnce(makeAllowResult({
+      evaluationId: "ev-abc",
+      permitToken: "pt-xyz",
+      proofHash: "ph-xyz",
+      riskScore: 42,
+    }));
+
+    await run();
+
+    const outputs = readOutputs(outputFile);
+    expect(outputs["evaluation-id"]).toBe("ev-abc");
+    expect(outputs["proof-hash"]).toBe("ph-xyz");
+    expect(outputs["risk-score"]).toBe("42");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Deny decision → process.exit(1) (setFailed)
+// ---------------------------------------------------------------------------
+
+describe("deny decision", () => {
+  it("calls process.exit(1) when enforce throws EnforceError with deny decision", async () => {
+    setInput("api-key", "ask_test_key");
+    setInput("action", "production_deploy");
+
+    const denyDecision = makeDecision({ decision: "deny", denyReason: "policy violation" });
+    mockEnforce.mockRejectedValueOnce(
+      new EnforceError("Denied: policy violation", "verify", denyDecision),
+    );
+
+    await expect(run()).rejects.toBeInstanceOf(ProcessExitError);
+    expect(getExitCalls()).toContain(1);
+    expect(getConsoleLogs().some((l) => l.includes("policy violation"))).toBe(true);
+  });
+
+  it("sets decision=deny output before failing", async () => {
+    setInput("api-key", "ask_test_key");
+    setInput("action", "deploy.prod");
+
+    const denyDecision = makeDecision({ decision: "deny", denyReason: "not allowed" });
+    mockEnforce.mockRejectedValueOnce(
+      new EnforceError("Denied: not allowed", "verify", denyDecision),
+    );
+
+    await expect(run()).rejects.toBeInstanceOf(ProcessExitError);
+
+    const outputs = readOutputs(outputFile);
+    expect(outputs["decision"]).toBe("deny");
+    expect(outputs["verified"]).toBe("false");
+  });
+
+  it("does NOT call process.exit when fail-on-deny=false and decision is deny", async () => {
+    setInput("api-key", "ask_test_key");
+    setInput("action", "deploy.prod");
+    setInput("fail-on-deny", "false");
+
+    const denyDecision = makeDecision({ decision: "deny", denyReason: "informational only" });
+    mockEnforce.mockRejectedValueOnce(
+      new EnforceError("Denied: informational only", "verify", denyDecision),
+    );
+
+    await run();
+
+    expect(getExitCalls()).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. v1.1 audit fields → setOutput('chain-entry', ...)
+// ---------------------------------------------------------------------------
+
+describe("v1.1 audit fields", () => {
+  it("sets chain-entry output when API returns chainEntry", async () => {
+    setInput("api-key", "ask_test_key");
+    setInput("action", "deploy.prod");
+
+    const chainEntry = { blockHash: "0xabc", txIndex: 1 };
+    mockEnforce.mockResolvedValueOnce(makeAllowResult({
+      chainEntry,
+      snapshot: { state: "captured" },
+      auditHash: "audit-hash-xyz",
+    }));
+
+    await run();
+
+    const outputs = readOutputs(outputFile);
+    expect(outputs["chain-entry"]).toBe(JSON.stringify(chainEntry));
+    expect(outputs["snapshot"]).toBe(JSON.stringify({ state: "captured" }));
+    expect(outputs["audit-hash"]).toBe("audit-hash-xyz");
+  });
+
+  it("sets chain-entry to JSON null when chainEntry is absent", async () => {
+    setInput("api-key", "ask_test_key");
+    setInput("action", "deploy.prod");
+
+    mockEnforce.mockResolvedValueOnce(makeAllowResult({ chainEntry: undefined }));
+
+    await run();
+
+    const outputs = readOutputs(outputFile);
+    expect(outputs["chain-entry"]).toBe("null");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. Deprecated ::set-output is NOT emitted
+// ---------------------------------------------------------------------------
+
+describe("deprecated ::set-output command", () => {
+  it("does not emit ::set-output:: workflow command on allow", async () => {
+    setInput("api-key", "ask_test_key");
+    setInput("action", "deploy.prod");
+
+    mockEnforce.mockResolvedValueOnce(makeAllowResult());
+
+    await run();
+
+    const allLogs = getConsoleLogs();
+    const deprecated = allLogs.filter((l) => l.includes("::set-output"));
+    expect(deprecated).toHaveLength(0);
+  });
+});

--- a/src/__tests__/v21.test.ts
+++ b/src/__tests__/v21.test.ts
@@ -5,15 +5,15 @@ import { runV21 } from "../v21";
 // parseInputs + evaluateMany + (optional) waitForTerminalDecision.
 
 vi.mock("../batch", () => ({ evaluateMany: vi.fn() }));
-vi.mock("../gate", () => ({ verifyOne: vi.fn() }));
+vi.mock("@atlasent/enforce", () => ({ verifyPermit: vi.fn() }));
 vi.mock("../stream", () => ({ waitForTerminalDecision: vi.fn() }));
 
 import { evaluateMany } from "../batch";
-import { verifyOne } from "../gate";
+import { verifyPermit } from "@atlasent/enforce";
 import { waitForTerminalDecision } from "../stream";
 
 const mockEvaluateMany = evaluateMany as ReturnType<typeof vi.fn>;
-const mockVerifyOne = verifyOne as ReturnType<typeof vi.fn>;
+const mockVerifyPermit = verifyPermit as ReturnType<typeof vi.fn>;
 const mockWait = waitForTerminalDecision as ReturnType<typeof vi.fn>;
 
 // Minimal env that drives the batch path (evaluations set).
@@ -37,7 +37,7 @@ function decision(
 
 beforeEach(() => {
   mockEvaluateMany.mockReset();
-  mockVerifyOne.mockReset();
+  mockVerifyPermit.mockReset();
   mockWait.mockReset();
 });
 
@@ -127,7 +127,7 @@ it("calls waitForTerminalDecision when waitForId matches a hold decision", async
   const terminal = decision("allow", "ev-hold", "pt-1");
   mockEvaluateMany.mockResolvedValueOnce({ decisions: [hold], batchId: "b1" });
   mockWait.mockResolvedValueOnce(terminal);
-  mockVerifyOne.mockResolvedValueOnce({ verified: true, outcome: "ok" });
+  mockVerifyPermit.mockResolvedValueOnce({ verified: true, outcome: "ok" });
 
   const out = await runV21({ ...BASE_ENV, "INPUT_WAIT-FOR-ID": "ev-hold" }, FLAGS);
 
@@ -135,7 +135,7 @@ it("calls waitForTerminalDecision when waitForId matches a hold decision", async
   expect(mockWait).toHaveBeenCalledWith(
     expect.objectContaining({ evaluationId: "ev-hold", apiKey: "ask_test_key" }),
   );
-  expect(mockVerifyOne).toHaveBeenCalledOnce();
+  expect(mockVerifyPermit).toHaveBeenCalledOnce();
   expect(out.decisions[0].decision).toBe("allow");
   expect(out.decisions[0].verified).toBe(true);
 });
@@ -145,16 +145,20 @@ it("verifies terminal allow from wait-for-id with correct permit params", async 
   const terminal = { ...decision("allow", "ev-hold", "pt-xyz"), verified: undefined };
   mockEvaluateMany.mockResolvedValueOnce({ decisions: [hold], batchId: "b1" });
   mockWait.mockResolvedValueOnce(terminal);
-  mockVerifyOne.mockResolvedValueOnce({ verified: true, outcome: "ok" });
+  mockVerifyPermit.mockResolvedValueOnce({ verified: true, outcome: "ok" });
 
   await runV21({ ...BASE_ENV, "INPUT_WAIT-FOR-ID": "ev-hold" }, FLAGS);
 
-  expect(mockVerifyOne).toHaveBeenCalledWith(
+  expect(mockVerifyPermit).toHaveBeenCalledWith(
     expect.objectContaining({
+      apiKey: "ask_test_key",
+      apiUrl: "https://api.test",
+      action: "deploy.prod",
+      actor: "alice",
+    }),
+    expect.objectContaining({
+      decision: "allow",
       permitToken: "pt-xyz",
-      actionType: "deploy.prod",
-      actorId: "alice",
-      verifyPath: "/v1/verify-permit",
     }),
   );
 });
@@ -167,7 +171,7 @@ it("sets verified=false when terminal allow has no permitToken", async () => {
 
   const out = await runV21({ ...BASE_ENV, "INPUT_WAIT-FOR-ID": "ev-hold" }, FLAGS);
 
-  expect(mockVerifyOne).not.toHaveBeenCalled();
+  expect(mockVerifyPermit).not.toHaveBeenCalled();
   expect(out.decisions[0].verified).toBe(false);
 });
 

--- a/src/batch.ts
+++ b/src/batch.ts
@@ -4,9 +4,12 @@
 // /v1/evaluate/batch. Otherwise, per-item /v1/evaluate loop. Either
 // path then runs verify-permit for every allow decision, matching the
 // single-eval runGate() contract — the gate is fail-closed end-to-end.
+//
+// Uses @atlasent/enforce's verifyPermit() as the canonical implementation.
 
-import { verifyOne } from "./gate";
-import type { Decision, EvaluateRequest } from "./types";
+import { verifyPermit } from "@atlasent/enforce";
+import type { EvaluateRequest } from "./types";
+import type { Decision } from "./types";
 
 export interface BatchResult {
   decisions: Decision[];
@@ -59,23 +62,18 @@ export async function evaluateMany(
     batchId = `loop-${Date.now()}`;
   }
 
-  // Verify permits for every allow decision.
-  // Uses the REST-style path (/v1/verify-permit) matching the v2 API convention.
-  // Fail-closed: if any verify throws, the error propagates up.
+  // Verify permits for every allow decision using the canonical verifyPermit()
+  // from @atlasent/enforce. Fail-closed: if any verify throws, the error
+  // propagates up.
   const verified = await Promise.all(
     decisions.map(async (d, i) => {
       if (d.decision !== "allow" || !d.permitToken) {
         return { ...d, verified: d.decision === "allow" ? false : undefined };
       }
       const item = items[i];
-      const result = await verifyOne({
-        apiUrl,
-        apiKey,
-        actionType: item.action,
-        actorId: item.actor,
-        permitToken: d.permitToken,
-        verifyPath: "/v1/verify-permit",
-      });
+      const enforceConfig = { apiKey, apiUrl, action: item.action, actor: item.actor };
+      const enforceDecision = { decision: "allow" as const, permitToken: d.permitToken };
+      const result = await verifyPermit(enforceConfig, enforceDecision);
       return { ...d, verified: result.verified, verifyOutcome: result.outcome };
     }),
   );

--- a/src/gate.ts
+++ b/src/gate.ts
@@ -1,28 +1,13 @@
-// verify-permit helper for the v2.1 batch path.
+// Infrastructure error type for the v2.1 batch path.
 //
 // The single-eval path (src/index.ts) uses @atlasent/enforce as the canonical
-// enforcement wrapper. This module only exports verifyOne(), which is called
-// per-decision after evaluateMany() in src/batch.ts.
+// enforcement wrapper, including its verifyPermit() function. The batch path
+// (src/batch.ts, src/v21.ts) also uses @atlasent/enforce's verifyPermit() as
+// the canonical verify-permit implementation.
 
 // ---------------------------------------------------------------------------
 // Public types
 // ---------------------------------------------------------------------------
-
-export interface VerifyParams {
-  apiUrl: string;
-  apiKey: string;
-  actionType: string;
-  actorId: string;
-  permitToken: string;
-  /** Override the verify endpoint path. Defaults to /v1-verify-permit
-   *  (Supabase style). Pass "/v1/verify-permit" for the REST API. */
-  verifyPath?: string;
-}
-
-export interface VerifyResult {
-  verified: boolean;
-  outcome?: string;
-}
 
 // Thrown for infrastructure failures (network, !2xx, non-JSON).
 // Distinct from a policy decision so callers always fail-closed on these.
@@ -34,45 +19,4 @@ export class GateInfraError extends Error {
     super(message);
     this.name = "GateInfraError";
   }
-}
-
-// ---------------------------------------------------------------------------
-// verifyOne — single verify-permit round-trip
-// ---------------------------------------------------------------------------
-
-export async function verifyOne(params: VerifyParams): Promise<VerifyResult> {
-  const path = params.verifyPath ?? "/v1-verify-permit";
-
-  let res: Response;
-  try {
-    res = await fetch(`${params.apiUrl}${path}`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${params.apiKey}`,
-      },
-      body: JSON.stringify({
-        permit_token: params.permitToken,
-        action_type: params.actionType,
-        actor_id: params.actorId,
-      }),
-    });
-  } catch (err) {
-    throw new GateInfraError(
-      `verify-permit unreachable: ${err instanceof Error ? err.message : String(err)}`,
-    );
-  }
-
-  if (!res.ok) {
-    throw new GateInfraError(`verify-permit HTTP ${res.status}`, res.status);
-  }
-
-  let body: { verified?: boolean; outcome?: string };
-  try {
-    body = (await res.json()) as { verified?: boolean; outcome?: string };
-  } catch {
-    throw new GateInfraError("failed to parse verify-permit response as JSON");
-  }
-
-  return { verified: body.verified === true, outcome: body.outcome };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -108,6 +108,9 @@ function setDecisionOutputs(d: Decision): void {
   setOutput("evaluation-id", d.evaluationId ?? "");
   setOutput("proof-hash", d.proofHash ?? "");
   setOutput("risk-score", d.riskScore !== undefined ? String(d.riskScore) : "");
+  setOutput("chain-entry", JSON.stringify(d.chainEntry ?? null));
+  setOutput("snapshot", JSON.stringify(d.snapshot ?? null));
+  setOutput("audit-hash", d.auditHash ?? "");
 }
 
 // ---------------------------------------------------------------------------
@@ -358,6 +361,9 @@ async function run(): Promise<void> {
         setOutput("evaluation-id", "");
         setOutput("proof-hash", "");
         setOutput("risk-score", "");
+        setOutput("chain-entry", JSON.stringify(null));
+        setOutput("snapshot", JSON.stringify(null));
+        setOutput("audit-hash", "");
       }
       setOutput("verified", "false");
 
@@ -427,6 +433,9 @@ async function run(): Promise<void> {
     setOutput("evaluation-id", "");
     setOutput("proof-hash", "");
     setOutput("risk-score", "");
+    setOutput("chain-entry", JSON.stringify(null));
+    setOutput("snapshot", JSON.stringify(null));
+    setOutput("audit-hash", "");
     setOutput("verified", "false");
 
     // Still emit advisory on unexpected errors

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,7 +37,6 @@ function setOutput(name: string, value: string): void {
     const fs = require("node:fs");
     fs.appendFileSync(outputFile, `${name}=${value}\n`);
   }
-  console.log(`::set-output name=${name}::${value}`);
 }
 
 function setFailed(message: string): never {
@@ -216,7 +215,7 @@ function emitFinancialGovernanceAdvisory(
 // Main
 // ---------------------------------------------------------------------------
 
-async function run(): Promise<void> {
+export async function run(): Promise<void> {
   // 1. Read shared inputs
   const apiKey = getInput("api-key", true);
   // Mask immediately on the literal next line so any code path that
@@ -464,7 +463,10 @@ async function run(): Promise<void> {
   emitFinancialGovernanceAdvisory(actionType, actor, orgId);
 }
 
-run().catch((err) => {
-  console.log(`::error::Unexpected error: ${err instanceof Error ? err.message : String(err)}`);
-  process.exit(1);
-});
+// Only auto-invoke when run as the main entry point (not during tests/imports).
+if (require.main === module) {
+  run().catch((err) => {
+    console.log(`::error::Unexpected error: ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
+  });
+}

--- a/src/v21.ts
+++ b/src/v21.ts
@@ -13,8 +13,8 @@
 //      flips it.
 //   4. Job summary is rendered per evaluation.
 
+import { verifyPermit } from "@atlasent/enforce";
 import { evaluateMany } from "./batch";
-import { verifyOne } from "./gate";
 import { parseInputs } from "./inputs";
 import { waitForTerminalDecision } from "./stream";
 import type { Decision } from "./types";
@@ -58,16 +58,13 @@ export async function runV21(
       decisions = [...decisions];
       if (terminal.decision === "allow") {
         // Terminal allow must be verified — same fail-closed contract as evaluateMany.
+        // Uses @atlasent/enforce's canonical verifyPermit() implementation.
         const item = items[idx];
         const vr = terminal.permitToken
-          ? await verifyOne({
-              apiUrl: inputs.apiUrl,
-              apiKey: inputs.apiKey,
-              actionType: item.action,
-              actorId: item.actor,
-              permitToken: terminal.permitToken,
-              verifyPath: "/v1/verify-permit",
-            })
+          ? await verifyPermit(
+              { apiKey: inputs.apiKey, apiUrl: inputs.apiUrl, action: item.action, actor: item.actor },
+              { decision: "allow" as const, permitToken: terminal.permitToken },
+            )
           : { verified: false as const, outcome: undefined };
         decisions[idx] = { ...terminal, verified: vr.verified, verifyOutcome: vr.outcome };
       } else {


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Add `src/__tests__/index.test.ts`** — new test file covering the main `run()` entry point: missing required inputs (`api-key`, `action`), allow/deny decision outputs, v1.1 audit chain fields (`chain-entry`, `snapshot`, `audit-hash`), and a regression test that the deprecated `::set-output` command is never emitted.
- **Remove duplicate verify-permit implementation** — `verifyOne()` and its supporting types (`VerifyParams`, `VerifyResult`) have been removed from `src/gate.ts`. `src/batch.ts` and `src/v21.ts` now use the canonical `verifyPermit()` from `@atlasent/enforce`. Related tests (`batch.test.ts`, `gate.test.ts`, `v21.test.ts`) updated accordingly.
- **Remove deprecated `::set-output` emission** — the `console.log(\`::set-output name=...\`)` line in `setOutput()` in `src/index.ts` has been removed; the `GITHUB_OUTPUT` file-write path remains as the correct modern API.

## Additional changes

- `run()` is now exported from `src/index.ts` to support direct testing.
- Auto-invocation at module load is guarded with `require.main === module` so importing the module in tests does not trigger side-effects.

## Test plan

- [ ] All 114 tests pass: `npm test`
- [ ] TypeScript compiles without errors: `npm run typecheck`
- [ ] Verify `src/__tests__/index.test.ts` covers: missing `api-key`, missing `action`, allow decision outputs, deny decision failure, v1.1 `chain-entry` output, no `::set-output` emission
- [ ] Confirm `src/gate.ts` no longer exports `verifyOne` — only `GateInfraError`
- [ ] Confirm `src/batch.ts` and `src/v21.ts` import `verifyPermit` from `@atlasent/enforce`

https://claude.ai/code/session_01VsVK8W4xp1VdztRRN1s9En
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VsVK8W4xp1VdztRRN1s9En)_