### PR TITLE
Stabilize Deploy Gate V1 GitHub Action

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -34,9 +34,10 @@ jobs:
       - name: AtlaSent authorization gate
         id: gate
         uses: ./
+        env:
+          ATLASENT_API_KEY: ${{ secrets.ATLASENT_API_KEY }}
         with:
-          api-key: ${{ secrets.ATLASENT_API_KEY }}
-          action: production_deploy
+          action: deployment.production
           actor: ${{ github.actor }}
           environment: ${{ inputs.environment || 'prod' }}
           fail-on-deny: ${{ inputs.fail_on_deny == false && 'false' || 'true' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Check evaluate step present
         run: |
-          grep -q 'v1/evaluate' src/batch.ts && echo 'evaluate step found'
+          grep -q 'v1-evaluate' src/batch.ts && echo 'evaluate step found'
 
       - name: Check verify step present
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ SemVer-1.0 promise.
   deployment step executes. Threads `actor`, `action`, `target-id`,
   `bundle-id`, `change_window`, `approvals`, and arbitrary `context`
   into the request.
-- **`verify-permit` step (A5)** — calls `POST /v1/verify-permit`
+- **`verify-permit` step (A5)** — calls `POST /v1-verify-permit`
   after evaluate returns `decision: allow`. Closes the audit record
   and confirms the permit hasn't been revoked or already consumed.
   `verified` output is `"true"` only when both gates pass; `"false"`
@@ -32,7 +32,7 @@ SemVer-1.0 promise.
   decision until the upstream approver flips it (SSE stream or
   polling fallback).
 - **`v2-batch` / `v2-streaming` flags** — opt in to
-  `/v1/evaluate/batch` and SSE streaming respectively.
+  `/v1-evaluate/batch` and SSE streaming respectively.
 
 ### Outputs
 

--- a/README.md
+++ b/README.md
@@ -11,9 +11,10 @@ Push to main → AtlaSent evaluates → permit issued → deploy
 
 ```yaml
 - uses: AtlaSent-Systems-Inc/atlasent-action@v1
+  env:
+    ATLASENT_API_KEY: ${{ secrets.ATLASENT_API_KEY }}
   with:
-    api-key: ${{ secrets.ATLASENT_API_KEY }}
-    action: production_deploy
+    action: deployment.production
     target-id: ${{ github.repository }}
 ```
 
@@ -23,9 +24,10 @@ Push to main → AtlaSent evaluates → permit issued → deploy
 - name: Authorization Gate
   id: gate
   uses: AtlaSent-Systems-Inc/atlasent-action@v1
+  env:
+    ATLASENT_API_KEY: ${{ secrets.ATLASENT_API_KEY }}
   with:
-    api-key: ${{ secrets.ATLASENT_API_KEY }}
-    action: production_deploy
+    action: deployment.production
     actor: ${{ github.actor }}
     target-id: api-service
     environment: live
@@ -42,9 +44,10 @@ The action sets several outputs you can reference in subsequent steps.
 - name: Authorization Gate
   id: gate
   uses: AtlaSent-Systems-Inc/atlasent-action@v1
+  env:
+    ATLASENT_API_KEY: ${{ secrets.ATLASENT_API_KEY }}
   with:
-    api-key: ${{ secrets.ATLASENT_API_KEY }}
-    action: production_deploy
+    action: deployment.production
     target-id: api-service
 
 - name: Deploy
@@ -80,8 +83,8 @@ The action sets several outputs you can reference in subsequent steps.
 
 | Input          | Required | Default                | Description                                             |
 |----------------|----------|------------------------|---------------------------------------------------------|
-| `api-key`      | Yes      | —                      | AtlaSent API key (`ask_live_*` or `ask_test_*`)         |
-| `action`       | Yes*     | —                      | Action type to evaluate (e.g. `production_deploy`). Ignored when `evaluations` is set. |
+| `ATLASENT_API_KEY` env | Yes | — | AtlaSent API key (`ask_live_*` or `ask_test_*`). This is the only required secret. |
+| `action`       | Yes*     | —                      | Action type to evaluate (e.g. `deployment.production`). Ignored when `evaluations` is set. |
 | `actor`        | No       | `${{ github.actor }}`  | Actor identity                                          |
 | `target-id`    | No       | —                      | Target resource being acted on (service, artifact, etc) |
 | `environment`  | No       | Auto-detected          | `live` for `main`/`master`, `test` otherwise            |
@@ -96,7 +99,7 @@ The action sets several outputs you can reference in subsequent steps.
 | `evaluations`      | No       | —         | JSON array of evaluation requests. When set, single-eval inputs are ignored. |
 | `wait-for-id`      | No       | —         | Evaluation ID to block on until it reaches a terminal state (allow/deny). |
 | `wait-timeout-ms`  | No       | `600000`  | Max milliseconds to wait for a terminal decision (default: 10 min). |
-| `v2-batch`         | No       | `false`   | Use the `/v1/evaluate/batch` endpoint instead of sequential loop.   |
+| `v2-batch`         | No       | `false`   | Use the `/v1-evaluate/batch` endpoint instead of sequential loop.   |
 | `v2-streaming`     | No       | `false`   | Use Server-Sent Events for `wait-for-id` polling instead of HTTP polling. |
 
 ## Streaming wait (v2.1)
@@ -105,9 +108,10 @@ For long-running approvals such as change-window gates, enable `v2-streaming` to
 
 ```yaml
 - uses: AtlaSent-Systems-Inc/atlasent-action@v1
+  env:
+    ATLASENT_API_KEY: ${{ secrets.ATLASENT_API_KEY }}
   with:
-    api-key: ${{ secrets.ATLASENT_API_KEY }}
-    action: production_deploy
+    action: deployment.production
     actor: ${{ github.actor }}
     v2-streaming: 'true'
     wait-timeout-ms: '600000'
@@ -119,15 +123,16 @@ When `v2-streaming` is `false` (the default) the action falls back to 5-second H
 
 The `actor` input defaults to `${{ github.actor }}`, so no additional identity setup is needed. The action automatically embeds the GitHub username in the evaluation context sent to AtlaSent.
 
-> **No OIDC exchange.** The `api-key` is what authenticates the workflow against the AtlaSent API. The GitHub `actor` value is a string the action embeds in the evaluation context so policies can branch on human identity. If you want true OIDC trust between GitHub and AtlaSent (no long-lived API key), file a feature request — the wire today does not support it.
+> **No OIDC exchange.** `ATLASENT_API_KEY` is what authenticates the workflow against the AtlaSent API. The GitHub `actor` value is a string the action embeds in the evaluation context so policies can branch on human identity. If you want true OIDC trust between GitHub and AtlaSent (no long-lived API key), file a feature request — the wire today does not support it.
 
 To branch on GitHub identity, write your AtlaSent policy against the `actor` field directly (e.g. `actor == "github:octocat"` or `actor in team:"github:platform-eng"`).
 
 ```yaml
 - uses: AtlaSent-Systems-Inc/atlasent-action@v1
+  env:
+    ATLASENT_API_KEY: ${{ secrets.ATLASENT_API_KEY }}
   with:
-    api-key: ${{ secrets.ATLASENT_API_KEY }}
-    action: production_deploy
+    action: deployment.production
     # actor defaults to ${{ github.actor }} — no extra config needed
 ```
 
@@ -139,12 +144,12 @@ Evaluate multiple actions in a single step:
 - name: Batch Authorization Gate
   id: gate
   uses: AtlaSent-Systems-Inc/atlasent-action@v1
+  env:
+    ATLASENT_API_KEY: ${{ secrets.ATLASENT_API_KEY }}
   with:
-    api-key: ${{ secrets.ATLASENT_API_KEY }}
     evaluations: |
       [
-        {"action": "deploy.staging", "actor": "${{ github.actor }}"},
-        {"action": "deploy.prod",    "actor": "${{ github.actor }}"}
+        {"action": "deployment.production", "actor": "${{ github.actor }}", "environment": "live"}
       ]
 
 - name: Deploy
@@ -154,9 +159,9 @@ Evaluate multiple actions in a single step:
 
 ## How It Works
 
-1. **Evaluate** — POST `/v1/evaluate` with `action_type`, `actor_id`, `target_id`, and a context object populated from GitHub workflow metadata (repo, ref, sha, workflow, run id, PR number, optional user-supplied `context`).
+1. **Evaluate** — POST `/v1-evaluate` with `action_type`, `actor_id`, `target_id`, and a context object populated from GitHub workflow metadata (repo, ref, sha, workflow, run id, PR number, optional user-supplied `context`).
 2. **Decide** — Server returns `allow` / `deny` / `hold` / `escalate` plus a single-use `permit_token` (only when `allow`) and an optional `risk-score`.
-3. **Verify permit** — POST `/v1/verify-permit` to confirm the token hasn’t been replayed. `verified=true` only when both steps pass.
+3. **Verify permit** — POST `/v1-verify-permit` to confirm the token hasn’t been replayed. `verified=true` only when both steps pass.
 4. **Proceed or block** — `fail-on-deny: true` (default) surfaces deny/hold/escalate as a failing step. `false` demotes them to a workflow `::warning`.
 5. **Audit** — Every evaluation writes to the AtlaSent append-only, hash-chained audit log. The `evaluation-id` and `proof-hash` outputs reference the record.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,8 +10,9 @@ This release aligns the public release notes with the shipped `action.yml` contr
 
 ```yaml
 - uses: AtlaSent-Systems-Inc/atlasent-action@v1
+  env:
+    ATLASENT_API_KEY: ${{ secrets.ATLASENT_API_KEY }}
   with:
-    api-key: ${{ secrets.ATLASENT_API_KEY }}
     action: deployment.production
     actor: ${{ github.actor }}
     context: '{"repo":"${{ github.repository }}"}'
@@ -21,7 +22,7 @@ This release aligns the public release notes with the shipped `action.yml` contr
 
 | Input | Required | Description |
 |---|---|---|
-| `api-key` | Yes | AtlaSent API key (`ask_live_*` or `ask_test_*`). |
+| `ATLASENT_API_KEY` env | Yes | AtlaSent API key (`ask_live_*` or `ask_test_*`). |
 | `action` | No* | Action type for single-eval path (ignored when `evaluations` is set). |
 | `actor` | No | Actor identity. Defaults to `${{ github.actor }}`. |
 | `target-id` | No | Target resource identifier; propagated for policy gating. |
@@ -32,7 +33,7 @@ This release aligns the public release notes with the shipped `action.yml` contr
 | `evaluations` | No | JSON array for batch mode; overrides single-eval inputs. |
 | `wait-for-id` | No | Evaluation ID to wait on until terminal (`allow`/`deny`). |
 | `wait-timeout-ms` | No | Wait timeout in ms when using `wait-for-id`. Default: `600000`. |
-| `v2-batch` | No | Opt into `/v1/evaluate/batch`. Default: `false`. |
+| `v2-batch` | No | Opt into `/v1-evaluate/batch`. Default: `false`. |
 | `v2-streaming` | No | Opt into SSE wait stream. Default: `false`. |
 
 \* `action` is effectively required for single-evaluation usage.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -50,7 +50,7 @@ GitHub Action that gates CI deploys on an AtlaSent `allow` decision. Distributed
 
 ## Cross-repo dependencies
 
-- **atlasent-api**: the `decision` enum (`allow|deny|hold|escalate`) and the `/v1/verify-permit` endpoint are on `main` and surfaced here.
+- **atlasent-api**: the `decision` enum (`allow|deny|hold|escalate`) and the `/v1-verify-permit` endpoint are on `main` and surfaced here.
 - **atlasent-sdk**: no longer a runtime dep — `@atlasent/enforce` is a workspace package bundled into `dist/index.js` at build time. The pre-v1.3.0 "pin SDK version" item is moot.
 - **atlasent-docs**: needs a "CI gate" page pointing at Marketplace.
 

--- a/V2_ROLLOUT.md
+++ b/V2_ROLLOUT.md
@@ -14,7 +14,7 @@ The action is a *bundled* gate — it doesn't runtime-import `@atlasent/sdk`. v2
 |---|---|---|---|
 | B.AC1 | Pin `@atlasent/sdk@^2` for the new code paths | `package.json`, build pipeline | Stays bundled. |
 | B.AC2 | New `evaluations` list input — fan out via `evaluateMany` | `action.yml`, `src/inputs.ts`, `src/batch.ts` | Single `action.yml` input parser auto-detects single (`action:`) vs list (`evaluations:`). List wins when both. |
-| B.AC3 | Streaming-wait for `change_window` approvals | `src/stream.ts` | Consumes `/v1/evaluate/stream` SSE; falls back to 5s polling when `v2_streaming` flag is off. |
+| B.AC3 | Streaming-wait for `change_window` approvals | `src/stream.ts` | Consumes `/v1-evaluate/stream` SSE; falls back to 5s polling when `v2_streaming` flag is off. |
 | B.AC4 | Wire B.AC1–3 into `src/index.ts` main flow + `action.yml` inputs | `src/index.ts`, `action.yml` | Last; depends on input-shape sign-off in plan PR #15. |
 | B.AC5 | Default `auth-mode: oidc` in README example | `README.md` | Backward-compatible (`api-key` remains the default *input* value). |
 
@@ -24,10 +24,10 @@ Each item ships with a fallback path so the v2.0 code stays byte-identical until
 
 | Flag (from `atlasent-control-plane`) | Code path |
 |---|---|
-| `v2_batch=true` | `evaluateMany` → `POST /v1/evaluate/batch` |
-| `v2_batch=false` (default) | per-item loop on `/v1/evaluate` (today's behavior) |
+| `v2_batch=true` | `evaluateMany` → `POST /v1-evaluate/batch` |
+| `v2_batch=false` (default) | per-item loop on `/v1-evaluate` (today's behavior) |
 | `v2_streaming=true` | SSE consumer for `change_window` waits |
-| `v2_streaming=false` (default) | 5-second polling on `/v1/evaluate/:id` |
+| `v2_streaming=false` (default) | 5-second polling on `/v1-evaluate/:id` |
 
 ## Behavior conditioning layer
 
@@ -43,13 +43,13 @@ agent is CI infrastructure, not a wellness app. But:
 
 1. Plan PR #15 input-shape decision (single vs list, auto-detect)
 2. B.AC1–3 in flight as draft PR #16 (modules sit alongside v2.0 entry, not yet wired)
-3. B.AC4 wiring once API endpoints (`/v1/evaluate/batch`, `/v1/evaluate/stream`) are deployed (Waqas lane)
+3. B.AC4 wiring once API endpoints (`/v1-evaluate/batch`, `/v1-evaluate/stream`) are deployed (Waqas lane)
 4. v1.2.0 polish (target-id input + risk-score output, draft PR #17) lands FIRST so v2.1 stacks cleanly
 
 ## Cross-repo dependencies
 
 - **atlasent-sdk**: 2.x publish must precede B.AC1
-- **atlasent-api**: `/v1/evaluate/batch`, `/v1/evaluate/stream`, plus the `evaluations[].id` correlation field — all Waqas lane
+- **atlasent-api**: `/v1-evaluate/batch`, `/v1-evaluate/stream`, plus the `evaluations[].id` correlation field — all Waqas lane
 - **atlasent-control-plane**: `v2_batch` and `v2_streaming` per-tenant flags
 - **atlasent-examples**: `flows/01-deploy-gate` becomes the canonical example workflow; updated in `flows/00-golden-path` once v2.1 ships
 

--- a/action.yml
+++ b/action.yml
@@ -4,11 +4,8 @@ branding:
   icon: 'shield'
   color: 'green'
 inputs:
-  api-key:
-    description: 'AtlaSent API key (ask_live_* or ask_test_*)'
-    required: true
   action:
-    description: 'Action type to evaluate (e.g., production_deploy). Used for single-eval path. Ignored when evaluations or policy-sync is set.'
+    description: 'Action type to evaluate (e.g., deployment.production). Used for single-eval path. Ignored when evaluations or policy-sync is set.'
     required: false
   actor:
     description: 'Actor identity (defaults to github.actor). Used for single-eval path.'
@@ -21,7 +18,7 @@ inputs:
     description: 'Environment (defaults to live for main branch, test otherwise)'
     required: false
   api-url:
-    description: 'AtlaSent API URL base (defaults to production). The enforcement wrapper appends /v1/evaluate and /v1/verify-permit.'
+    description: 'AtlaSent API URL base (defaults to production). The enforcement wrapper appends /v1-evaluate and /v1-verify-permit.'
     required: false
     default: 'https://api.atlasent.io'
   fail-on-deny:
@@ -33,7 +30,7 @@ inputs:
     required: false
     default: '{}'
   evaluations:
-    description: 'JSON array of evaluation requests for batch mode, e.g. [{"action":"deploy.prod","actor":"alice"}]. When set, single-eval inputs (action, actor, context) are ignored.'
+    description: 'JSON array of evaluation requests for batch mode, e.g. [{"action":"deployment.production","actor":"alice"}]. When set, single-eval inputs (action, actor, context) are ignored.'
     required: false
   wait-for-id:
     description: 'Evaluation ID to block on until it reaches a terminal state (allow/deny). Used with hold/escalate decisions that require async approval.'
@@ -43,7 +40,7 @@ inputs:
     required: false
     default: '600000'
   v2-batch:
-    description: 'Enable the /v1/evaluate/batch endpoint for batch evaluations (default: false, falls back to sequential /v1/evaluate loop).'
+    description: 'Enable the /v1-evaluate/batch endpoint for batch evaluations (default: false, falls back to sequential /v1-evaluate loop).'
     required: false
     default: 'false'
   v2-streaming:

--- a/dist/index.js
+++ b/dist/index.js
@@ -113,7 +113,7 @@ var require_dist = __commonJS({
       let status;
       let body;
       try {
-        ({ status, body } = await (0, transport_1.post)(`${apiUrl}/v1/evaluate`, JSON.stringify(payload), {
+        ({ status, body } = await (0, transport_1.post)(`${apiUrl}/v1-evaluate`, JSON.stringify(payload), {
           Authorization: `Bearer ${config.apiKey}`
         }));
       } catch (err) {
@@ -161,7 +161,7 @@ var require_dist = __commonJS({
       let status;
       let body;
       try {
-        ({ status, body } = await (0, transport_1.post)(`${apiUrl}/v1/verify-permit`, JSON.stringify({
+        ({ status, body } = await (0, transport_1.post)(`${apiUrl}/v1-verify-permit`, JSON.stringify({
           permit_token: decision.permitToken,
           action_type: config.action,
           actor_id: config.actor
@@ -252,13 +252,13 @@ async function evaluateMany(apiUrl, apiKey, items, v2Batch) {
   let decisions;
   let batchId;
   if (v2Batch) {
-    const r = await fetch(`${apiUrl}/v1/evaluate/batch`, {
+    const r = await fetch(`${apiUrl}/v1-evaluate/batch`, {
       method: "POST",
       headers,
       body: JSON.stringify({ items })
     });
     if (!r.ok) {
-      throw new Error(`atlasent /v1/evaluate/batch ${r.status}`);
+      throw new Error(`atlasent /v1-evaluate/batch ${r.status}`);
     }
     const data = await r.json();
     decisions = data.results;
@@ -266,13 +266,13 @@ async function evaluateMany(apiUrl, apiKey, items, v2Batch) {
   } else {
     decisions = [];
     for (const item of items) {
-      const r = await fetch(`${apiUrl}/v1/evaluate`, {
+      const r = await fetch(`${apiUrl}/v1-evaluate`, {
         method: "POST",
         headers,
         body: JSON.stringify(item)
       });
       if (!r.ok) {
-        throw new Error(`atlasent /v1/evaluate ${r.status}`);
+        throw new Error(`atlasent /v1-evaluate ${r.status}`);
       }
       decisions.push(await r.json());
     }
@@ -294,8 +294,9 @@ async function evaluateMany(apiUrl, apiKey, items, v2Batch) {
 }
 
 // src/inputs.ts
+var PROTECTED_ACTION = "deployment.production";
 function parseInputs(env) {
-  const apiKey = required(env, "INPUT_API-KEY");
+  const apiKey = required(env, "ATLASENT_API_KEY");
   const apiUrl = env["INPUT_API-URL"] || "https://api.atlasent.io";
   const failOnDeny = (env["INPUT_FAIL-ON-DENY"] || "true") === "true";
   const policySyncEnabled = (env["INPUT_POLICY-SYNC"] ?? "").toLowerCase() === "true";
@@ -329,16 +330,21 @@ function parseInputs(env) {
         "`evaluations` must be a non-empty JSON array of evaluation requests"
       );
     }
+    const evaluations = parsed;
+    for (const item of evaluations) {
+      validateProtectedAction(item.action);
+    }
     return {
       apiKey,
       apiUrl,
       failOnDeny,
-      evaluations: parsed,
+      evaluations,
       waitForId: env["INPUT_WAIT-FOR-ID"] || void 0,
       waitTimeoutMs: parseInt(env["INPUT_WAIT-TIMEOUT-MS"] || "600000", 10)
     };
   }
   const action = required(env, "INPUT_ACTION");
+  validateProtectedAction(action);
   const actor = env["INPUT_ACTOR"] || env["GITHUB_ACTOR"] || "unknown";
   const environment = env["INPUT_ENVIRONMENT"];
   const contextRaw = env["INPUT_CONTEXT"] || "{}";
@@ -360,9 +366,18 @@ function parseInputs(env) {
 function required(env, key) {
   const v = env[key];
   if (!v) {
-    throw new Error(`Missing required input: ${key.replace("INPUT_", "").toLowerCase()}`);
+    throw new Error(
+      key === "ATLASENT_API_KEY" ? "Missing required secret: ATLASENT_API_KEY" : `Missing required input: ${key.replace("INPUT_", "").toLowerCase()}`
+    );
   }
   return v;
+}
+function validateProtectedAction(action) {
+  if (action !== PROTECTED_ACTION) {
+    throw new Error(
+      `Unsupported protected action "${action}". Deploy Gate V1 only permits "${PROTECTED_ACTION}"`
+    );
+  }
 }
 
 // src/stream.ts
@@ -375,7 +390,7 @@ async function waitForTerminalDecision(opts) {
   return waitViaPolling(opts);
 }
 async function waitViaStream(opts) {
-  const r = await fetch(`${opts.apiUrl}/v1/evaluate/stream`, {
+  const r = await fetch(`${opts.apiUrl}/v1-evaluate/stream`, {
     method: "POST",
     headers: {
       "content-type": "application/json",
@@ -386,7 +401,7 @@ async function waitViaStream(opts) {
     signal: opts.signal
   });
   if (!r.ok || !r.body) {
-    throw new Error(`atlasent /v1/evaluate/stream ${r.status}`);
+    throw new Error(`atlasent /v1-evaluate/stream ${r.status}`);
   }
   const reader = r.body.getReader();
   const decoder = new TextDecoder();
@@ -421,7 +436,7 @@ async function waitViaPolling(opts) {
   while (Date.now() < deadline) {
     try {
       const r = await fetch(
-        `${opts.apiUrl}/v1/evaluate/${encodeURIComponent(opts.evaluationId)}`,
+        `${opts.apiUrl}/v1-evaluate/${encodeURIComponent(opts.evaluationId)}`,
         {
           headers: { authorization: `Bearer ${opts.apiKey}` },
           signal: opts.signal
@@ -507,10 +522,10 @@ async function emitBatchEvidence(decisions, items, cfg, log = console) {
           environment: item.environment ?? "unknown",
           execution_started_at: (/* @__PURE__ */ new Date()).toISOString(),
           metadata: {
+            ...item.context ?? {},
             source: "github-action-batch",
             action: item.action,
-            actor: item.actor,
-            ...item.context ?? {}
+            actor: item.actor
           }
         },
         log
@@ -720,6 +735,23 @@ function assessFinancialGovernance(input) {
 }
 
 // src/index.ts
+var PROTECTED_ACTION2 = "deployment.production";
+function getApiKey() {
+  const apiKey = (process.env["ATLASENT_API_KEY"] ?? "").trim();
+  if (!apiKey) {
+    setFailed("ATLASENT_API_KEY is required");
+  }
+  return apiKey;
+}
+function validateProtectedAction2(actionType) {
+  if (actionType !== PROTECTED_ACTION2) {
+    setOutput("decision", "error");
+    setOutput("verified", "false");
+    setFailed(
+      `AtlaSent Gate: unsupported protected action "${actionType}". Deploy Gate V1 only permits "${PROTECTED_ACTION2}" (fail-closed).`
+    );
+  }
+}
 function getInput(name, required2 = false) {
   const envKey = `INPUT_${name.replace(/-/g, "_").toUpperCase()}`;
   const val = (process.env[envKey] ?? "").trim();
@@ -930,7 +962,7 @@ async function runPolicySyncStep(apiKey, apiUrl) {
   }
 }
 async function run() {
-  const apiKey = getInput("api-key", true);
+  const apiKey = getApiKey();
   maskValue(apiKey);
   const apiUrl = getInput("api-url") || "https://api.atlasent.io";
   const failOnDeny = getInput("fail-on-deny") !== "false";
@@ -949,7 +981,7 @@ async function run() {
     try {
       result = await runV21(
         {
-          "INPUT_API-KEY": apiKey,
+          ATLASENT_API_KEY: apiKey,
           "INPUT_API-URL": apiUrl,
           "INPUT_FAIL-ON-DENY": failOnDeny ? "true" : "false",
           INPUT_EVALUATIONS: evaluationsRaw,
@@ -999,6 +1031,7 @@ async function run() {
     return;
   }
   const actionType = getInput("action", true);
+  validateProtectedAction2(actionType);
   const actor = getInput("actor") || "unknown";
   const targetId = getInput("target-id") || void 0;
   const explicitEnv = getInput("environment");

--- a/docs/DESIGN_V2.md
+++ b/docs/DESIGN_V2.md
@@ -2,7 +2,7 @@
 
 ## Breaking Change
 
-`atlasent-action` v2 removes its bundled evaluator and calls `POST /v1/evaluate`
+`atlasent-action` v2 removes its bundled evaluator and calls `POST /v1-evaluate`
 on the AtlaSent API instead. This is a **major version bump** (v2 tag).
 
 ## New Inputs
@@ -10,8 +10,8 @@ on the AtlaSent API instead. This is a **major version bump** (v2 tag).
 | Input | Required | Description |
 |-------|----------|-------------|
 | `atlasent-api-url` | Yes | Base URL of your AtlaSent API (e.g. `https://api.atlasent.io`) |
-| `atlasent-api-key` | Yes | Org-scoped API key with `evaluation:execute` scope |
-| `action-id` | Yes | Action identifier to evaluate (e.g. `ci.production-deploy`) |
+| `ATLASENT_API_KEY` env | Yes | Org-scoped API key with `evaluation:execute` scope |
+| `action-id` | Yes | Action identifier to evaluate (e.g. `deployment.production`) |
 | `environment` | No | Target environment (default: `production`) |
 | `actor-id` | No | Actor ID (default: GitHub actor) |
 | `context` | No | JSON string of extra context |
@@ -28,10 +28,11 @@ on the AtlaSent API instead. This is a **major version bump** (v2 tag).
 
 ```yaml
 - uses: atlasent-systems-inc/atlasent-action@v2
+  env:
+    ATLASENT_API_KEY: ${{ secrets.ATLASENT_API_KEY }}
   with:
     atlasent-api-url: ${{ vars.ATLASENT_API_URL }}
-    atlasent-api-key: ${{ secrets.ATLASENT_API_KEY }}
-    action-id: ci.production-deploy
+    action-id: deployment.production
     environment: production
     actor-id: ${{ github.actor }}
     context: |
@@ -68,8 +69,9 @@ If the decision is `deny`, the action fails the workflow step by default
 
 # v2
 - uses: atlasent-systems-inc/atlasent-action@v2
+  env:
+    ATLASENT_API_KEY: ${{ secrets.ATLASENT_API_KEY }}
   with:
     atlasent-api-url: ${{ vars.ATLASENT_API_URL }}
-    atlasent-api-key: ${{ secrets.ATLASENT_API_KEY }}
-    action-id: ci.production-deploy
+    action-id: deployment.production
 ```

--- a/docs/V1_PLAN.md
+++ b/docs/V1_PLAN.md
@@ -19,7 +19,7 @@ every production deploy was pre-authorized by a named approver — the
       permit token, and a link to the console's proof page.
 - [ ] Test mode (`mode: advisory`) logs the decision without blocking;
       enforced mode blocks on `deny` / `hold`.
-- [ ] README has a 3-line copy-paste for a production-deploy gate.
+- [ ] README has a 3-line copy-paste for a deployment.production gate.
 - [ ] E2E test: the action runs against a staging atlasent-api org on
       every PR.
 - [ ] Tag-based release: `v1.0.0`, plus a moving `v1` major tag.

--- a/docs/V2_PILLAR9_PROOF_SYSTEM.md
+++ b/docs/V2_PILLAR9_PROOF_SYSTEM.md
@@ -48,9 +48,10 @@ Example workflow:
 ```yaml
 - uses: atlasent-systems/atlasent-action@v2
   id: gate
+  env:
+    ATLASENT_API_KEY: ${{ secrets.ATLASENT_KEY }}
   with:
-    action: deploy_to_production
-    api-key: ${{ secrets.ATLASENT_KEY }}
+    action: deployment.production
     payload-fields: |
       environment=production
       approver=${{ github.actor }}

--- a/docs/V2_PLAN.md
+++ b/docs/V2_PLAN.md
@@ -15,7 +15,7 @@ The single biggest action-side v2 win. CI matrix jobs today fan out
 N action invocations = N HTTP round-trips. Move to one call.
 
 - **`mode: batch` input** — collects every action invocation in the
-  same workflow run and submits a single `POST /v1/evaluate:batch` at
+  same workflow run and submits a single `POST /v1-evaluate:batch` at
   the join point.
 - **`needs:` declaration** — when set, the batch step blocks downstream
   jobs only on the subset of decisions they depend on, not the whole

--- a/docs/V2_ROLLOUT.md
+++ b/docs/V2_ROLLOUT.md
@@ -7,7 +7,7 @@ Wave B of the [umbrella v2 rollout](https://github.com/AtlaSent-Systems-Inc/atla
 | Item | Module | State |
 |---|---|---|
 | B.AC1 — list-input parser (`evaluations:`) | `src/inputs.ts` | landed (this PR, draft) |
-| B.AC2 — batch fan-out via `/v1/evaluate/batch` | `src/batch.ts` | landed (this PR, draft) |
+| B.AC2 — batch fan-out via `/v1-evaluate/batch` | `src/batch.ts` | landed (this PR, draft) |
 | B.AC3 — streaming-wait for change_window | `src/stream.ts` | landed (this PR, draft) |
 | B.AC4 — wire v2.1 modules into `action.yml` + `src/index.ts` | not in this PR | pending review of the new shape |
 
@@ -20,7 +20,7 @@ settles.
 
 ## Tenant flags
 
-- `v2_batch` — `evaluateMany()` switches between `/v1/evaluate/batch`
+- `v2_batch` — `evaluateMany()` switches between `/v1-evaluate/batch`
   and per-item loop.
 - `v2_streaming` — `waitForTerminalDecision()` switches between SSE
   consumption and 5s polling.

--- a/docs/evaluate-allow.json
+++ b/docs/evaluate-allow.json
@@ -8,7 +8,7 @@
   "expires_at": "2026-04-16T06:00:00Z",
   "metadata": {
     "agent": "github-actions",
-    "action": "production-deploy",
+    "action": "deployment.production",
     "actor": "deploy-engineer",
     "sha": "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4",
     "branch": "refs/heads/main",

--- a/docs/evaluate-deny.json
+++ b/docs/evaluate-deny.json
@@ -24,7 +24,7 @@
   ],
   "metadata": {
     "agent": "github-actions",
-    "action": "production-deploy",
+    "action": "deployment.production",
     "actor": "deploy-engineer",
     "environment": "prod",
     "approvals": 0,

--- a/docs/policy-sync-example.yml
+++ b/docs/policy-sync-example.yml
@@ -37,8 +37,9 @@ jobs:
       - name: AtlaSent policy sync (dry run)
         id: sync
         uses: atlasent-systems-inc/atlasent-action@main
+        env:
+          ATLASENT_API_KEY: ${{ secrets.ATLASENT_API_KEY }}
         with:
-          api-key: ${{ secrets.ATLASENT_API_KEY }}
           policy-sync: 'true'
           policy-bundle: 'policies/bundle.json'
           policy-source: 'github-pr'
@@ -84,8 +85,9 @@ jobs:
       - name: AtlaSent policy sync (apply)
         id: sync
         uses: atlasent-systems-inc/atlasent-action@main
+        env:
+          ATLASENT_API_KEY: ${{ secrets.ATLASENT_API_KEY }}
         with:
-          api-key: ${{ secrets.ATLASENT_API_KEY }}
           policy-sync: 'true'
           policy-bundle: 'policies/bundle.json'
           policy-source: 'github-main'

--- a/docs/v1-migration.md
+++ b/docs/v1-migration.md
@@ -37,7 +37,7 @@ v1 adds three new outputs:
   with:
     atlasent_api_key: ${{ secrets.ATLASENT_API_KEY }}
     atlasent_anon_key: ${{ secrets.ATLASENT_ANON_KEY }}
-    action: production-deploy
+    action: deployment.production
     environment: production
 
 # ... your deploy steps ...

--- a/docs/verify-allow.json
+++ b/docs/verify-allow.json
@@ -8,7 +8,7 @@
   "permit_age_seconds": 12,
   "metadata": {
     "agent": "github-actions",
-    "action": "production-deploy",
+    "action": "deployment.production",
     "actor": "deploy-engineer",
     "environment": "prod",
     "original_decision_id": "eval_9f8e7d6c5b4a3210",

--- a/packages/enforce/dist/index.js
+++ b/packages/enforce/dist/index.js
@@ -2,9 +2,9 @@
 // @atlasent/enforce — fail-closed execution wrapper.
 //
 // Enforces the evaluate → verify → verifyPermit → execute contract:
-//   1. evaluate()     — calls POST /v1/evaluate; any infra error blocks execution
+//   1. evaluate()     — calls POST /v1-evaluate; any infra error blocks execution
 //   2. verify()       — rejects non-allow decisions (deny / hold / escalate)
-//   3. verifyPermit() — calls POST /v1/verify-permit; replay/expired tokens block
+//   3. verifyPermit() — calls POST /v1-verify-permit; replay/expired tokens block
 //   4. enforce()      — composes all three; fn never runs unless all steps pass
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.EnforceError = void 0;
@@ -44,7 +44,7 @@ async function evaluate(config) {
     let status;
     let body;
     try {
-        ({ status, body } = await (0, transport_1.post)(`${apiUrl}/v1/evaluate`, JSON.stringify(payload), {
+        ({ status, body } = await (0, transport_1.post)(`${apiUrl}/v1-evaluate`, JSON.stringify(payload), {
             Authorization: `Bearer ${config.apiKey}`,
         }));
     }
@@ -90,7 +90,7 @@ function verify(decision) {
     }
 }
 // ---------------------------------------------------------------------------
-// Step 3 — verifyPermit (calls /v1/verify-permit, fail-closed)
+// Step 3 — verifyPermit (calls /v1-verify-permit, fail-closed)
 //
 // Without this round-trip the enforce wrapper is evaluate-only: a tampered or
 // replayed permit_token would still surface decision=allow. This step consumes
@@ -104,7 +104,7 @@ async function verifyPermit(config, decision) {
     let status;
     let body;
     try {
-        ({ status, body } = await (0, transport_1.post)(`${apiUrl}/v1/verify-permit`, JSON.stringify({
+        ({ status, body } = await (0, transport_1.post)(`${apiUrl}/v1-verify-permit`, JSON.stringify({
             permit_token: decision.permitToken,
             action_type: config.action,
             actor_id: config.actor,

--- a/packages/enforce/src/__tests__/enforce.test.ts
+++ b/packages/enforce/src/__tests__/enforce.test.ts
@@ -10,7 +10,7 @@ const mockPost = post as ReturnType<typeof vi.fn>;
 const BASE_CONFIG = {
   apiKey: "ask_test_key",
   apiUrl: "https://api.test",
-  action: "production_deploy",
+  action: "deployment.production",
   actor: "alice",
 };
 
@@ -48,8 +48,8 @@ describe("enforce — contract invariants", () => {
     mockAllow();
     await enforce(BASE_CONFIG, vi.fn().mockResolvedValue(null));
     expect(mockPost).toHaveBeenCalledTimes(2);
-    expect(mockPost.mock.calls[0][0]).toBe("https://api.test/v1/evaluate");
-    expect(mockPost.mock.calls[1][0]).toBe("https://api.test/v1/verify-permit");
+    expect(mockPost.mock.calls[0][0]).toBe("https://api.test/v1-evaluate");
+    expect(mockPost.mock.calls[1][0]).toBe("https://api.test/v1-verify-permit");
   });
 
   it("fn never runs when evaluate throws (network failure)", async () => {

--- a/packages/enforce/src/__tests__/evaluate.test.ts
+++ b/packages/enforce/src/__tests__/evaluate.test.ts
@@ -9,7 +9,7 @@ const mockPost = post as ReturnType<typeof vi.fn>;
 const BASE_CONFIG = {
   apiKey: "ask_test_key",
   apiUrl: "https://api.test",
-  action: "production_deploy",
+  action: "deployment.production",
   actor: "alice",
 };
 
@@ -95,7 +95,7 @@ describe("evaluate", () => {
   it("hits the correct endpoint", async () => {
     mockResponse(200, { decision: "allow" });
     await evaluate(BASE_CONFIG);
-    expect(mockPost.mock.calls[0][0]).toBe("https://api.test/v1/evaluate");
+    expect(mockPost.mock.calls[0][0]).toBe("https://api.test/v1-evaluate");
   });
 
   it("sends Authorization header with the api key", async () => {
@@ -109,6 +109,6 @@ describe("evaluate", () => {
   it("strips trailing slash from apiUrl", async () => {
     mockResponse(200, { decision: "allow" });
     await evaluate({ ...BASE_CONFIG, apiUrl: "https://api.test/" });
-    expect(mockPost.mock.calls[0][0]).toBe("https://api.test/v1/evaluate");
+    expect(mockPost.mock.calls[0][0]).toBe("https://api.test/v1-evaluate");
   });
 });

--- a/packages/enforce/src/__tests__/transport.test.ts
+++ b/packages/enforce/src/__tests__/transport.test.ts
@@ -36,7 +36,7 @@ describe("transport.post", () => {
       return req;
     });
 
-    const p = post("https://api.test/v1/evaluate", '{"x":1}', { Authorization: "Bearer k" });
+    const p = post("https://api.test/v1-evaluate", '{"x":1}', { Authorization: "Bearer k" });
     res.emit("data", Buffer.from('{"ok"'));
     res.emit("data", Buffer.from(':true}'));
     res.emit("end");
@@ -57,7 +57,7 @@ describe("transport.post", () => {
       return req;
     });
 
-    const p = post("https://api.test/v1/evaluate", '{"x":1}', { Authorization: "Bearer k" });
+    const p = post("https://api.test/v1-evaluate", '{"x":1}', { Authorization: "Bearer k" });
     res.emit("end");
     await p;
 
@@ -71,7 +71,7 @@ describe("transport.post", () => {
     const req = fakeReq();
     mockRequest.mockImplementation(() => req);
 
-    const p = post("https://api.test/v1/evaluate", "{}", {});
+    const p = post("https://api.test/v1-evaluate", "{}", {});
     req.emit("error", new Error("ECONNREFUSED"));
 
     await expect(p).rejects.toThrow("ECONNREFUSED");
@@ -86,7 +86,7 @@ describe("transport.post", () => {
       return req;
     });
 
-    const p = post("https://api.test/v1/evaluate", "{}", {});
+    const p = post("https://api.test/v1-evaluate", "{}", {});
     res.emit("data", Buffer.from("partial"));
     res.emit("error", new Error("ECONNRESET"));
 
@@ -97,7 +97,7 @@ describe("transport.post", () => {
     const req = fakeReq();
     mockRequest.mockImplementation(() => req);
 
-    const p = post("https://api.test/v1/evaluate", "{}", {});
+    const p = post("https://api.test/v1-evaluate", "{}", {});
     req.emit("timeout");
 
     await expect(p).rejects.toThrow("Request timed out after 30s");

--- a/packages/enforce/src/__tests__/verify-permit.test.ts
+++ b/packages/enforce/src/__tests__/verify-permit.test.ts
@@ -10,7 +10,7 @@ const mockPost = post as ReturnType<typeof vi.fn>;
 const BASE_CONFIG = {
   apiKey: "ask_test_key",
   apiUrl: "https://api.test",
-  action: "production_deploy",
+  action: "deployment.production",
   actor: "alice",
 };
 
@@ -40,7 +40,7 @@ describe("verifyPermit", () => {
   it("hits the correct verify-permit endpoint", async () => {
     mockResponse(200, { verified: true });
     await verifyPermit(BASE_CONFIG, ALLOW_DECISION);
-    expect(mockPost.mock.calls[0][0]).toBe("https://api.test/v1/verify-permit");
+    expect(mockPost.mock.calls[0][0]).toBe("https://api.test/v1-verify-permit");
   });
 
   it("sends permit_token + action_type + actor_id in body", async () => {
@@ -48,7 +48,7 @@ describe("verifyPermit", () => {
     await verifyPermit(BASE_CONFIG, ALLOW_DECISION);
     const body = JSON.parse(mockPost.mock.calls[0][1] as string) as Record<string, unknown>;
     expect(body.permit_token).toBe("pt-abc");
-    expect(body.action_type).toBe("production_deploy");
+    expect(body.action_type).toBe("deployment.production");
     expect(body.actor_id).toBe("alice");
   });
 
@@ -63,7 +63,7 @@ describe("verifyPermit", () => {
   it("strips trailing slash from apiUrl", async () => {
     mockResponse(200, { verified: true });
     await verifyPermit({ ...BASE_CONFIG, apiUrl: "https://api.test/" }, ALLOW_DECISION);
-    expect(mockPost.mock.calls[0][0]).toBe("https://api.test/v1/verify-permit");
+    expect(mockPost.mock.calls[0][0]).toBe("https://api.test/v1-verify-permit");
   });
 
   // ── No permit_token ─────────────────────────────────────────────────────────

--- a/packages/enforce/src/index.ts
+++ b/packages/enforce/src/index.ts
@@ -1,9 +1,9 @@
 // @atlasent/enforce — fail-closed execution wrapper.
 //
 // Enforces the evaluate → verify → verifyPermit → execute contract:
-//   1. evaluate()     — calls POST /v1/evaluate; any infra error blocks execution
+//   1. evaluate()     — calls POST /v1-evaluate; any infra error blocks execution
 //   2. verify()       — rejects non-allow decisions (deny / hold / escalate)
-//   3. verifyPermit() — calls POST /v1/verify-permit; replay/expired tokens block
+//   3. verifyPermit() — calls POST /v1-verify-permit; replay/expired tokens block
 //   4. enforce()      — composes all three; fn never runs unless all steps pass
 
 import { post } from "./transport";
@@ -78,7 +78,7 @@ export async function evaluate(config: EnforceConfig): Promise<Decision> {
   let status: number;
   let body: string;
   try {
-    ({ status, body } = await post(`${apiUrl}/v1/evaluate`, JSON.stringify(payload), {
+    ({ status, body } = await post(`${apiUrl}/v1-evaluate`, JSON.stringify(payload), {
       Authorization: `Bearer ${config.apiKey}`,
     }));
   } catch (err) {
@@ -143,7 +143,7 @@ export function verify(decision: Decision): void {
 }
 
 // ---------------------------------------------------------------------------
-// Step 3 — verifyPermit (calls /v1/verify-permit, fail-closed)
+// Step 3 — verifyPermit (calls /v1-verify-permit, fail-closed)
 //
 // Without this round-trip the enforce wrapper is evaluate-only: a tampered or
 // replayed permit_token would still surface decision=allow. This step consumes
@@ -168,7 +168,7 @@ export async function verifyPermit(
   let body: string;
   try {
     ({ status, body } = await post(
-      `${apiUrl}/v1/verify-permit`,
+      `${apiUrl}/v1-verify-permit`,
       JSON.stringify({
         permit_token: decision.permitToken,
         action_type: config.action,

--- a/src/__tests__/batch.test.ts
+++ b/src/__tests__/batch.test.ts
@@ -27,7 +27,7 @@ describe("evaluateMany", () => {
     );
   }
 
-  it("hits /v1/evaluate/batch when v2Batch=true and verifies allow decisions", async () => {
+  it("hits /v1-evaluate/batch when v2Batch=true and verifies allow decisions", async () => {
     fetchMock.mockResolvedValueOnce(
       new Response(
         JSON.stringify({
@@ -48,15 +48,15 @@ describe("evaluateMany", () => {
     expect(out.batchId).toBe("b1");
     expect(out.decisions[0].verified).toBe(true);
     expect(fetchMock).toHaveBeenCalledWith(
-      "https://api.test/v1/evaluate/batch",
+      "https://api.test/v1-evaluate/batch",
       expect.anything(),
     );
     expect(mockVerifyPermit).toHaveBeenCalledOnce();
   });
 
-  it("loops /v1/evaluate when v2Batch=false and verifies each allow decision", async () => {
+  it("loops /v1-evaluate when v2Batch=false and verifies each allow decision", async () => {
     fetchMock.mockImplementation((url: string) => {
-      if (url.endsWith("/v1/evaluate")) {
+      if (url.endsWith("/v1-evaluate")) {
         return Promise.resolve(evalResp("allow", "tok1"));
       }
       return Promise.reject(new Error(`unexpected url: ${url}`));
@@ -139,7 +139,7 @@ describe("evaluateMany", () => {
     await evaluateMany(
       "https://api.test",
       "api-key-123",
-      [{ action: "deploy.prod", actor: "alice" }],
+      [{ action: "deployment.production", actor: "alice" }],
       false,
     );
 
@@ -147,7 +147,7 @@ describe("evaluateMany", () => {
       expect.objectContaining({
         apiKey: "api-key-123",
         apiUrl: "https://api.test",
-        action: "deploy.prod",
+        action: "deployment.production",
         actor: "alice",
       }),
       expect.objectContaining({

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -6,6 +6,8 @@ import * as path from "node:path";
 // Mock @atlasent/enforce before importing index so that enforce() is
 // intercepted. EnforceError must still be the real class so instanceof checks
 // in run() work correctly.
+vi.mock("../evidenceClient", () => ({ emitEvidenceEvent: vi.fn(async () => {}) }));
+
 vi.mock("@atlasent/enforce", async (importOriginal) => {
   const original = await importOriginal<typeof import("@atlasent/enforce")>();
   return {
@@ -118,6 +120,10 @@ function setInput(name: string, value: string) {
   process.env[`INPUT_${name.replace(/-/g, "_").toUpperCase()}`] = value;
 }
 
+function setApiKey(value = "ask_test_key") {
+  process.env["ATLASENT_API_KEY"] = value;
+}
+
 function getConsoleLogs(): string[] {
   return (consoleSpy as unknown as { mock: { calls: Array<Array<unknown>> } })
     .mock.calls.map((c) => String(c[0]));
@@ -133,22 +139,35 @@ function getExitCalls(): Array<number | string | null | undefined> {
 // ---------------------------------------------------------------------------
 
 describe("missing required inputs", () => {
-  it("calls process.exit(1) when api-key is missing", async () => {
-    setInput("action", "deploy.prod");
-    // api-key is NOT set
+  it("calls process.exit(1) when ATLASENT_API_KEY is missing", async () => {
+    setInput("action", "deployment.production");
+    // ATLASENT_API_KEY is NOT set
 
     await expect(run()).rejects.toBeInstanceOf(ProcessExitError);
     expect(getExitCalls()).toContain(1);
-    expect(getConsoleLogs().some((l) => l.includes("Input required and not supplied: api-key"))).toBe(true);
+    expect(getConsoleLogs().some((l) => l.includes("ATLASENT_API_KEY is required"))).toBe(true);
   });
 
   it("calls process.exit(1) when action is missing on the single-eval path", async () => {
-    setInput("api-key", "ask_test_key");
+    setApiKey();
     // action is NOT set, evaluations also not set
 
     await expect(run()).rejects.toBeInstanceOf(ProcessExitError);
     expect(getExitCalls()).toContain(1);
     expect(getConsoleLogs().some((l) => l.includes("Input required and not supplied: action"))).toBe(true);
+  });
+
+  it("fails closed when action is not deployment.production", async () => {
+    setApiKey();
+    setInput("action", "deploy.staging");
+
+    await expect(run()).rejects.toBeInstanceOf(ProcessExitError);
+    expect(getExitCalls()).toContain(1);
+    expect(mockEnforce).not.toHaveBeenCalled();
+    const outputs = readOutputs(outputFile);
+    expect(outputs["decision"]).toBe("error");
+    expect(outputs["verified"]).toBe("false");
+    expect(getConsoleLogs().some((l) => l.includes("deployment.production"))).toBe(true);
   });
 });
 
@@ -158,8 +177,8 @@ describe("missing required inputs", () => {
 
 describe("allow response", () => {
   it("sets decision=allow output and does NOT call process.exit", async () => {
-    setInput("api-key", "ask_test_key");
-    setInput("action", "production_deploy");
+    setApiKey();
+    setInput("action", "deployment.production");
 
     mockEnforce.mockResolvedValueOnce(makeAllowResult());
 
@@ -172,8 +191,8 @@ describe("allow response", () => {
   });
 
   it("sets permit-token, evaluation-id, proof-hash, risk-score outputs on allow", async () => {
-    setInput("api-key", "ask_test_key");
-    setInput("action", "deploy.prod");
+    setApiKey();
+    setInput("action", "deployment.production");
 
     mockEnforce.mockResolvedValueOnce(makeAllowResult({
       evaluationId: "ev-abc",
@@ -197,8 +216,8 @@ describe("allow response", () => {
 
 describe("deny decision", () => {
   it("calls process.exit(1) when enforce throws EnforceError with deny decision", async () => {
-    setInput("api-key", "ask_test_key");
-    setInput("action", "production_deploy");
+    setApiKey();
+    setInput("action", "deployment.production");
 
     const denyDecision = makeDecision({ decision: "deny", denyReason: "policy violation" });
     mockEnforce.mockRejectedValueOnce(
@@ -211,8 +230,8 @@ describe("deny decision", () => {
   });
 
   it("sets decision=deny output before failing", async () => {
-    setInput("api-key", "ask_test_key");
-    setInput("action", "deploy.prod");
+    setApiKey();
+    setInput("action", "deployment.production");
 
     const denyDecision = makeDecision({ decision: "deny", denyReason: "not allowed" });
     mockEnforce.mockRejectedValueOnce(
@@ -227,8 +246,8 @@ describe("deny decision", () => {
   });
 
   it("does NOT call process.exit when fail-on-deny=false and decision is deny", async () => {
-    setInput("api-key", "ask_test_key");
-    setInput("action", "deploy.prod");
+    setApiKey();
+    setInput("action", "deployment.production");
     setInput("fail-on-deny", "false");
 
     const denyDecision = makeDecision({ decision: "deny", denyReason: "informational only" });
@@ -248,8 +267,8 @@ describe("deny decision", () => {
 
 describe("v1.1 audit fields", () => {
   it("sets chain-entry output when API returns chainEntry", async () => {
-    setInput("api-key", "ask_test_key");
-    setInput("action", "deploy.prod");
+    setApiKey();
+    setInput("action", "deployment.production");
 
     const chainEntry = { blockHash: "0xabc", txIndex: 1 };
     mockEnforce.mockResolvedValueOnce(makeAllowResult({
@@ -267,8 +286,8 @@ describe("v1.1 audit fields", () => {
   });
 
   it("sets chain-entry to JSON null when chainEntry is absent", async () => {
-    setInput("api-key", "ask_test_key");
-    setInput("action", "deploy.prod");
+    setApiKey();
+    setInput("action", "deployment.production");
 
     mockEnforce.mockResolvedValueOnce(makeAllowResult({ chainEntry: undefined }));
 
@@ -280,13 +299,36 @@ describe("v1.1 audit fields", () => {
 });
 
 // ---------------------------------------------------------------------------
-// 5. Deprecated ::set-output is NOT emitted
+// 5. Verify failure → process.exit(1) (fail-closed)
+// ---------------------------------------------------------------------------
+
+describe("verify failure", () => {
+  it("fails closed when permit verification fails", async () => {
+    setApiKey();
+    setInput("action", "deployment.production");
+
+    const allowDecision = makeDecision({ decision: "allow", permitToken: "pt-replay" });
+    mockEnforce.mockRejectedValueOnce(
+      new EnforceError("Permit verification failed (outcome=permit_consumed)", "verify-permit", allowDecision),
+    );
+
+    await expect(run()).rejects.toBeInstanceOf(ProcessExitError);
+
+    const outputs = readOutputs(outputFile);
+    expect(outputs["decision"]).toBe("allow");
+    expect(outputs["verified"]).toBe("false");
+    expect(getConsoleLogs().some((l) => l.includes("Deploy blocked (fail-closed)"))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. Deprecated ::set-output is NOT emitted
 // ---------------------------------------------------------------------------
 
 describe("deprecated ::set-output command", () => {
   it("does not emit ::set-output:: workflow command on allow", async () => {
-    setInput("api-key", "ask_test_key");
-    setInput("action", "deploy.prod");
+    setApiKey();
+    setInput("action", "deployment.production");
 
     mockEnforce.mockResolvedValueOnce(makeAllowResult());
 

--- a/src/__tests__/inputs.test.ts
+++ b/src/__tests__/inputs.test.ts
@@ -6,13 +6,13 @@ describe("parseInputs", () => {
 
   it("parses v2.0 single-input path", () => {
     const out = parseInputs({
-      "INPUT_API-KEY": "ask_test",
-      INPUT_ACTION: "production_deploy",
+      ATLASENT_API_KEY: "ask_test",
+      INPUT_ACTION: "deployment.production",
       GITHUB_ACTOR: "alice",
     });
     expect(out.evaluations).toBeUndefined();
     expect(out.policySync).toBeUndefined();
-    expect(out.single?.action).toBe("production_deploy");
+    expect(out.single?.action).toBe("deployment.production");
     expect(out.single?.actor).toBe("alice");
   });
 
@@ -20,22 +20,22 @@ describe("parseInputs", () => {
 
   it("parses v2.1 list-input path", () => {
     const out = parseInputs({
-      "INPUT_API-KEY": "ask_test",
+      ATLASENT_API_KEY: "ask_test",
       INPUT_EVALUATIONS: JSON.stringify([
-        { action: "deploy.staging", actor: "alice" },
-        { action: "deploy.prod", actor: "alice" },
+        { action: "deployment.production", actor: "alice" },
+        { action: "deployment.production", actor: "alice" },
       ]),
     });
     expect(out.evaluations).toHaveLength(2);
-    expect(out.evaluations?.[1].action).toBe("deploy.prod");
+    expect(out.evaluations?.[1].action).toBe("deployment.production");
     expect(out.policySync).toBeUndefined();
   });
 
   it("prefers list when both action and evaluations are set", () => {
     const out = parseInputs({
-      "INPUT_API-KEY": "ask_test",
+      ATLASENT_API_KEY: "ask_test",
       INPUT_ACTION: "ignored",
-      INPUT_EVALUATIONS: JSON.stringify([{ action: "deploy.prod", actor: "alice" }]),
+      INPUT_EVALUATIONS: JSON.stringify([{ action: "deployment.production", actor: "alice" }]),
     });
     expect(out.evaluations).toHaveLength(1);
     expect(out.single).toBeUndefined();
@@ -44,7 +44,7 @@ describe("parseInputs", () => {
   it("throws on empty list", () => {
     expect(() =>
       parseInputs({
-        "INPUT_API-KEY": "ask_test",
+        ATLASENT_API_KEY: "ask_test",
         INPUT_EVALUATIONS: "[]",
       }),
     ).toThrow(/non-empty/);
@@ -53,7 +53,7 @@ describe("parseInputs", () => {
   it("throws a clear error on invalid JSON in evaluations", () => {
     expect(() =>
       parseInputs({
-        "INPUT_API-KEY": "ask_test",
+        ATLASENT_API_KEY: "ask_test",
         INPUT_EVALUATIONS: "not-json",
       }),
     ).toThrow(/not valid JSON/);
@@ -62,24 +62,42 @@ describe("parseInputs", () => {
   it("throws a clear error on invalid JSON in context", () => {
     expect(() =>
       parseInputs({
-        "INPUT_API-KEY": "ask_test",
-        INPUT_ACTION: "deploy",
+        ATLASENT_API_KEY: "ask_test",
+        INPUT_ACTION: "deployment.production",
         INPUT_CONTEXT: "{bad json}",
       }),
     ).toThrow(/not valid JSON/);
   });
 
   it("throws when neither single nor list is set", () => {
-    expect(() => parseInputs({ "INPUT_API-KEY": "ask_test" })).toThrow(
+    expect(() => parseInputs({ ATLASENT_API_KEY: "ask_test" })).toThrow(
       /Missing required input: action/,
     );
+  });
+
+  it("accepts ATLASENT_API_KEY as the required secret", () => {
+    const out = parseInputs({
+      ATLASENT_API_KEY: "ask_test_env",
+      INPUT_ACTION: "deployment.production",
+      GITHUB_ACTOR: "alice",
+    });
+    expect(out.apiKey).toBe("ask_test_env");
+  });
+
+  it("throws on wrong protected action", () => {
+    expect(() =>
+      parseInputs({
+        ATLASENT_API_KEY: "ask_test_env",
+        INPUT_ACTION: "deploy.staging",
+      }),
+    ).toThrow(/deployment\.production/);
   });
 
   // ── Policy sync path ─────────────────────────────────────────────────
 
   it("parses policy sync mode with defaults", () => {
     const out = parseInputs({
-      "INPUT_API-KEY": "ask_test",
+      ATLASENT_API_KEY: "ask_test",
       "INPUT_POLICY-SYNC": "true",
       "INPUT_POLICY-BUNDLE": "policies/bundle.json",
     });
@@ -93,7 +111,7 @@ describe("parseInputs", () => {
 
   it("parses policy-dry-run=false", () => {
     const out = parseInputs({
-      "INPUT_API-KEY": "ask_test",
+      ATLASENT_API_KEY: "ask_test",
       "INPUT_POLICY-SYNC": "true",
       "INPUT_POLICY-BUNDLE": "policies/bundle.json",
       "INPUT_POLICY-DRY-RUN": "false",
@@ -103,7 +121,7 @@ describe("parseInputs", () => {
 
   it("parses policy-dry-run=true explicitly", () => {
     const out = parseInputs({
-      "INPUT_API-KEY": "ask_test",
+      ATLASENT_API_KEY: "ask_test",
       "INPUT_POLICY-SYNC": "true",
       "INPUT_POLICY-BUNDLE": "policies/bundle.json",
       "INPUT_POLICY-DRY-RUN": "true",
@@ -113,7 +131,7 @@ describe("parseInputs", () => {
 
   it("parses policy-source", () => {
     const out = parseInputs({
-      "INPUT_API-KEY": "ask_test",
+      ATLASENT_API_KEY: "ask_test",
       "INPUT_POLICY-SYNC": "true",
       "INPUT_POLICY-BUNDLE": "policies/bundle.json",
       "INPUT_POLICY-SOURCE": "ci-pipeline",
@@ -124,7 +142,7 @@ describe("parseInputs", () => {
   it("throws when policy-sync=true but policy-bundle is missing", () => {
     expect(() =>
       parseInputs({
-        "INPUT_API-KEY": "ask_test",
+        ATLASENT_API_KEY: "ask_test",
         "INPUT_POLICY-SYNC": "true",
       }),
     ).toThrow(/policy-bundle.*required/);
@@ -132,7 +150,7 @@ describe("parseInputs", () => {
 
   it("policy-sync=true takes priority over evaluations", () => {
     const out = parseInputs({
-      "INPUT_API-KEY": "ask_test",
+      ATLASENT_API_KEY: "ask_test",
       "INPUT_POLICY-SYNC": "true",
       "INPUT_POLICY-BUNDLE": "policies/bundle.json",
       INPUT_EVALUATIONS: JSON.stringify([{ action: "deploy", actor: "alice" }]),
@@ -143,10 +161,10 @@ describe("parseInputs", () => {
 
   it("policy-sync=true takes priority over single action", () => {
     const out = parseInputs({
-      "INPUT_API-KEY": "ask_test",
+      ATLASENT_API_KEY: "ask_test",
       "INPUT_POLICY-SYNC": "true",
       "INPUT_POLICY-BUNDLE": "policies/bundle.json",
-      INPUT_ACTION: "production_deploy",
+      INPUT_ACTION: "deployment.production",
     });
     expect(out.policySync).toBeDefined();
     expect(out.single).toBeUndefined();
@@ -154,12 +172,12 @@ describe("parseInputs", () => {
 
   it("policy-sync=false falls through to normal routing", () => {
     const out = parseInputs({
-      "INPUT_API-KEY": "ask_test",
+      ATLASENT_API_KEY: "ask_test",
       "INPUT_POLICY-SYNC": "false",
-      INPUT_ACTION: "production_deploy",
+      INPUT_ACTION: "deployment.production",
       GITHUB_ACTOR: "alice",
     });
     expect(out.policySync).toBeUndefined();
-    expect(out.single?.action).toBe("production_deploy");
+    expect(out.single?.action).toBe("deployment.production");
   });
 });

--- a/src/__tests__/policySync.test.ts
+++ b/src/__tests__/policySync.test.ts
@@ -124,21 +124,21 @@ describe("runPolicySync", () => {
 
   it("throws when bundle is not valid JSON", async () => {
     vi.mocked(fs.existsSync).mockReturnValue(true);
-    vi.mocked(fs.readFileSync).mockReturnValue("not-json" as unknown as Buffer);
+    vi.mocked(fs.readFileSync).mockReturnValue("not-json" as unknown as string);
     await expect(runPolicySync(BASE)).rejects.toThrow(/Failed to parse policy bundle/);
   });
 
   it("throws when bundle JSON is not an array", async () => {
     vi.mocked(fs.existsSync).mockReturnValue(true);
     vi.mocked(fs.readFileSync).mockReturnValue(
-      JSON.stringify({ name: "x" }) as unknown as Buffer,
+      JSON.stringify({ name: "x" }) as unknown as string,
     );
     await expect(runPolicySync(BASE)).rejects.toThrow(/must be a JSON array/);
   });
 
   it("throws when bundle array is empty", async () => {
     vi.mocked(fs.existsSync).mockReturnValue(true);
-    vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify([]) as unknown as Buffer);
+    vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify([]) as unknown as string);
     await expect(runPolicySync(BASE)).rejects.toThrow(/empty/);
   });
 
@@ -147,7 +147,7 @@ describe("runPolicySync", () => {
   it("throws on network error (fetch rejects)", async () => {
     vi.mocked(fs.existsSync).mockReturnValue(true);
     vi.mocked(fs.readFileSync).mockReturnValue(
-      JSON.stringify(BUNDLE) as unknown as Buffer,
+      JSON.stringify(BUNDLE) as unknown as string,
     );
     vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("ECONNREFUSED")));
     await expect(runPolicySync(BASE)).rejects.toThrow(/Network error/);
@@ -156,7 +156,7 @@ describe("runPolicySync", () => {
   it("throws on non-OK response with error detail in body", async () => {
     vi.mocked(fs.existsSync).mockReturnValue(true);
     vi.mocked(fs.readFileSync).mockReturnValue(
-      JSON.stringify(BUNDLE) as unknown as Buffer,
+      JSON.stringify(BUNDLE) as unknown as string,
     );
     vi.stubGlobal(
       "fetch",
@@ -172,7 +172,7 @@ describe("runPolicySync", () => {
   it("throws on non-OK response when error body is unparseable", async () => {
     vi.mocked(fs.existsSync).mockReturnValue(true);
     vi.mocked(fs.readFileSync).mockReturnValue(
-      JSON.stringify(BUNDLE) as unknown as Buffer,
+      JSON.stringify(BUNDLE) as unknown as string,
     );
     vi.stubGlobal(
       "fetch",
@@ -188,7 +188,7 @@ describe("runPolicySync", () => {
   it("throws when success response body is not valid JSON", async () => {
     vi.mocked(fs.existsSync).mockReturnValue(true);
     vi.mocked(fs.readFileSync).mockReturnValue(
-      JSON.stringify(BUNDLE) as unknown as Buffer,
+      JSON.stringify(BUNDLE) as unknown as string,
     );
     vi.stubGlobal(
       "fetch",
@@ -206,7 +206,7 @@ describe("runPolicySync", () => {
   it("returns run, formatted diff, and rejected=false on completed", async () => {
     vi.mocked(fs.existsSync).mockReturnValue(true);
     vi.mocked(fs.readFileSync).mockReturnValue(
-      JSON.stringify(BUNDLE) as unknown as Buffer,
+      JSON.stringify(BUNDLE) as unknown as string,
     );
     const run = makeRun({ policies_added: 2, policies_updated: 1 });
     vi.stubGlobal("fetch", stubFetch(run));
@@ -220,7 +220,7 @@ describe("runPolicySync", () => {
   it('sets rejected=true when status is "rejected"', async () => {
     vi.mocked(fs.existsSync).mockReturnValue(true);
     vi.mocked(fs.readFileSync).mockReturnValue(
-      JSON.stringify(BUNDLE) as unknown as Buffer,
+      JSON.stringify(BUNDLE) as unknown as string,
     );
     vi.stubGlobal("fetch", stubFetch(makeRun({ status: "rejected" })));
     const result = await runPolicySync(BASE);
@@ -230,7 +230,7 @@ describe("runPolicySync", () => {
   it('sets rejected=true when status is "failed"', async () => {
     vi.mocked(fs.existsSync).mockReturnValue(true);
     vi.mocked(fs.readFileSync).mockReturnValue(
-      JSON.stringify(BUNDLE) as unknown as Buffer,
+      JSON.stringify(BUNDLE) as unknown as string,
     );
     vi.stubGlobal("fetch", stubFetch(makeRun({ status: "failed" })));
     const result = await runPolicySync(BASE);
@@ -240,7 +240,7 @@ describe("runPolicySync", () => {
   it('sets rejected=false when status is "validating" (still in progress)', async () => {
     vi.mocked(fs.existsSync).mockReturnValue(true);
     vi.mocked(fs.readFileSync).mockReturnValue(
-      JSON.stringify(BUNDLE) as unknown as Buffer,
+      JSON.stringify(BUNDLE) as unknown as string,
     );
     vi.stubGlobal("fetch", stubFetch(makeRun({ status: "validating" })));
     const result = await runPolicySync(BASE);
@@ -252,7 +252,7 @@ describe("runPolicySync", () => {
   it("hits the correct URL, stripping trailing slash from apiUrl", async () => {
     vi.mocked(fs.existsSync).mockReturnValue(true);
     vi.mocked(fs.readFileSync).mockReturnValue(
-      JSON.stringify(BUNDLE) as unknown as Buffer,
+      JSON.stringify(BUNDLE) as unknown as string,
     );
     const fetchMock = stubFetch(makeRun());
     vi.stubGlobal("fetch", fetchMock);
@@ -264,7 +264,7 @@ describe("runPolicySync", () => {
   it("sends Bearer Authorization header", async () => {
     vi.mocked(fs.existsSync).mockReturnValue(true);
     vi.mocked(fs.readFileSync).mockReturnValue(
-      JSON.stringify(BUNDLE) as unknown as Buffer,
+      JSON.stringify(BUNDLE) as unknown as string,
     );
     const fetchMock = stubFetch(makeRun());
     vi.stubGlobal("fetch", fetchMock);
@@ -279,7 +279,7 @@ describe("runPolicySync", () => {
   it("sends dry_run=true in request body", async () => {
     vi.mocked(fs.existsSync).mockReturnValue(true);
     vi.mocked(fs.readFileSync).mockReturnValue(
-      JSON.stringify(BUNDLE) as unknown as Buffer,
+      JSON.stringify(BUNDLE) as unknown as string,
     );
     const fetchMock = stubFetch(makeRun());
     vi.stubGlobal("fetch", fetchMock);
@@ -292,7 +292,7 @@ describe("runPolicySync", () => {
   it("sends dry_run=false in request body", async () => {
     vi.mocked(fs.existsSync).mockReturnValue(true);
     vi.mocked(fs.readFileSync).mockReturnValue(
-      JSON.stringify(BUNDLE) as unknown as Buffer,
+      JSON.stringify(BUNDLE) as unknown as string,
     );
     const fetchMock = stubFetch(makeRun());
     vi.stubGlobal("fetch", fetchMock);
@@ -305,7 +305,7 @@ describe("runPolicySync", () => {
   it("sends source, commit_sha, and ref in request body", async () => {
     vi.mocked(fs.existsSync).mockReturnValue(true);
     vi.mocked(fs.readFileSync).mockReturnValue(
-      JSON.stringify(BUNDLE) as unknown as Buffer,
+      JSON.stringify(BUNDLE) as unknown as string,
     );
     const fetchMock = stubFetch(makeRun());
     vi.stubGlobal("fetch", fetchMock);
@@ -326,7 +326,7 @@ describe("runPolicySync", () => {
   it("defaults source to 'github-action' when not provided", async () => {
     vi.mocked(fs.existsSync).mockReturnValue(true);
     vi.mocked(fs.readFileSync).mockReturnValue(
-      JSON.stringify(BUNDLE) as unknown as Buffer,
+      JSON.stringify(BUNDLE) as unknown as string,
     );
     const fetchMock = stubFetch(makeRun());
     vi.stubGlobal("fetch", fetchMock);
@@ -339,7 +339,7 @@ describe("runPolicySync", () => {
   it("sends the full policy array from the bundle file", async () => {
     vi.mocked(fs.existsSync).mockReturnValue(true);
     vi.mocked(fs.readFileSync).mockReturnValue(
-      JSON.stringify(BUNDLE) as unknown as Buffer,
+      JSON.stringify(BUNDLE) as unknown as string,
     );
     const fetchMock = stubFetch(makeRun());
     vi.stubGlobal("fetch", fetchMock);

--- a/src/__tests__/stream.test.ts
+++ b/src/__tests__/stream.test.ts
@@ -54,7 +54,7 @@ describe("waitForTerminalDecision", () => {
     const result = await waitForTerminalDecision(BASE_OPTS);
     expect(result.decision).toBe("allow");
     expect(fetchMock).toHaveBeenCalledWith(
-      "https://api.test/v1/evaluate/ev-123",
+      "https://api.test/v1-evaluate/ev-123",
       expect.objectContaining({
         headers: expect.objectContaining({ authorization: "Bearer ask_test_key" }),
       }),
@@ -123,7 +123,7 @@ describe("waitForTerminalDecision", () => {
 
     expect(result.decision).toBe("allow");
     expect(fetchMock).toHaveBeenCalledWith(
-      "https://api.test/v1/evaluate/stream",
+      "https://api.test/v1-evaluate/stream",
       expect.objectContaining({ method: "POST" }),
     );
   });

--- a/src/__tests__/v21-emit.test.ts
+++ b/src/__tests__/v21-emit.test.ts
@@ -44,7 +44,7 @@ describe("emitBatchEvidence", () => {
       allowVerified("eval-1", "permit-1"),
       allowVerified("eval-2", "permit-2"),
     ];
-    const items = [item("deploy.production", "live"), item("rotate.key", "test")];
+    const items = [item("deployment.production", "live"), item("rotate.key", "test")];
 
     await emitBatchEvidence(decisions, items, cfg, noopLog);
 
@@ -62,7 +62,7 @@ describe("emitBatchEvidence", () => {
     expect((firstCall[1] as { metadata: Record<string, unknown> }).metadata)
       .toMatchObject({
         source: "github-action-batch",
-        action: "deploy.production",
+        action: "deployment.production",
         actor: "github:tester",
       });
   });
@@ -76,7 +76,7 @@ describe("emitBatchEvidence", () => {
     });
 
     const decisions: Decision[] = [allowVerified("eval-1", "permit-1")];
-    const items = [item("deploy.production", "live")];
+    const items = [item("deployment.production", "live")];
 
     // Must not reject. If it did, the action would crash at this point and
     // the build outcome would be wrong.
@@ -91,7 +91,7 @@ describe("emitBatchEvidence", () => {
     });
     const log = { info: vi.fn(), warning: vi.fn() };
     const decisions: Decision[] = [allowVerified("eval-1", "permit-1")];
-    const items = [item("deploy.production", "live")];
+    const items = [item("deployment.production", "live")];
 
     await emitBatchEvidence(decisions, items, cfg, log);
 

--- a/src/__tests__/v21.test.ts
+++ b/src/__tests__/v21.test.ts
@@ -7,6 +7,7 @@ import { runV21 } from "../v21";
 vi.mock("../batch", () => ({ evaluateMany: vi.fn() }));
 vi.mock("@atlasent/enforce", () => ({ verifyPermit: vi.fn() }));
 vi.mock("../stream", () => ({ waitForTerminalDecision: vi.fn() }));
+vi.mock("../evidenceClient", () => ({ emitEvidenceEvent: vi.fn(async () => {}) }));
 
 import { evaluateMany } from "../batch";
 import { verifyPermit } from "@atlasent/enforce";
@@ -18,10 +19,10 @@ const mockWait = waitForTerminalDecision as ReturnType<typeof vi.fn>;
 
 // Minimal env that drives the batch path (evaluations set).
 const BASE_ENV = {
-  "INPUT_API-KEY": "ask_test_key",
+  ATLASENT_API_KEY: "ask_test_key",
   "INPUT_API-URL": "https://api.test",
   "INPUT_FAIL-ON-DENY": "true",
-  INPUT_EVALUATIONS: JSON.stringify([{ action: "deploy.prod", actor: "alice" }]),
+  INPUT_EVALUATIONS: JSON.stringify([{ action: "deployment.production", actor: "alice" }]),
   "INPUT_WAIT-TIMEOUT-MS": "30000",
 };
 
@@ -51,7 +52,7 @@ it("passes items and flags through to evaluateMany", async () => {
   expect(mockEvaluateMany).toHaveBeenCalledWith(
     "https://api.test",
     "ask_test_key",
-    [{ action: "deploy.prod", actor: "alice" }],
+    [{ action: "deployment.production", actor: "alice" }],
     true,
   );
 });
@@ -59,13 +60,13 @@ it("passes items and flags through to evaluateMany", async () => {
 it("wraps single action/actor into a 1-item batch", async () => {
   mockEvaluateMany.mockResolvedValueOnce({ decisions: [decision("allow")], batchId: "b1" });
   await runV21(
-    { "INPUT_API-KEY": "ask_test_key", INPUT_ACTION: "deploy.staging", INPUT_ACTOR: "bob" },
+    { ATLASENT_API_KEY: "ask_test_key", INPUT_ACTION: "deployment.production", INPUT_ACTOR: "bob" },
     FLAGS,
   );
   expect(mockEvaluateMany).toHaveBeenCalledWith(
     "https://api.atlasent.io",
     "ask_test_key",
-    [expect.objectContaining({ action: "deploy.staging", actor: "bob" })],
+    [expect.objectContaining({ action: "deployment.production", actor: "bob" })],
     false,
   );
 });
@@ -153,7 +154,7 @@ it("verifies terminal allow from wait-for-id with correct permit params", async 
     expect.objectContaining({
       apiKey: "ask_test_key",
       apiUrl: "https://api.test",
-      action: "deploy.prod",
+      action: "deployment.production",
       actor: "alice",
     }),
     expect.objectContaining({

--- a/src/batch.ts
+++ b/src/batch.ts
@@ -1,7 +1,7 @@
 // Wave B.AC2 / B.AC4 — batch fan-out helper with per-decision verify-permit.
 //
 // When the per-tenant `v2Batch` flag is on, posts a single batch to
-// /v1/evaluate/batch. Otherwise, per-item /v1/evaluate loop. Either
+// /v1-evaluate/batch. Otherwise, per-item /v1-evaluate loop. Either
 // path then runs verify-permit for every allow decision, matching the
 // single-eval runGate() contract — the gate is fail-closed end-to-end.
 //
@@ -32,13 +32,13 @@ export async function evaluateMany(
   let batchId: string;
 
   if (v2Batch) {
-    const r = await fetch(`${apiUrl}/v1/evaluate/batch`, {
+    const r = await fetch(`${apiUrl}/v1-evaluate/batch`, {
       method: "POST",
       headers,
       body: JSON.stringify({ items }),
     });
     if (!r.ok) {
-      throw new Error(`atlasent /v1/evaluate/batch ${r.status}`);
+      throw new Error(`atlasent /v1-evaluate/batch ${r.status}`);
     }
     const data = (await r.json()) as {
       results: Decision[];
@@ -49,13 +49,13 @@ export async function evaluateMany(
   } else {
     decisions = [];
     for (const item of items) {
-      const r = await fetch(`${apiUrl}/v1/evaluate`, {
+      const r = await fetch(`${apiUrl}/v1-evaluate`, {
         method: "POST",
         headers,
         body: JSON.stringify(item),
       });
       if (!r.ok) {
-        throw new Error(`atlasent /v1/evaluate ${r.status}`);
+        throw new Error(`atlasent /v1-evaluate ${r.status}`);
       }
       decisions.push((await r.json()) as Decision);
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,28 @@ import {
 import type { FinancialAdvisoryInput } from "./financialGovernanceAdvisory";
 import { emitEvidenceEvent } from "./evidenceClient";
 
+
+const PROTECTED_ACTION = "deployment.production";
+
+function getApiKey(): string {
+  const apiKey = (process.env["ATLASENT_API_KEY"] ?? "").trim();
+  if (!apiKey) {
+    setFailed("ATLASENT_API_KEY is required");
+  }
+  return apiKey;
+}
+
+function validateProtectedAction(actionType: string): void {
+  if (actionType !== PROTECTED_ACTION) {
+    setOutput("decision", "error");
+    setOutput("verified", "false");
+    setFailed(
+      `AtlaSent Gate: unsupported protected action "${actionType}". ` +
+        `Deploy Gate V1 only permits "${PROTECTED_ACTION}" (fail-closed).`,
+    );
+  }
+}
+
 // ---------------------------------------------------------------------------
 // GitHub Actions helpers
 // ---------------------------------------------------------------------------
@@ -304,7 +326,7 @@ async function runPolicySyncStep(apiKey: string, apiUrl: string): Promise<void> 
 
 export async function run(): Promise<void> {
   // 1. Read shared inputs
-  const apiKey = getInput("api-key", true);
+  const apiKey = getApiKey();
   maskValue(apiKey);
 
   const apiUrl = getInput("api-url") || "https://api.atlasent.io";
@@ -330,7 +352,7 @@ export async function run(): Promise<void> {
     try {
       result = await runV21(
         {
-          "INPUT_API-KEY": apiKey,
+          ATLASENT_API_KEY: apiKey,
           "INPUT_API-URL": apiUrl,
           "INPUT_FAIL-ON-DENY": failOnDeny ? "true" : "false",
           INPUT_EVALUATIONS: evaluationsRaw,
@@ -390,6 +412,7 @@ export async function run(): Promise<void> {
 
   // ── Single-eval path via @atlasent/enforce ─────────────────────────────────
   const actionType = getInput("action", true);
+  validateProtectedAction(actionType);
   const actor = getInput("actor") || "unknown";
   const targetId = getInput("target-id") || undefined;
   const explicitEnv = getInput("environment");

--- a/src/inputs.ts
+++ b/src/inputs.ts
@@ -10,6 +10,8 @@
 
 import type { EvaluateRequest } from "./types";
 
+export const PROTECTED_ACTION = "deployment.production";
+
 export interface ActionInputs {
   apiKey: string;
   apiUrl: string;
@@ -30,7 +32,7 @@ export interface ActionInputs {
 }
 
 export function parseInputs(env: Record<string, string | undefined>): ActionInputs {
-  const apiKey = required(env, "INPUT_API-KEY");
+  const apiKey = required(env, "ATLASENT_API_KEY");
   const apiUrl = env["INPUT_API-URL"] || "https://api.atlasent.io";
   const failOnDeny = (env["INPUT_FAIL-ON-DENY"] || "true") === "true";
 
@@ -68,11 +70,15 @@ export function parseInputs(env: Record<string, string | undefined>): ActionInpu
         "`evaluations` must be a non-empty JSON array of evaluation requests",
       );
     }
+    const evaluations = parsed as EvaluateRequest[];
+    for (const item of evaluations) {
+      validateProtectedAction(item.action);
+    }
     return {
       apiKey,
       apiUrl,
       failOnDeny,
-      evaluations: parsed as EvaluateRequest[],
+      evaluations,
       waitForId: env["INPUT_WAIT-FOR-ID"] || undefined,
       waitTimeoutMs: parseInt(env["INPUT_WAIT-TIMEOUT-MS"] || "600000", 10),
     };
@@ -80,6 +86,7 @@ export function parseInputs(env: Record<string, string | undefined>): ActionInpu
 
   // ── Single-eval mode (v2.0 fallback) ────────────────────────────────────────
   const action = required(env, "INPUT_ACTION");
+  validateProtectedAction(action);
   const actor = env["INPUT_ACTOR"] || env["GITHUB_ACTOR"] || "unknown";
   const environment = env["INPUT_ENVIRONMENT"];
   const contextRaw = env["INPUT_CONTEXT"] || "{}";
@@ -103,7 +110,19 @@ export function parseInputs(env: Record<string, string | undefined>): ActionInpu
 function required(env: Record<string, string | undefined>, key: string): string {
   const v = env[key];
   if (!v) {
-    throw new Error(`Missing required input: ${key.replace("INPUT_", "").toLowerCase()}`);
+    throw new Error(
+      key === "ATLASENT_API_KEY"
+        ? "Missing required secret: ATLASENT_API_KEY"
+        : `Missing required input: ${key.replace("INPUT_", "").toLowerCase()}`,
+    );
   }
   return v;
+}
+
+function validateProtectedAction(action: string): void {
+  if (action !== PROTECTED_ACTION) {
+    throw new Error(
+      `Unsupported protected action "${action}". Deploy Gate V1 only permits "${PROTECTED_ACTION}"`,
+    );
+  }
 }

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -1,11 +1,11 @@
 // Wave B.AC3 — streaming-wait helper.
 //
-// Consumes /v1/evaluate/stream Server-Sent Events for the duration of
+// Consumes /v1-evaluate/stream Server-Sent Events for the duration of
 // a change_window approval. Resolves with the first terminal decision
 // (allow / deny) for the watched evaluation id, or rejects on timeout.
 //
 // When the per-tenant `v2_streaming` flag is off, falls back to
-// polling /v1/evaluate/:id every 5 seconds.
+// polling /v1-evaluate/:id every 5 seconds.
 
 import type { Decision } from "./types";
 
@@ -31,7 +31,7 @@ export async function waitForTerminalDecision(
 }
 
 async function waitViaStream(opts: WaitOptions): Promise<Decision> {
-  const r = await fetch(`${opts.apiUrl}/v1/evaluate/stream`, {
+  const r = await fetch(`${opts.apiUrl}/v1-evaluate/stream`, {
     method: "POST",
     headers: {
       "content-type": "application/json",
@@ -42,7 +42,7 @@ async function waitViaStream(opts: WaitOptions): Promise<Decision> {
     signal: opts.signal,
   });
   if (!r.ok || !r.body) {
-    throw new Error(`atlasent /v1/evaluate/stream ${r.status}`);
+    throw new Error(`atlasent /v1-evaluate/stream ${r.status}`);
   }
   const reader = r.body.getReader();
   const decoder = new TextDecoder();
@@ -76,7 +76,7 @@ async function waitViaPolling(opts: WaitOptions): Promise<Decision> {
   while (Date.now() < deadline) {
     try {
       const r = await fetch(
-        `${opts.apiUrl}/v1/evaluate/${encodeURIComponent(opts.evaluationId)}`,
+        `${opts.apiUrl}/v1-evaluate/${encodeURIComponent(opts.evaluationId)}`,
         {
           headers: { authorization: `Bearer ${opts.apiKey}` },
           signal: opts.signal,

--- a/src/v21.ts
+++ b/src/v21.ts
@@ -66,10 +66,10 @@ export async function emitBatchEvidence(
           environment: item.environment ?? "unknown",
           execution_started_at: new Date().toISOString(),
           metadata: {
+            ...(item.context ?? {}),
             source: "github-action-batch",
             action: item.action,
             actor: item.actor,
-            ...(item.context ?? {}),
           },
         },
         log,


### PR DESCRIPTION
### Motivation
- Align the Deploy Gate V1 action with the canonical protected action and backend contract so CI deploys are evaluated and verified reliably (evaluate → verify-permit → execute) and the gate fails closed on any mismatch or infra error.
- Require a single secret surface (`ATLASENT_API_KEY`) to simplify secret handling and avoid leaking `api-key` across inputs/outputs and examples.

### Description
- Enforce the canonical protected action `deployment.production` and fail-closed when any other action is supplied via `validateProtectedAction` in `src/index.ts` and `src/inputs.ts`.
- Normalize API paths to the rollout contract by switching calls to `POST /v1-evaluate` and `POST /v1-verify-permit` (and batch/stream variants under `/v1-evaluate/*`) across `packages/enforce`, `src/batch.ts`, `src/stream.ts`, `src/v21.ts`, and bundled `dist` outputs.
- Require `ATLASENT_API_KEY` as the runtime secret (read from `env`) and remove/mark the `api-key` input as deprecated in `action.yml`, update `src/inputs.ts` parsing to accept `ATLASENT_API_KEY`, and validate per-item actions in batch mode.
- Update documentation, examples, and workflow templates to use `env: ATLASENT_API_KEY`, `deployment.production`, and the new endpoint naming; add/adjust tests to cover allow, deny, missing key, verify-permit failure, and wrong-action cases; rebuild `dist/` and `@atlasent/enforce` artifacts.

### Testing
- Ran the unit test suite with `npm test` (Vitest) which completed successfully: all tests passed (`162 passed`).
- Type-checks succeeded via `npm run typecheck` and the workspace package via `npm run typecheck -w @atlasent/enforce` with no errors.
- Built artifacts successfully using `npm run build -w @atlasent/enforce` and `npm run build` (esbuild bundle refreshed `dist/index.js`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03c867ae588320a4631d4295a0e0c5)