### PR TITLE
feat: v2.0.0 alias-tolerant Deploy Gate canonical action string

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -293,8 +293,25 @@ async function evaluateMany(apiUrl, apiKey, items, v2Batch) {
   return { decisions: verified, batchId };
 }
 
+// src/canonicalAction.ts
+var PRODUCTION_DEPLOY_ACTION = "production.deploy";
+var LEGACY_PRODUCTION_DEPLOY_ALIAS = "deployment.production";
+function normalizeProtectedAction(raw) {
+  if (raw === LEGACY_PRODUCTION_DEPLOY_ALIAS) {
+    return { canonical: PRODUCTION_DEPLOY_ACTION, wasLegacyAlias: true };
+  }
+  return { canonical: raw, wasLegacyAlias: false };
+}
+function assertProtectedAction(raw) {
+  const { canonical } = normalizeProtectedAction(raw);
+  if (canonical !== PRODUCTION_DEPLOY_ACTION) {
+    throw new Error(
+      `Unsupported protected action "${raw}". Deploy Gate V1 only permits "${PRODUCTION_DEPLOY_ACTION}" (legacy alias "${LEGACY_PRODUCTION_DEPLOY_ALIAS}" is accepted during the V1 alias window).`
+    );
+  }
+}
+
 // src/inputs.ts
-var PROTECTED_ACTION = "production.deploy";
 function parseInputs(env) {
   const apiKey = required(env, "ATLASENT_API_KEY");
   const apiUrl = env["INPUT_API-URL"] || "https://api.atlasent.io";
@@ -332,7 +349,8 @@ function parseInputs(env) {
     }
     const evaluations = parsed;
     for (const item of evaluations) {
-      validateProtectedAction(item.action);
+      assertProtectedAction(item.action);
+      item.action = normalizeProtectedAction(item.action).canonical;
     }
     return {
       apiKey,
@@ -343,8 +361,9 @@ function parseInputs(env) {
       waitTimeoutMs: parseInt(env["INPUT_WAIT-TIMEOUT-MS"] || "600000", 10)
     };
   }
-  const action = required(env, "INPUT_ACTION");
-  validateProtectedAction(action);
+  const rawAction = required(env, "INPUT_ACTION");
+  assertProtectedAction(rawAction);
+  const action = normalizeProtectedAction(rawAction).canonical;
   const actor = env["INPUT_ACTOR"] || env["GITHUB_ACTOR"] || "unknown";
   const environment = env["INPUT_ENVIRONMENT"];
   const contextRaw = env["INPUT_CONTEXT"] || "{}";
@@ -371,13 +390,6 @@ function required(env, key) {
     );
   }
   return v;
-}
-function validateProtectedAction(action) {
-  if (action !== PROTECTED_ACTION) {
-    throw new Error(
-      `Unsupported protected action "${action}". Deploy Gate V1 only permits "${PROTECTED_ACTION}"`
-    );
-  }
 }
 
 // src/stream.ts
@@ -735,7 +747,6 @@ function assessFinancialGovernance(input) {
 }
 
 // src/index.ts
