### PR TITLE
docs: V1 GA (2026-05-17) banner

### DIFF
--- a/V2_ROLLOUT.md
+++ b/V2_ROLLOUT.md
@@ -2,6 +2,15 @@
 
 **Status:** plan · **Wave:** B (action SDK pin + batch + streaming-wait) · **Updated:** 2026-04-26
 
+> **V1 GA — 2026-05-17.** V1 substrate frozen — the canonical foundation
+> this V2 plan extends. The `/v1/*` wire surface, schema, audit chain,
+> and Ed25519-signed export envelope are stable; V2 work in this plan is
+> **additive** on V1 (no V1 wire/schema/audit-chain changes ship under V2).
+> V2 implementation is unblocked pending umbrella
+> [`V2_DECISIONS.md`](https://github.com/AtlaSent-Systems-Inc/atlasent/blob/main/V2_DECISIONS.md) sign-off.
+> Canonical V1 reference: [`atlasent-api/docs/runtime/golden-path-v1.md`](https://github.com/AtlaSent-Systems-Inc/atlasent-api/blob/main/docs/runtime/golden-path-v1.md).
+> V1 GA closeout PRs: see umbrella [`ROADMAP.md`](https://github.com/AtlaSent-Systems-Inc/atlasent/blob/main/ROADMAP.md) "V1 GA — what closed" section.
+
 Action-side cut of the [umbrella v2 rollout](https://github.com/AtlaSent-Systems-Inc/atlasent/blob/claude/plan-v2-rollout-5IPGF/V2_ROLLOUT.md). The action already shipped v2.0.0 (OIDC keyless). v2.1 adds batch fan-out, streaming-wait, and SDK 2.x pin.
 
 ## Position


### PR DESCRIPTION
Part of the AtlaSent V1 GA (2026-05-17) documentation pass (Wave 2).

Adds a V1 GA banner to `V2_ROLLOUT.md` noting:

- V1 substrate is frozen as of 2026-05-17
- The V2 plan in this file is **additive** on the canonical V1 surface
- No V1 wire/schema/audit-chain changes ship under V2
- V2 implementation is unblocked pending umbrella `V2_DECISIONS.md` sign-off

Doc-only. No code, no migrations.

Umbrella context: AtlaSent-Systems-Inc/atlasent#202 (ROADMAP + V2/V3 banners, merged) and AtlaSent-Systems-Inc/atlasent-api#739 (V2_ROLLOUT banner, merged).

---
_Generated by [Claude Code](https://claude.ai/code/session_01DGEzAyaErrZ1nQX2cYs5yi)_