### PR TITLE
chore(action): rebuild dist bundle after src changes

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -8,6 +8,10 @@ var __hasOwnProp = Object.prototype.hasOwnProperty;
 var __commonJS = (cb, mod) => function __require() {
   return mod || (0, cb[__getOwnPropNames(cb)[0]])((mod = { exports: {} }).exports, mod), mod.exports;
 };
+var __export = (target, all) => {
+  for (var name in all)
+    __defProp(target, name, { get: all[name], enumerable: true });
+};
 var __copyProps = (to, from, except, desc) => {
   if (from && typeof from === "object" || typeof from === "function") {
     for (let key of __getOwnPropNames(from))
@@ -24,6 +28,7 @@ var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__ge
   isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", { value: mod, enumerable: true }) : target,
   mod
 ));
+var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
 
 // packages/enforce/dist/transport.js
 var require_transport = __commonJS({
@@ -77,7 +82,7 @@ var require_dist = __commonJS({
     exports2.EnforceError = void 0;
     exports2.evaluate = evaluate;
     exports2.verify = verify;
-    exports2.verifyPermit = verifyPermit;
+    exports2.verifyPermit = verifyPermit3;
     exports2.enforce = enforce2;
     var transport_1 = require_transport();
     var DEFAULT_API_URL = "https://api.atlasent.io";
@@ -148,7 +153,7 @@ var require_dist = __commonJS({
           throw new EnforceError2(`Unknown decision: ${String(decision.decision)}`, "verify", decision);
       }
     }
-    async function verifyPermit(config, decision) {
+    async function verifyPermit3(config, decision) {
       if (!decision.permitToken) {
         throw new EnforceError2("evaluate returned allow but no permit_token \u2014 refusing to execute without verifiable permit", "verify-permit", decision);
       }
@@ -184,7 +189,7 @@ var require_dist = __commonJS({
     async function enforce2(config, fn) {
       const decision = await evaluate(config);
       verify(decision);
-      const vp = await verifyPermit(config, decision);
+      const vp = await verifyPermit3(config, decision);
       const result = await fn();
       return { result, decision, verifyOutcome: vp.outcome };
     }
@@ -218,7 +223,12 @@ var require_dist = __commonJS({
 });
 
 // src/index.ts
-var import_enforce = __toESM(require_dist());
+var src_exports = {};
+__export(src_exports, {
+  run: () => run
+});
+module.exports = __toCommonJS(src_exports);
+var import_enforce3 = __toESM(require_dist());
 
 // src/gate.ts
 var GateInfraError = class extends Error {
@@ -228,40 +238,12 @@ var GateInfraError = class extends Error {
     this.name = "GateInfraError";
   }
 };
-async function verifyOne(params) {
-  const path = params.verifyPath ?? "/v1-verify-permit";
-  let res;
-  try {
-    res = await fetch(`${params.apiUrl}${path}`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${params.apiKey}`
-      },
-      body: JSON.stringify({
-        permit_token: params.permitToken,
-        action_type: params.actionType,
-        actor_id: params.actorId
-      })
-    });
-  } catch (err) {
-    throw new GateInfraError(
-      `verify-permit unreachable: ${err instanceof Error ? err.message : String(err)}`
-    );
-  }
-  if (!res.ok) {
-    throw new GateInfraError(`verify-permit HTTP ${res.status}`, res.status);
-  }
-  let body;
-  try {
-    body = await res.json();
-  } catch {
-    throw new GateInfraError("failed to parse verify-permit response as JSON");
-  }
-  return { verified: body.verified === true, outcome: body.outcome };
-}
+
+// src/v21.ts
+var import_enforce2 = __toESM(require_dist());
 
 // src/batch.ts
+var import_enforce = __toESM(require_dist());
 async function evaluateMany(apiUrl, apiKey, items, v2Batch) {
   const headers = {
     "content-type": "application/json",
@@ -302,14 +284,9 @@ async function evaluateMany(apiUrl, apiKey, items, v2Batch) {
         return { ...d, verified: d.decision === "allow" ? false : void 0 };
       }
       const item = items[i];
-      const result = await verifyOne({
-        apiUrl,
-        apiKey,
-        actionType: item.action,
-        actorId: item.actor,
-        permitToken: d.permitToken,
-        verifyPath: "/v1/verify-permit"
-      });
+      const enforceConfig = { apiKey, apiUrl, action: item.action, actor: item.actor };
+      const enforceDecision = { decision: "allow", permitToken: d.permitToken };
+      const result = await (0, import_enforce.verifyPermit)(enforceConfig, enforceDecision);
       return { ...d, verified: result.verified, verifyOutcome: result.outcome };
     })
   );
@@ -475,14 +452,10 @@ async function runV21(env, flags) {
       decisions = [...decisions];
       if (terminal.decision === "allow") {
         const item = items[idx];
-        const vr = terminal.permitToken ? await verifyOne({
-          apiUrl: inputs.apiUrl,
-          apiKey: inputs.apiKey,
-          actionType: item.action,
-          actorId: item.actor,
-          permitToken: terminal.permitToken,
-          verifyPath: "/v1/verify-permit"
-        }) : { verified: false, outcome: void 0 };
+        const vr = terminal.permitToken ? await (0, import_enforce2.verifyPermit)(
+          { apiKey: inputs.apiKey, apiUrl: inputs.apiUrl, action: item.action, actor: item.actor },
+          { decision: "allow", permitToken: terminal.permitToken }
+        ) : { verified: false, outcome: void 0 };
         decisions[idx] = { ...terminal, verified: vr.verified, verifyOutcome: vr.outcome };
       } else {
         decisions[idx] = terminal;
@@ -579,7 +552,6 @@ function setOutput(name, value) {
     fs.appendFileSync(outputFile, `${name}=${value}
 `);
   }
-  console.log(`::set-output name=${name}::${value}`);
 }
 function setFailed(message) {
   console.log(`::error::${message}`);
@@ -726,7 +698,7 @@ async function run() {
         { v2Batch, v2Streaming }
       );
     } catch (err) {
-      const msg = err instanceof import_enforce.EnforceError || err instanceof GateInfraError ? err.message : `Unexpected error: ${err instanceof Error ? err.message : String(err)}`;
+      const msg = err instanceof import_enforce3.EnforceError || err instanceof GateInfraError ? err.message : `Unexpected error: ${err instanceof Error ? err.message : String(err)}`;
       setOutput("verified", "false");
       setOutput("decisions", "[]");
       setOutput("batch-id", "");
@@ -804,10 +776,10 @@ async function run() {
   };
   let enforceResult;
   try {
-    enforceResult = await (0, import_enforce.enforce)(config, async () => {
+    enforceResult = await (0, import_enforce3.enforce)(config, async () => {
     });
   } catch (err) {
-    if (err instanceof import_enforce.EnforceError) {
+    if (err instanceof import_enforce3.EnforceError) {
       if (err.decision) {
         setDecisionOutputs(err.decision);
       } else {
@@ -900,7 +872,13 @@ async function run() {
   info(`  Verify:       ${verifyOutcome ?? "verified"}`);
   emitFinancialGovernanceAdvisory(actionType, actor, orgId);
 }
-run().catch((err) => {
-  console.log(`::error::Unexpected error: ${err instanceof Error ? err.message : String(err)}`);
-  process.exit(1);
+if (require.main === module) {
+  run().catch((err) => {
+    console.log(`::error::Unexpected error: ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
+  });
+}
+// Annotate the CommonJS export names for ESM import in node:
+0 && (module.exports = {
+  run
 });


### PR DESCRIPTION
## Summary

- Rebuilds `dist/index.js` to reflect recent `src/index.ts` changes: removal of `::set-output`, dual verify-permit cleanup, and new test exports
- The published action runs `dist/index.js`, so this sync is required for any workflow using the action to run current code
- All 114 tests pass after rebuild

## Test plan

- [x] `npm ci` completes cleanly
- [x] `npm run build` succeeds (esbuild, 30.5kb output)
- [x] `dist/index.js` timestamp is newer than `src/index.ts`
- [x] `npm test` — 114/114 tests pass across 12 test files

https://claude.ai/code/session_01VsVK8W4xp1VdztRRN1s9En

---
_Generated by [Claude Code](https://claude.ai/code/session_01VsVK8W4xp1VdztRRN1s9En)_