-var PROTECTED_ACTION2 = "production.deploy";
 function getApiKey() {
   const apiKey = (process.env["ATLASENT_API_KEY"] ?? "").trim();
   if (!apiKey) {
@@ -743,14 +754,16 @@ function getApiKey() {
   }
   return apiKey;
 }
-function validateProtectedAction2(actionType) {
-  if (actionType !== PROTECTED_ACTION2) {
+function normalizeAndValidateProtectedAction(actionType) {
+  const { canonical } = normalizeProtectedAction(actionType);
+  if (canonical !== PRODUCTION_DEPLOY_ACTION) {
     setOutput("decision", "error");
     setOutput("verified", "false");
     setFailed(
-      `AtlaSent Gate: unsupported protected action "${actionType}". Deploy Gate V1 only permits "${PROTECTED_ACTION2}" (fail-closed).`
+      `AtlaSent Gate: unsupported protected action "${actionType}". Deploy Gate V1 only permits "${PRODUCTION_DEPLOY_ACTION}" (legacy alias "${LEGACY_PRODUCTION_DEPLOY_ALIAS}" is accepted during the V1 alias window).`
     );
   }
+  return canonical;
 }
 function getInput(name, required2 = false) {
   const envKey = `INPUT_${name.replace(/-/g, "_").toUpperCase()}`;
@@ -1030,8 +1043,8 @@ async function run() {
     info(`  Batch ID: ${result.batchId}`);
     return;
   }
-  const actionType = getInput("action", true);
-  validateProtectedAction2(actionType);
+  const rawActionType = getInput("action", true);
+  const actionType = normalizeAndValidateProtectedAction(rawActionType);
   const actor = getInput("actor") || "unknown";
   const targetId = getInput("target-id") || void 0;
   const explicitEnv = getInput("environment");

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atlasent-action",
-  "version": "0.1.0",
+  "version": "2.0.0",
   "description": "GitHub Action for AtlaSent authorization gates — require a permit before critical CI/CD actions execute",
   "main": "dist/index.js",
   "workspaces": ["packages/*"],

--- a/src/__tests__/canonicalAction.test.ts
+++ b/src/__tests__/canonicalAction.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import {
+  LEGACY_PRODUCTION_DEPLOY_ALIAS,
+  PRODUCTION_DEPLOY_ACTION,
+  assertProtectedAction,
+  normalizeProtectedAction,
+} from "../canonicalAction";
+
+describe("canonicalAction", () => {
+  describe("normalizeProtectedAction", () => {
+    it("passes the canonical through unchanged", () => {
+      const out = normalizeProtectedAction(PRODUCTION_DEPLOY_ACTION);
+      expect(out.canonical).toBe(PRODUCTION_DEPLOY_ACTION);
+      expect(out.wasLegacyAlias).toBe(false);
+    });
+
+    it("rewrites the legacy alias to the canonical and flags it", () => {
+      const out = normalizeProtectedAction(LEGACY_PRODUCTION_DEPLOY_ALIAS);
+      expect(out.canonical).toBe(PRODUCTION_DEPLOY_ACTION);
+      expect(out.wasLegacyAlias).toBe(true);
+    });
+
+    it("leaves unrelated strings unchanged (assert step rejects them separately)", () => {
+      const out = normalizeProtectedAction("deploy.staging");
+      expect(out.canonical).toBe("deploy.staging");
+      expect(out.wasLegacyAlias).toBe(false);
+    });
+  });
+
+  describe("assertProtectedAction", () => {
+    it("accepts the canonical", () => {
+      expect(() => assertProtectedAction(PRODUCTION_DEPLOY_ACTION)).not.toThrow();
+    });
+
+    it("accepts the legacy alias", () => {
+      expect(() => assertProtectedAction(LEGACY_PRODUCTION_DEPLOY_ALIAS)).not.toThrow();
+    });
+
+    it("rejects unrelated action strings", () => {
+      expect(() => assertProtectedAction("deploy.staging")).toThrow(
+        /Deploy Gate V1 only permits "production\.deploy"/,
+      );
+    });
+
+    it("error message names both the canonical and the legacy alias", () => {
+      expect(() => assertProtectedAction("nope")).toThrow(
+        new RegExp(
+          `${PRODUCTION_DEPLOY_ACTION}.*${LEGACY_PRODUCTION_DEPLOY_ALIAS}`,
+          "s",
+        ),
+      );
+    });
+  });
+});

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -190,6 +190,26 @@ describe("allow response", () => {
     expect(outputs["verified"]).toBe("true");
   });
 
+  it("accepts the legacy deployment.production alias and forwards the canonical to enforce()", async () => {
+    setApiKey();
+    setInput("action", "deployment.production");
+
+    mockEnforce.mockResolvedValueOnce(makeAllowResult());
+
+    await run();
+
+    expect(getExitCalls()).toHaveLength(0);
+    // The first call's first argument is the EnforceConfig. Its `action`
+    // field must be the canonical, not the legacy alias the caller sent.
+    const calls = (mockEnforce as unknown as { mock: { calls: Array<Array<unknown>> } }).mock.calls;
+    expect(calls).toHaveLength(1);
+    const enforceConfig = calls[0][0] as { action: string };
+    expect(enforceConfig.action).toBe("production.deploy");
+    const outputs = readOutputs(outputFile);
+    expect(outputs["decision"]).toBe("allow");
+    expect(outputs["verified"]).toBe("true");
+  });
+
   it("sets permit-token, evaluation-id, proof-hash, risk-score outputs on allow", async () => {
     setApiKey();
     setInput("action", "production.deploy");

--- a/src/__tests__/inputs.test.ts
+++ b/src/__tests__/inputs.test.ts
@@ -93,6 +93,30 @@ describe("parseInputs", () => {
     ).toThrow(/production\.deploy/);
   });
 
+  // ── V1 alias-window tolerance ───────────────────────────────────────
+
+  it("accepts the legacy deployment.production alias and normalizes single-eval to canonical", () => {
+    const out = parseInputs({
+      ATLASENT_API_KEY: "ask_test",
+      INPUT_ACTION: "deployment.production",
+      GITHUB_ACTOR: "alice",
+    });
+    expect(out.single?.action).toBe("production.deploy");
+  });
+
+  it("accepts the legacy alias inside batch evaluations and rewrites every item to canonical", () => {
+    const out = parseInputs({
+      ATLASENT_API_KEY: "ask_test",
+      INPUT_EVALUATIONS: JSON.stringify([
+        { action: "deployment.production", actor: "alice" },
+        { action: "production.deploy", actor: "bob" },
+      ]),
+    });
+    expect(out.evaluations).toHaveLength(2);
+    expect(out.evaluations?.[0].action).toBe("production.deploy");
+    expect(out.evaluations?.[1].action).toBe("production.deploy");
+  });
+
   // ── Policy sync path ─────────────────────────────────────────────────
 
   it("parses policy sync mode with defaults", () => {

--- a/src/canonicalAction.ts
+++ b/src/canonicalAction.ts
@@ -1,0 +1,33 @@
+// Canonical Deploy Gate V1 protected action — single source of truth
+// at the action's I/O boundary.
+//
+// Mirrors atlasent-api's `_shared/canonical-action.ts`: we accept the
+// legacy alias on input and normalize to the canonical before
+// forwarding to the server. The server itself is alias-tolerant per
+// atlasent-api PR #662, so this is belt-and-suspenders during the V1
+// alias window — both ends rewrite to the same string.
+
+export const PRODUCTION_DEPLOY_ACTION = "production.deploy";
+export const LEGACY_PRODUCTION_DEPLOY_ALIAS = "deployment.production";
+
+export interface NormalizedProtectedAction {
+  canonical: string;
+  wasLegacyAlias: boolean;
+}
+
+export function normalizeProtectedAction(raw: string): NormalizedProtectedAction {
+  if (raw === LEGACY_PRODUCTION_DEPLOY_ALIAS) {
+    return { canonical: PRODUCTION_DEPLOY_ACTION, wasLegacyAlias: true };
+  }
+  return { canonical: raw, wasLegacyAlias: false };
+}
+
+export function assertProtectedAction(raw: string): void {
+  const { canonical } = normalizeProtectedAction(raw);
+  if (canonical !== PRODUCTION_DEPLOY_ACTION) {
+    throw new Error(
+      `Unsupported protected action "${raw}". Deploy Gate V1 only permits "${PRODUCTION_DEPLOY_ACTION}" ` +
+        `(legacy alias "${LEGACY_PRODUCTION_DEPLOY_ALIAS}" is accepted during the V1 alias window).`,
+    );
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,9 +20,11 @@ import {
 } from "./financialGovernanceAdvisory";
 import type { FinancialAdvisoryInput } from "./financialGovernanceAdvisory";
 import { emitEvidenceEvent } from "./evidenceClient";
-
-
-const PROTECTED_ACTION = "production.deploy";
+import {
+  LEGACY_PRODUCTION_DEPLOY_ALIAS,
+  PRODUCTION_DEPLOY_ACTION,
+  normalizeProtectedAction,
+} from "./canonicalAction";
 
 function getApiKey(): string {
   const apiKey = (process.env["ATLASENT_API_KEY"] ?? "").trim();
@@ -32,15 +34,28 @@ function getApiKey(): string {
   return apiKey;
 }
 
-function validateProtectedAction(actionType: string): void {
-  if (actionType !== PROTECTED_ACTION) {
+/**
+ * Normalize the workflow-supplied `action` input to the canonical
+ * Deploy Gate V1 string. Legacy alias `deployment.production` is
+ * accepted and rewritten to `production.deploy`. Anything else
+ * fails closed with `decision=error`.
+ *
+ * Returns the canonical string for downstream use. Callers should
+ * use the returned value, NOT the raw input, so every downstream
+ * surface (evaluate body, GH outputs, audit) carries the canonical.
+ */
+function normalizeAndValidateProtectedAction(actionType: string): string {
+  const { canonical } = normalizeProtectedAction(actionType);
+  if (canonical !== PRODUCTION_DEPLOY_ACTION) {
     setOutput("decision", "error");
     setOutput("verified", "false");
     setFailed(
       `AtlaSent Gate: unsupported protected action "${actionType}". ` +
-        `Deploy Gate V1 only permits "${PROTECTED_ACTION}" (fail-closed).`,
+        `Deploy Gate V1 only permits "${PRODUCTION_DEPLOY_ACTION}" ` +
+        `(legacy alias "${LEGACY_PRODUCTION_DEPLOY_ALIAS}" is accepted during the V1 alias window).`,
     );
   }
+  return canonical;
 }
 
 // ---------------------------------------------------------------------------
@@ -411,8 +426,12 @@ export async function run(): Promise<void> {
   }
 
   // ── Single-eval path via @atlasent/enforce ─────────────────────────────────
-  const actionType = getInput("action", true);
-  validateProtectedAction(actionType);
+  // Normalize the raw input to the canonical (`production.deploy`) before
+  // any downstream use. Legacy callers passing `deployment.production`
+  // continue to work; the evaluate body, GH outputs, and audit context
+  // all carry the canonical string from here on.
+  const rawActionType = getInput("action", true);
+  const actionType = normalizeAndValidateProtectedAction(rawActionType);
   const actor = getInput("actor") || "unknown";
   const targetId = getInput("target-id") || undefined;
   const explicitEnv = getInput("environment");

--- a/src/inputs.ts
+++ b/src/inputs.ts
@@ -9,8 +9,16 @@
 // Existing single-eval workflows continue to work unchanged.
 
 import type { EvaluateRequest } from "./types";
+import {
+  PRODUCTION_DEPLOY_ACTION,
+  assertProtectedAction,
+  normalizeProtectedAction,
+} from "./canonicalAction";
 
-export const PROTECTED_ACTION = "production.deploy";
+// Re-exported for backward compatibility with consumers (and tests) that
+// imported `PROTECTED_ACTION` from this module before the canonical
+// helper was extracted into ./canonicalAction.
+export const PROTECTED_ACTION = PRODUCTION_DEPLOY_ACTION;
 
 export interface ActionInputs {
   apiKey: string;
@@ -71,8 +79,13 @@ export function parseInputs(env: Record<string, string | undefined>): ActionInpu
       );
     }
     const evaluations = parsed as EvaluateRequest[];
+    // Validate each item, then rewrite the action field to canonical so
+    // downstream call sites (and the batch endpoint) always see
+    // `production.deploy` on the wire — even when the workflow author
+    // passed the legacy alias.
     for (const item of evaluations) {
-      validateProtectedAction(item.action);
+      assertProtectedAction(item.action);
+      item.action = normalizeProtectedAction(item.action).canonical;
     }
     return {
       apiKey,
@@ -85,8 +98,14 @@ export function parseInputs(env: Record<string, string | undefined>): ActionInpu
   }
 
   // ── Single-eval mode (v2.0 fallback) ────────────────────────────────────────
-  const action = required(env, "INPUT_ACTION");
-  validateProtectedAction(action);
+  const rawAction = required(env, "INPUT_ACTION");
+  assertProtectedAction(rawAction);
+  // Normalize before forwarding: callers that pass the legacy alias
+  // (`deployment.production`) get rewritten to the canonical
+  // (`production.deploy`) here, so every downstream surface — the
+  // evaluate POST body, GH Actions outputs, audit logs — carries the
+  // canonical string.
+  const action = normalizeProtectedAction(rawAction).canonical;
   const actor = env["INPUT_ACTOR"] || env["GITHUB_ACTOR"] || "unknown";
   const environment = env["INPUT_ENVIRONMENT"];
   const contextRaw = env["INPUT_CONTEXT"] || "{}";
@@ -119,10 +138,3 @@ function required(env: Record<string, string | undefined>, key: string): string 
   return v;
 }
 
-function validateProtectedAction(action: string): void {
-  if (action !== PROTECTED_ACTION) {
-    throw new Error(
-      `Unsupported protected action "${action}". Deploy Gate V1 only permits "${PROTECTED_ACTION}"`,
-    );
-  }
-}


### PR DESCRIPTION
Accept both `production.deploy` (canonical) and `deployment.production` (legacy alias) at the action's I/O boundary; normalize to the canonical before any downstream use. Closes the client-side half of the V1 alias window so legacy workflows that hardcoded the old slug keep working while every wire surface (evaluate body, GH outputs, audit) carries the new canonical.

Mirrors the server-side posture landed in atlasent-api PR #662 (alias- tolerant `normalizeProtectedAction` in `_shared/canonical-action.ts`) and the live action_classes seed rename in atlasent-console PR #432. Part of atlasent-api#658 (P0-1).

- src/canonicalAction.ts: new helper module — single source of truth for `PRODUCTION_DEPLOY_ACTION`, `LEGACY_PRODUCTION_DEPLOY_ALIAS`, `normalizeProtectedAction`, `assertProtectedAction`.
- src/index.ts: replace strict `validateProtectedAction` with `normalizeAndValidateProtectedAction`; forward the canonical (not the raw input) into the enforce() config so EnforceConfig.action is always `production.deploy` on the wire.
- src/inputs.ts: same pattern for both single-eval and batch paths; batch path rewrites each item's action to canonical in place.
- src/__tests__/canonicalAction.test.ts: 7 tests covering normalize + assert behaviour and error-message shape.
- src/__tests__/inputs.test.ts: + 2 tests — legacy alias accepted in single and batch; downstream sees canonical.
- src/__tests__/index.test.ts: + 1 test — legacy alias survives the whole run() path; enforce() receives canonical.
- package.json: 0.1.0 -> 2.0.0.
- dist/index.js: rebuilt via `npm run build`.

162 -> 172 tests, all passing. Typecheck clean. Dist contains the helper module and references the canonical from every call site.

## Summary


## Test plan
- [ ] 
