### PR TITLE
feat: add NOTICE file (Tier A licensing)

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,19 @@
+AtlaSent Action — GitHub Actions Gate
+Copyright (c) 2025 AtlaSent Systems Inc.
+
+LICENSING
+---------
+This software is licensed under the MIT License.
+See LICENSE for the full license text.
+
+ATTRIBUTION
+-----------
+This GitHub Action integrates with the AtlaSent governance platform.
+The AtlaSent core runtime is governed by the AtlaSent Software License 1.0.
+This Action (the developer-facing integration) is fully open-source.
+
+For commercial licensing of core infrastructure: licensing@atlasent.io
+
+TRADEMARKS
+----------
+"AtlaSent" and the AtlaSent logo are trademarks of AtlaSent Systems Inc.


### PR DESCRIPTION
## Summary

Adds a `NOTICE` file identifying this repo as "AtlaSent Action — GitHub Actions Gate" under the Tier A (MIT) licensing framework. Notes that the action calls AtlaSent governance runtime (Tier B) at execution time.

This is a low-risk, non-breaking addition as part of the broader licensing architecture standardization tracked in `atlasent-legal`.

## Test plan

- [ ] NOTICE file present at repo root
- [ ] Existing GitHub Actions workflow unaffected

https://claude.ai/code/session_01BHxyPGXLaeULPWDBAStCzC

---
_Generated by [Claude Code](https://claude.ai/code/session_01BHxyPGXLaeULPWDBAStCzC)_