### PR TITLE
B7: GitHub Actions runtime evidence event emitter

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -638,6 +638,45 @@ function assessFinancialGovernance(input) {
   };
 }
 
+// src/evidenceClient.ts
+async function emitEvidenceEvent(cfg, event, log = console) {
+  const url = `${cfg.apiUrl.replace(/\/$/, "")}${cfg.endpoint ?? "/v1-runtime-events"}`;
+  const timeoutMs = cfg.timeoutMs ?? 5e3;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Authorization": `Bearer ${cfg.apiKey}`,
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify(event),
+      signal: controller.signal
+    });
+    if (res.status === 404) {
+      log.info(
+        `AtlaSent: runtime evidence endpoint not present at ${url} (skipping ${event.event_type})`
+      );
+      return;
+    }
+    if (!res.ok) {
+      log.warning(
+        `AtlaSent: evidence emit ${event.event_type} \u2192 HTTP ${res.status} (advisory; build not affected)`
+      );
+      return;
+    }
+    log.info(`AtlaSent: evidence event ${event.event_type} emitted`);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log.warning(
+      `AtlaSent: evidence emit failed (advisory; build not affected): ${msg}`
+    );
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 // src/index.ts
 function getInput(name, required2 = false) {
   const envKey = `INPUT_${name.replace(/-/g, "_").toUpperCase()}`;
@@ -1050,6 +1089,30 @@ async function run() {
   if (d.riskScore !== void 0)
     info(`  Risk score:   ${d.riskScore}`);
   info(`  Verify:       ${verifyOutcome ?? "verified"}`);
+  if (d.permitToken && d.evaluationId) {
+    await emitEvidenceEvent(
+      { apiKey, apiUrl },
+      {
+        event_type: "execution_started",
+        permit_token: d.permitToken,
+        evaluation_id: d.evaluationId,
+        environment,
+        execution_started_at: (/* @__PURE__ */ new Date()).toISOString(),
+        metadata: {
+          source: "github-action",
+          repository: gh.repository,
+          ref: gh.ref,
+          sha: gh.sha,
+          workflow: gh.workflow,
+          run_id: gh.run_id,
+          run_url: `${gh.server_url}/${gh.repository}/actions/runs/${gh.run_id}`,
+          action: actionType,
+          actor: `github:${actor}`
+        }
+      },
+      { info, warning }
+    );
+  }
   emitFinancialGovernanceAdvisory(actionType, actor, orgId);
 }
 if (require.main === module) {

--- a/src/evidenceClient.ts
+++ b/src/evidenceClient.ts
@@ -1,0 +1,119 @@
+/**
+ * Best-effort evidence event emitter.
+ *
+ * After a successful enforce() the action posts an `execution_started`
+ * evidence event to /v1-runtime-events so the runtime verification chain
+ * (Phase B2/B4 in the API) has a real record of the CI run that was
+ * authorized. The emit is fire-and-forget:
+ *
+ *   - Failures NEVER fail the build (advisory-grade)
+ *   - The endpoint may not exist on every API deployment; absence is
+ *     reported as a debug-level message, not a warning
+ *   - We don't await unbounded; a hard 5s timeout caps the cost
+ *
+ * Stable event payload shape (must match the API's append_evidence_event
+ * contract, per ADR-runtime-verification-and-governance-provenance):
+ *   {
+ *     event_type: "execution_started" | "execution_completed" | "execution_failed",
+ *     permit_token: string,
+ *     evaluation_id: string,
+ *     environment: string,
+ *     execution_started_at?: ISO8601,
+ *     execution_result_hash?: hex(sha256) (for *_completed only),
+ *     metadata: {
+ *       source: "github-action",
+ *       repository, ref, sha, run_id, run_url, ...
+ *     }
+ *   }
+ */
+
+import { createHash } from "node:crypto";
+
+export type EvidenceEventType =
+  | "execution_started"
+  | "execution_completed"
+  | "execution_failed";
+
+export interface EvidenceEvent {
+  event_type: EvidenceEventType;
+  permit_token: string;
+  evaluation_id: string;
+  environment: string;
+  execution_started_at?: string;
+  execution_result_hash?: string;
+  metadata: Record<string, unknown>;
+}
+
+export interface EmitConfig {
+  apiKey: string;
+  apiUrl: string;
+  timeoutMs?: number;
+  /**
+   * Optional override for the endpoint path. The default points at the
+   * canonical handler the API will expose for B2/B7 wiring. Lets users on
+   * a forked or self-hosted API redirect without rebuilding the action.
+   */
+  endpoint?: string;
+}
+
+/**
+ * Compute a stable SHA-256 hash of the execution result payload. Used by
+ * Phase B3's action_hash_mismatch / output_hash_mismatch binding checks.
+ * Pure function so tests are trivial.
+ */
+export function hashResult(payload: unknown): string {
+  const canonical = typeof payload === "string"
+    ? payload
+    : JSON.stringify(payload, Object.keys(payload as object).sort());
+  return createHash("sha256").update(canonical, "utf8").digest("hex");
+}
+
+export async function emitEvidenceEvent(
+  cfg: EmitConfig,
+  event: EvidenceEvent,
+  log: { info: (m: string) => void; warning: (m: string) => void } = console as unknown as {
+    info: (m: string) => void;
+    warning: (m: string) => void;
+  },
+): Promise<void> {
+  const url = `${cfg.apiUrl.replace(/\/$/, "")}${cfg.endpoint ?? "/v1-runtime-events"}`;
+  const timeoutMs = cfg.timeoutMs ?? 5000;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const res = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Authorization": `Bearer ${cfg.apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(event),
+      signal: controller.signal,
+    });
+
+    if (res.status === 404) {
+      // Endpoint not deployed on this API — common during the rollout
+      // window when atlasent-action is ahead of atlasent-api. Don't warn.
+      log.info(
+        `AtlaSent: runtime evidence endpoint not present at ${url} (skipping ${event.event_type})`,
+      );
+      return;
+    }
+    if (!res.ok) {
+      log.warning(
+        `AtlaSent: evidence emit ${event.event_type} → HTTP ${res.status} (advisory; build not affected)`,
+      );
+      return;
+    }
+    log.info(`AtlaSent: evidence event ${event.event_type} emitted`);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log.warning(
+      `AtlaSent: evidence emit failed (advisory; build not affected): ${msg}`,
+    );
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ import {
   assessFinancialGovernance,
 } from "./financialGovernanceAdvisory";
 import type { FinancialAdvisoryInput } from "./financialGovernanceAdvisory";
+import { emitEvidenceEvent } from "./evidenceClient";
 
 // ---------------------------------------------------------------------------
 // GitHub Actions helpers
@@ -532,6 +533,33 @@ export async function run(): Promise<void> {
   info(`  Evaluation:   ${d.evaluationId ?? ""}`);
   if (d.riskScore !== undefined) info(`  Risk score:   ${d.riskScore}`);
   info(`  Verify:       ${verifyOutcome ?? "verified"}`);
+
+  // ── B7: emit execution_started evidence event ────────────────────────────
+  // Best-effort, fire-and-forget. Build outcome is already determined above.
+  if (d.permitToken && d.evaluationId) {
+    await emitEvidenceEvent(
+      { apiKey, apiUrl },
+      {
+        event_type: "execution_started",
+        permit_token: d.permitToken,
+        evaluation_id: d.evaluationId,
+        environment,
+        execution_started_at: new Date().toISOString(),
+        metadata: {
+          source: "github-action",
+          repository: gh.repository,
+          ref: gh.ref,
+          sha: gh.sha,
+          workflow: gh.workflow,
+          run_id: gh.run_id,
+          run_url: `${gh.server_url}/${gh.repository}/actions/runs/${gh.run_id}`,
+          action: actionType,
+          actor: `github:${actor}`,
+        },
+      },
+      { info, warning },
+    );
+  }
 
   emitFinancialGovernanceAdvisory(actionType, actor, orgId);
 }


### PR DESCRIPTION
## Summary

Phase B7 of Runtime Verification & Governance Provenance — extends the GitHub Actions reference connector to emit runtime evidence events.

After `enforce()` authorizes a CI run, the action fire-and-forget posts an `execution_started` evidence event to `${api-url}/v1-runtime-events` carrying:
- `permit_token` + `evaluation_id` (linkage to the authorization)
- `environment` (matches Phase B3's environment-binding check)
- GitHub context (repo, sha, workflow, run_url)
- `execution_started_at`

This closes the connector-contract gap pinned in `ADR-runtime-verification-and-governance-provenance` (B13) — runtime executions now produce real evidence rolling in for every CI run that goes through the action.

### What's added

- `src/evidenceClient.ts` (new) — standalone emitter:
  - `emitEvidenceEvent(cfg, event, log?)` — POSTs JSON to `/v1-runtime-events`
  - `hashResult(payload)` — pure SHA-256 over canonicalized JSON for `execution_result_hash` (used by B3's binding check)
  - 5-second hard timeout
  - 404 from API logs at `info` (endpoint may not be deployed yet during rollout)
  - Any other failure logs `warning` but **never** affects build outcome
- `src/index.ts` — wires the emit into the single-eval enforce success path

### Build-safety contract

The emit runs **after** the build outcome is already determined. The action sets `verified=true`, prints "Authorization GRANTED", then attempts to emit. If the emit fails or times out, the action exits 0 anyway. Existing CI workflows behave identically to today.

### Non-goals

- Batch path (`runV21`) wiring — different flow, separate PR
- `execution_completed` / `execution_failed` emission — requires a post-step or follow-up action invocation
- The `/v1-runtime-events` API endpoint — best-effort emit means it can land in a follow-up PR without breaking this one

### Test plan

- [ ] `tsc` / `npm run build` passes
- [ ] CI run with valid AtlaSent gate produces a single POST to `/v1-runtime-events`
- [ ] CI run when API is unreachable still completes successfully (advisory)
- [ ] CI run when API returns 404 logs at info, not warning, and completes successfully
- [ ] No additional secret leaks in logs (`permit_token` / `proof_hash` continue to be masked by the existing `setDecisionOutputs` flow)

Part of: Runtime Verification & Governance Provenance.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GEUZj3Mn78oxTgSeVTTGbo)_