### PR TITLE
feat(batch): V2-D3 auto-fallback, chunking, single-item short-circuit (Wave B)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ The action sets several outputs you can reference in subsequent steps.
 |-------------|--------------------------------------------------------------------------------------------------|
 | `verified`  | `"true"` only when every allow decision verified; `"false"` otherwise                            |
 | `decisions` | JSON array of per-item results: `{decision, verified, evaluationId, permitToken, reasons, verifyOutcome}` |
-| `batch-id`  | Server-assigned batch ID, or `loop-<ts>` for the sequential fallback                            |
+| `batch-id`  | Server-assigned batch ID, `chunked-<ts>` when client-side chunking ran, or `loop-<ts>` for the sequential fallback |
 
 ## Inputs
 
@@ -99,7 +99,7 @@ The action sets several outputs you can reference in subsequent steps.
 | `evaluations`      | No       | —         | JSON array of evaluation requests. When set, single-eval inputs are ignored. |
 | `wait-for-id`      | No       | —         | Evaluation ID to block on until it reaches a terminal state (allow/deny). |
 | `wait-timeout-ms`  | No       | `600000`  | Max milliseconds to wait for a terminal decision (default: 10 min). |
-| `v2-batch`         | No       | `false`   | Use the `/v1-evaluate/batch` endpoint instead of sequential loop.   |
+| `v2-batch`         | No       | `false`   | Use the `/v1-evaluate/batch` endpoint instead of the sequential loop. Falls back to the loop automatically when the endpoint returns 404 or only one item is supplied. |
 | `v2-streaming`     | No       | `false`   | Use Server-Sent Events for `wait-for-id` polling instead of HTTP polling. |
 
 ## Streaming wait (v2.1)
@@ -147,15 +147,39 @@ Evaluate multiple actions in a single step:
   env:
     ATLASENT_API_KEY: ${{ secrets.ATLASENT_API_KEY }}
   with:
+    v2-batch: 'true'
     evaluations: |
       [
-        {"action": "production.deploy", "actor": "${{ github.actor }}", "environment": "live"}
+        {"action": "production.deploy", "actor": "${{ github.actor }}", "environment": "live", "context": {"service": "api"}},
+        {"action": "production.deploy", "actor": "${{ github.actor }}", "environment": "live", "context": {"service": "worker"}},
+        {"action": "production.deploy", "actor": "${{ github.actor }}", "environment": "live", "context": {"service": "web"}}
       ]
 
 - name: Deploy
   if: steps.gate.outputs.verified == 'true'
   run: ./deploy.sh
 ```
+
+See [`docs/batch-example.yml`](./docs/batch-example.yml) for a fully-commented end-to-end workflow.
+
+### Batch auto-fallback (V2-D3)
+
+The `/v1-evaluate/batch` endpoint is **closed-by-default per tenant** — the
+`v2_batch` flag must be flipped on by AtlaSent operations before a given org
+can use it. To keep workflows portable across orgs at different rollout stages,
+the action falls back automatically:
+
+| Condition                                              | Transport                                       |
+|--------------------------------------------------------|-------------------------------------------------|
+| `v2-batch: false` (default)                            | Per-item `/v1-evaluate` loop                    |
+| `v2-batch: true` AND only 1 item supplied              | Per-item `/v1-evaluate` loop (no batch benefit) |
+| `v2-batch: true` AND `/v1-evaluate/batch` returns 404 | Per-item `/v1-evaluate` loop (tenant flag off)  |
+| `v2-batch: true` AND `items.length > 100`              | Multiple `/v1-evaluate/batch` POSTs, chunked client-side to the 100-item server cap |
+| `v2-batch: true` AND `/v1-evaluate/batch` returns 5xx | Step fails (fail-closed — does NOT silently downgrade) |
+
+`batch-id` distinguishes the path that actually ran: a UUID for server-side
+batches, `chunked-<ts>` when the action chunked client-side, and `loop-<ts>`
+for the per-item fallback.
 
 ## How It Works
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -244,6 +244,8 @@ var import_enforce2 = __toESM(require_dist());
 
 // src/batch.ts
 var import_enforce = __toESM(require_dist());
+var BATCH_MAX_ITEMS = 100;
+var BATCH_MIN_ITEMS = 2;
 async function evaluateMany(apiUrl, apiKey, items, v2Batch) {
   const headers = {
     "content-type": "application/json",
@@ -251,32 +253,25 @@ async function evaluateMany(apiUrl, apiKey, items, v2Batch) {
   };
   let decisions;
   let batchId;
-  if (v2Batch) {
-    const r = await fetch(`${apiUrl}/v1-evaluate/batch`, {
-      method: "POST",
-      headers,
-      body: JSON.stringify({ items })
-    });
-    if (!r.ok) {
-      throw new Error(`atlasent /v1-evaluate/batch ${r.status}`);
-    }
-    const data = await r.json();
-    decisions = data.results;
-    batchId = data.batchId;
-  } else {
-    decisions = [];
-    for (const item of items) {
-      const r = await fetch(`${apiUrl}/v1-evaluate`, {
-        method: "POST",
-        headers,
-        body: JSON.stringify(item)
-      });
-      if (!r.ok) {
-        throw new Error(`atlasent /v1-evaluate ${r.status}`);
+  const shouldUseBatch = v2Batch && items.length >= BATCH_MIN_ITEMS;
+  if (shouldUseBatch) {
+    try {
+      const out = await postBatchChunked(apiUrl, headers, items);
+      decisions = out.decisions;
+      batchId = out.batchId;
+    } catch (err) {
+      if (err instanceof BatchEndpointDisabled) {
+        const out = await loopEvaluate(apiUrl, headers, items);
+        decisions = out.decisions;
+        batchId = out.batchId;
+      } else {
+        throw err;
       }
-      decisions.push(await r.json());
     }
-    batchId = `loop-${Date.now()}`;
+  } else {
+    const out = await loopEvaluate(apiUrl, headers, items);
+    decisions = out.decisions;
+    batchId = out.batchId;
   }
   const verified = await Promise.all(
     decisions.map(async (d, i) => {
@@ -291,6 +286,54 @@ async function evaluateMany(apiUrl, apiKey, items, v2Batch) {
     })
   );
   return { decisions: verified, batchId };
+}
+var BatchEndpointDisabled = class extends Error {
+  constructor() {
+    super("v1-evaluate/batch disabled for this tenant (404)");
+    this.name = "BatchEndpointDisabled";
+  }
+};
+async function postBatchChunked(apiUrl, headers, items) {
+  const chunks = [];
+  for (let i = 0; i < items.length; i += BATCH_MAX_ITEMS) {
+    chunks.push(items.slice(i, i + BATCH_MAX_ITEMS));
+  }
+  const all = [];
+  let firstBatchId = "";
+  for (let c = 0; c < chunks.length; c++) {
+    const r = await fetch(`${apiUrl}/v1-evaluate/batch`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ items: chunks[c] })
+    });
+    if (r.status === 404) {
+      throw new BatchEndpointDisabled();
+    }
+    if (!r.ok) {
+      throw new Error(`atlasent /v1-evaluate/batch ${r.status}`);
+    }
+    const data = await r.json();
+    all.push(...data.results);
+    if (c === 0)
+      firstBatchId = data.batchId;
+  }
+  const batchId = chunks.length > 1 ? `chunked-${Date.now()}` : firstBatchId;
+  return { decisions: all, batchId };
+}
+async function loopEvaluate(apiUrl, headers, items) {
+  const decisions = [];
+  for (const item of items) {
+    const r = await fetch(`${apiUrl}/v1-evaluate`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(item)
+    });
+    if (!r.ok) {
+      throw new Error(`atlasent /v1-evaluate ${r.status}`);
+    }
+    decisions.push(await r.json());
+  }
+  return { decisions, batchId: `loop-${Date.now()}` };
 }
 
 // src/canonicalAction.ts

--- a/docs/batch-example.yml
+++ b/docs/batch-example.yml
@@ -1,0 +1,92 @@
+# AtlaSent Batch Gate — example GitHub Actions workflow
+#
+# Demonstrates evaluating MULTIPLE protected actions in a single step
+# using the `evaluations:` input. The action posts the list to
+# /v1-evaluate/batch when `v2-batch: 'true'` is set, and verifies each
+# allow decision's permit before returning. The deploy job is gated on
+# `outputs.verified == 'true'` — which is only set when EVERY allow
+# decision passed permit verification.
+#
+# Auto-fallback behaviour (Wave B):
+#   • items.length < 2 → action skips the batch endpoint and uses the
+#     per-item /v1-evaluate loop directly (no batch benefit for 1 item).
+#   • /v1-evaluate/batch returns 404 → the action falls back to the
+#     per-item loop automatically (V2-D3: v2_batch is closed-by-default;
+#     a tenant without the flag flipped on gets a 404 and the workflow
+#     still succeeds via the loop transport).
+#   • items.length > 100 → the action chunks the batch client-side into
+#     ≤100-item POSTs (server hard-cap is 100 per request).
+#
+# Prerequisites:
+#   - Store your AtlaSent API key as a repository secret named
+#     ATLASENT_API_KEY.
+
+name: AtlaSent Batch Gate
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  multi-service-deploy:
+    name: Authorize + deploy three services in one batch
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: AtlaSent Batch Authorization Gate
+        id: gate
+        uses: atlasent-systems-inc/atlasent-action@main
+        env:
+          ATLASENT_API_KEY: ${{ secrets.ATLASENT_API_KEY }}
+        with:
+          # `evaluations:` is a JSON array — one entry per protected
+          # action. When set, single-eval inputs (`action:`, `actor:`,
+          # `context:`) are ignored.
+          evaluations: |
+            [
+              {
+                "action": "production.deploy",
+                "actor": "${{ github.actor }}",
+                "environment": "live",
+                "context": { "service": "api", "ref": "${{ github.ref }}" }
+              },
+              {
+                "action": "production.deploy",
+                "actor": "${{ github.actor }}",
+                "environment": "live",
+                "context": { "service": "worker", "ref": "${{ github.ref }}" }
+              },
+              {
+                "action": "production.deploy",
+                "actor": "${{ github.actor }}",
+                "environment": "live",
+                "context": { "service": "web", "ref": "${{ github.ref }}" }
+              }
+            ]
+          # Opt in to the /v1-evaluate/batch endpoint. The action falls
+          # back to the per-item /v1-evaluate loop automatically if the
+          # endpoint returns 404 (tenant's v2_batch flag is off).
+          v2-batch: 'true'
+          # fail-on-deny=true (default) fails this step if ANY of the
+          # evaluations comes back deny/hold/escalate. The deploy job
+          # below is additionally gated on `verified == 'true'`.
+
+      - name: Inspect per-item decisions
+        if: always()
+        run: |
+          echo "Batch ID: ${{ steps.gate.outputs.batch-id }}"
+          echo "Verified (all-or-nothing): ${{ steps.gate.outputs.verified }}"
+          echo "Per-item decisions:"
+          echo '${{ steps.gate.outputs.decisions }}' | jq '.'
+
+      - name: Deploy all services
+        if: steps.gate.outputs.verified == 'true'
+        run: |
+          ./deploy.sh api
+          ./deploy.sh worker
+          ./deploy.sh web

--- a/src/__tests__/batch.test.ts
+++ b/src/__tests__/batch.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { evaluateMany } from "../batch";
+import { evaluateMany, BATCH_MAX_ITEMS, BATCH_MIN_ITEMS } from "../batch";
 
 // Mock @atlasent/enforce so verifyPermit uses a test double rather than the
 // real HTTP transport. fetch is still needed for the evaluate calls.
@@ -27,31 +27,39 @@ describe("evaluateMany", () => {
     );
   }
 
+  function batchResp(count: number, batchId = "b1", permitTokenPrefix = "tok") {
+    const results = Array.from({ length: count }, (_, i) => ({
+      decision: "allow",
+      evaluatedAt: "2026-04-25T00:00:00Z",
+      permitToken: `${permitTokenPrefix}${i}`,
+    }));
+    return new Response(JSON.stringify({ results, batchId }));
+  }
+
   it("hits /v1-evaluate/batch when v2Batch=true and verifies allow decisions", async () => {
-    fetchMock.mockResolvedValueOnce(
-      new Response(
-        JSON.stringify({
-          results: [{ decision: "allow", evaluatedAt: "2026-04-25T00:00:00Z", permitToken: "tok1" }],
-          batchId: "b1",
-        }),
-      ),
-    );
-    mockVerifyPermit.mockResolvedValueOnce({ verified: true, outcome: "ok" });
+    // Two items so the batch path is actually taken (single-item batches
+    // short-circuit to the loop now).
+    fetchMock.mockResolvedValueOnce(batchResp(2, "b1"));
+    mockVerifyPermit.mockResolvedValue({ verified: true, outcome: "ok" });
 
     const out = await evaluateMany(
       "https://api.test",
       "k",
-      [{ action: "a", actor: "u" }],
+      [
+        { action: "a", actor: "u" },
+        { action: "b", actor: "u" },
+      ],
       true,
     );
 
     expect(out.batchId).toBe("b1");
     expect(out.decisions[0].verified).toBe(true);
+    expect(out.decisions[1].verified).toBe(true);
     expect(fetchMock).toHaveBeenCalledWith(
       "https://api.test/v1-evaluate/batch",
       expect.anything(),
     );
-    expect(mockVerifyPermit).toHaveBeenCalledOnce();
+    expect(mockVerifyPermit).toHaveBeenCalledTimes(2);
   });
 
   it("loops /v1-evaluate when v2Batch=false and verifies each allow decision", async () => {
@@ -119,7 +127,15 @@ describe("evaluateMany", () => {
   it("throws on non-2xx batch response", async () => {
     fetchMock.mockResolvedValueOnce(new Response("x", { status: 500 }));
     await expect(
-      evaluateMany("https://api.test", "k", [{ action: "a", actor: "u" }], true),
+      evaluateMany(
+        "https://api.test",
+        "k",
+        [
+          { action: "a", actor: "u" },
+          { action: "b", actor: "u" },
+        ],
+        true,
+      ),
     ).rejects.toThrow(/500/);
   });
 
@@ -155,5 +171,181 @@ describe("evaluateMany", () => {
         permitToken: "tok-xyz",
       }),
     );
+  });
+
+  // ── Wave B hardening: items<2 short-circuit ────────────────────────────────
+
+  it("short-circuits to /v1-evaluate loop when v2Batch=true but only 1 item (no batch benefit)", async () => {
+    // Even with v2Batch=true the single-item case should skip the batch
+    // endpoint entirely — the round-trip cost isn't justified for one item.
+    fetchMock.mockImplementation((url: string) => {
+      if (url.endsWith("/v1-evaluate")) {
+        return Promise.resolve(evalResp("allow", "tok-solo"));
+      }
+      return Promise.reject(new Error(`unexpected url: ${url}`));
+    });
+    mockVerifyPermit.mockResolvedValueOnce({ verified: true, outcome: "ok" });
+
+    const out = await evaluateMany(
+      "https://api.test",
+      "k",
+      [{ action: "production.deploy", actor: "u" }],
+      true, // v2Batch=true
+    );
+
+    // batch endpoint was NOT hit
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      "https://api.test/v1-evaluate/batch",
+      expect.anything(),
+    );
+    expect(out.batchId).toMatch(/^loop-/);
+    expect(out.decisions).toHaveLength(1);
+    expect(out.decisions[0].verified).toBe(true);
+  });
+
+  it("BATCH_MIN_ITEMS is 2 (documented contract)", () => {
+    expect(BATCH_MIN_ITEMS).toBe(2);
+  });
+
+  // ── Wave B hardening: 404 fallback ─────────────────────────────────────────
+
+  it("falls back to per-item loop on 404 from /v1-evaluate/batch (v2_batch flag off)", async () => {
+    // First call: batch 404 (tenant flag off)
+    // Subsequent calls: per-item /v1-evaluate loop
+    fetchMock.mockImplementation((url: string) => {
+      if (url.endsWith("/v1-evaluate/batch")) {
+        return Promise.resolve(new Response("not found", { status: 404 }));
+      }
+      if (url.endsWith("/v1-evaluate")) {
+        return Promise.resolve(evalResp("allow", "tok-fallback"));
+      }
+      return Promise.reject(new Error(`unexpected url: ${url}`));
+    });
+    mockVerifyPermit.mockResolvedValue({ verified: true, outcome: "ok" });
+
+    const out = await evaluateMany(
+      "https://api.test",
+      "k",
+      [
+        { action: "a", actor: "u" },
+        { action: "b", actor: "u" },
+      ],
+      true,
+    );
+
+    // 1 batch attempt + 2 per-item evaluate calls = 3 fetches total
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchMock.mock.calls[0][0]).toBe("https://api.test/v1-evaluate/batch");
+    expect(fetchMock.mock.calls[1][0]).toBe("https://api.test/v1-evaluate");
+    expect(fetchMock.mock.calls[2][0]).toBe("https://api.test/v1-evaluate");
+
+    // After fallback, batchId is the loop marker (NOT a server batchId).
+    expect(out.batchId).toMatch(/^loop-/);
+    expect(out.decisions).toHaveLength(2);
+    expect(out.decisions.every((d) => d.verified === true)).toBe(true);
+  });
+
+  it("does NOT fall back on non-404 batch errors (e.g. 500 is a real failure)", async () => {
+    fetchMock.mockResolvedValueOnce(new Response("oops", { status: 500 }));
+
+    await expect(
+      evaluateMany(
+        "https://api.test",
+        "k",
+        [
+          { action: "a", actor: "u" },
+          { action: "b", actor: "u" },
+        ],
+        true,
+      ),
+    ).rejects.toThrow(/500/);
+
+    // 5xx fail-closed — must not silently fall back to the loop.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  // ── Wave B hardening: chunking when items > BATCH_MAX_ITEMS ────────────────
+
+  it("BATCH_MAX_ITEMS is 100 (V2-D3 server hard-cap)", () => {
+    expect(BATCH_MAX_ITEMS).toBe(100);
+  });
+
+  it("chunks into ≤100-item batches when items > BATCH_MAX_ITEMS", async () => {
+    // 150 items → 2 chunks (100 + 50)
+    const items = Array.from({ length: 150 }, (_, i) => ({
+      action: "production.deploy",
+      actor: `actor-${i}`,
+    }));
+
+    fetchMock
+      .mockResolvedValueOnce(batchResp(100, "chunk-a"))
+      .mockResolvedValueOnce(batchResp(50, "chunk-b"));
+    mockVerifyPermit.mockResolvedValue({ verified: true, outcome: "ok" });
+
+    const out = await evaluateMany("https://api.test", "k", items, true);
+
+    // Two batch calls, no per-item loop.
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[0][0]).toBe("https://api.test/v1-evaluate/batch");
+    expect(fetchMock.mock.calls[1][0]).toBe("https://api.test/v1-evaluate/batch");
+
+    // First chunk has 100 items, second has 50 (sliced in input order).
+    const firstBody = JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string);
+    const secondBody = JSON.parse((fetchMock.mock.calls[1][1] as RequestInit).body as string);
+    expect(firstBody.items).toHaveLength(100);
+    expect(secondBody.items).toHaveLength(50);
+    expect(firstBody.items[0].actor).toBe("actor-0");
+    expect(firstBody.items[99].actor).toBe("actor-99");
+    expect(secondBody.items[0].actor).toBe("actor-100");
+    expect(secondBody.items[49].actor).toBe("actor-149");
+
+    // All 150 decisions are present in input order.
+    expect(out.decisions).toHaveLength(150);
+    // Multi-chunk: batchId is a synthetic `chunked-*` marker so
+    // downstream audit refs aren't misleadingly pinned to chunk 0.
+    expect(out.batchId).toMatch(/^chunked-/);
+  });
+
+  it("single chunk (≤BATCH_MAX_ITEMS) returns the server batchId verbatim", async () => {
+    const items = Array.from({ length: 100 }, (_, i) => ({
+      action: "production.deploy",
+      actor: `actor-${i}`,
+    }));
+    fetchMock.mockResolvedValueOnce(batchResp(100, "server-batch-99"));
+    mockVerifyPermit.mockResolvedValue({ verified: true, outcome: "ok" });
+
+    const out = await evaluateMany("https://api.test", "k", items, true);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(out.batchId).toBe("server-batch-99");
+  });
+
+  it("chunked path falls back to per-item loop if FIRST chunk 404s (no partial state)", async () => {
+    // 120 items, but the very first batch call returns 404. We must NOT
+    // half-commit (i.e. ship chunk 0 to /v1-evaluate/batch and then fall
+    // back to the loop for the remaining 20 — that would mix transports
+    // mid-batch). Falling back means looping ALL 120.
+    const items = Array.from({ length: 120 }, (_, i) => ({
+      action: "production.deploy",
+      actor: `actor-${i}`,
+    }));
+
+    fetchMock.mockImplementation((url: string) => {
+      if (url.endsWith("/v1-evaluate/batch")) {
+        return Promise.resolve(new Response("not found", { status: 404 }));
+      }
+      if (url.endsWith("/v1-evaluate")) {
+        return Promise.resolve(evalResp("allow", "tok-loop"));
+      }
+      return Promise.reject(new Error(`unexpected url: ${url}`));
+    });
+    mockVerifyPermit.mockResolvedValue({ verified: true, outcome: "ok" });
+
+    const out = await evaluateMany("https://api.test", "k", items, true);
+
+    // 1 batch attempt + 120 per-item evaluate calls = 121 fetches
+    expect(fetchMock).toHaveBeenCalledTimes(121);
+    expect(out.decisions).toHaveLength(120);
+    expect(out.batchId).toMatch(/^loop-/);
   });
 });

--- a/src/batch.ts
+++ b/src/batch.ts
@@ -6,10 +6,30 @@
 // single-eval runGate() contract — the gate is fail-closed end-to-end.
 //
 // Uses @atlasent/enforce's verifyPermit() as the canonical implementation.
+//
+// Wave B hardening (V2-D3 contract alignment):
+//   • items < 2 → skip batch entirely, use per-item loop (no benefit).
+//   • items > 100 → chunk into ≤100-item batches (server hard-cap).
+//   • 404 from /v1-evaluate/batch → automatic fallback to per-item loop
+//     (v2_batch tenant flag is off; closed-by-default behavior).
 
 import { verifyPermit } from "@atlasent/enforce";
 import type { EvaluateRequest } from "./types";
 import type { Decision } from "./types";
+
+/**
+ * Server-enforced cap from V2-D3: `/v1-evaluate/batch` rejects requests
+ * with more than 100 items via `413 batch_too_large`. Mirror it here so
+ * we chunk client-side rather than discovering the limit at runtime.
+ */
+export const BATCH_MAX_ITEMS = 100;
+
+/**
+ * Below this threshold, the batch endpoint provides no benefit (it adds
+ * a round-trip and a server-side fan-out for nothing) so we short-circuit
+ * straight to the per-item /v1-evaluate path.
+ */
+export const BATCH_MIN_ITEMS = 2;
 
 export interface BatchResult {
   decisions: Decision[];
@@ -31,35 +51,34 @@ export async function evaluateMany(
   let decisions: Decision[];
   let batchId: string;
 
-  if (v2Batch) {
-    const r = await fetch(`${apiUrl}/v1-evaluate/batch`, {
-      method: "POST",
-      headers,
-      body: JSON.stringify({ items }),
-    });
-    if (!r.ok) {
-      throw new Error(`atlasent /v1-evaluate/batch ${r.status}`);
-    }
-    const data = (await r.json()) as {
-      results: Decision[];
-      batchId: string;
-    };
-    decisions = data.results;
-    batchId = data.batchId;
-  } else {
-    decisions = [];
-    for (const item of items) {
-      const r = await fetch(`${apiUrl}/v1-evaluate`, {
-        method: "POST",
-        headers,
-        body: JSON.stringify(item),
-      });
-      if (!r.ok) {
-        throw new Error(`atlasent /v1-evaluate ${r.status}`);
+  // Short-circuit: a "batch" of 0 or 1 items has no fan-out advantage
+  // over the single-item endpoint, and skipping the batch hop also
+  // avoids the v2_batch tenant-flag 404 round-trip for single-item
+  // callers using the runV21 wrapper.
+  const shouldUseBatch = v2Batch && items.length >= BATCH_MIN_ITEMS;
+
+  if (shouldUseBatch) {
+    try {
+      const out = await postBatchChunked(apiUrl, headers, items);
+      decisions = out.decisions;
+      batchId = out.batchId;
+    } catch (err) {
+      // 404 from /v1-evaluate/batch means the tenant doesn't have the
+      // `v2_batch` flag flipped on yet (V2-D3 closed-by-default). Fall
+      // back to the per-item /v1-evaluate loop so the workflow still
+      // succeeds — the per-item path is fail-closed in the same way.
+      if (err instanceof BatchEndpointDisabled) {
+        const out = await loopEvaluate(apiUrl, headers, items);
+        decisions = out.decisions;
+        batchId = out.batchId;
+      } else {
+        throw err;
       }
-      decisions.push((await r.json()) as Decision);
     }
-    batchId = `loop-${Date.now()}`;
+  } else {
+    const out = await loopEvaluate(apiUrl, headers, items);
+    decisions = out.decisions;
+    batchId = out.batchId;
   }
 
   // Verify permits for every allow decision using the canonical verifyPermit()
@@ -79,4 +98,83 @@ export async function evaluateMany(
   );
 
   return { decisions: verified, batchId };
+}
+
+/** Marker error: batch endpoint returned 404 → fall back to per-item loop. */
+class BatchEndpointDisabled extends Error {
+  constructor() {
+    super("v1-evaluate/batch disabled for this tenant (404)");
+    this.name = "BatchEndpointDisabled";
+  }
+}
+
+/**
+ * POST one or more batches to /v1-evaluate/batch, chunked to
+ * BATCH_MAX_ITEMS. Decisions are concatenated in input order. The
+ * returned batchId is the first chunk's batchId (or a synthetic
+ * `chunked-<ts>` when there are multiple chunks, so downstream
+ * audit references aren't misleadingly pinned to chunk 0).
+ *
+ * Throws `BatchEndpointDisabled` on the FIRST 404 so the caller can
+ * fall back to the per-item loop without partial state. Any other
+ * non-2xx throws a generic Error.
+ */
+async function postBatchChunked(
+  apiUrl: string,
+  headers: Record<string, string>,
+  items: EvaluateRequest[],
+): Promise<BatchResult> {
+  const chunks: EvaluateRequest[][] = [];
+  for (let i = 0; i < items.length; i += BATCH_MAX_ITEMS) {
+    chunks.push(items.slice(i, i + BATCH_MAX_ITEMS));
+  }
+
+  const all: Decision[] = [];
+  let firstBatchId = "";
+
+  for (let c = 0; c < chunks.length; c++) {
+    const r = await fetch(`${apiUrl}/v1-evaluate/batch`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ items: chunks[c] }),
+    });
+    if (r.status === 404) {
+      throw new BatchEndpointDisabled();
+    }
+    if (!r.ok) {
+      throw new Error(`atlasent /v1-evaluate/batch ${r.status}`);
+    }
+    const data = (await r.json()) as { results: Decision[]; batchId: string };
+    all.push(...data.results);
+    if (c === 0) firstBatchId = data.batchId;
+  }
+
+  const batchId = chunks.length > 1 ? `chunked-${Date.now()}` : firstBatchId;
+  return { decisions: all, batchId };
+}
+
+/**
+ * Per-item /v1-evaluate loop. Used when:
+ *   • v2Batch=false (caller didn't opt in), or
+ *   • items.length < BATCH_MIN_ITEMS (no batch benefit), or
+ *   • /v1-evaluate/batch returned 404 (v2_batch tenant flag off).
+ */
+async function loopEvaluate(
+  apiUrl: string,
+  headers: Record<string, string>,
+  items: EvaluateRequest[],
+): Promise<BatchResult> {
+  const decisions: Decision[] = [];
+  for (const item of items) {
+    const r = await fetch(`${apiUrl}/v1-evaluate`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(item),
+    });
+    if (!r.ok) {
+      throw new Error(`atlasent /v1-evaluate ${r.status}`);
+    }
+    decisions.push((await r.json()) as Decision);
+  }
+  return { decisions, batchId: `loop-${Date.now()}` };
 }


### PR DESCRIPTION
## Summary

Wave B hardening for `/v1-evaluate/batch` integration, aligning the
GitHub Action with V2-D3 contract semantics (atlasent-api#742,
atlasent#204).

- **Single-item short-circuit** — when `v2-batch: true` but only one
  item is supplied, skip the batch endpoint entirely and use the
  per-item `/v1-evaluate` loop. No batch benefit, and it avoids a
  pointless tenant-flag 404 round-trip.
- **Client-side chunking** — when `items.length > 100`, the action
  splits the batch into ≤100-item POSTs (V2-D3 server hard-cap;
  otherwise the server returns `413 batch_too_large`).
- **404 auto-fallback** — `/v1-evaluate/batch` returns 404 when an
  org's `v2_batch` flag is off (closed-by-default). The action now
  catches that and falls back to the per-item loop so the workflow
  still succeeds. 5xx is **not** caught — real failures still
  fail-closed as before.
- New `batch-id` value `chunked-<ts>` distinguishes client-chunked
  runs from server-assigned UUIDs and per-item-loop `loop-<ts>`.

## OIDC deferred (blocker)

V2_ROLLOUT.md asks for "Bump example workflow to OIDC keyless." I
checked `atlasent-api` and there is **no** `/v1/oidc/exchange` (or
similar) endpoint — the closest 200+ `v1-*` functions cover billing,
audit, evaluate, etc., but nothing for OIDC token swap. The current
README also documents `No OIDC exchange. ... If you want true OIDC
trust between GitHub and AtlaSent (no long-lived API key), file a
feature request — the wire today does not support it.`

Per Wave B instructions, OIDC plumbing is **not** shipped in this PR
because the exchange endpoint isn't built. Static `ATLASENT_API_KEY`
remains the only auth path. The OIDC piece can land in a follow-up
once atlasent-api ships the exchange endpoint.

## What's untouched

- V1 single-item `/v1-evaluate` flow is byte-identical.
- Static-key auth fallback preserved (no change to auth path).
- No new GH Action release tag (deferred per Wave B scope).
- Existing v2.1 modules (`stream.ts`, `v21.ts`, `evidenceClient.ts`)
  unchanged.

## Test plan

- [x] Add `BATCH_MAX_ITEMS=100` and `BATCH_MIN_ITEMS=2` exported constants
- [x] Test: short-circuit to loop when items < 2 even with v2-batch=true
- [x] Test: 404 from batch → automatic loop fallback
- [x] Test: 5xx from batch → fail-closed (no silent downgrade)
- [x] Test: 150 items → 2 chunks (100 + 50), input order preserved
- [x] Test: 100 items → single chunk, server `batchId` returned verbatim
- [x] Test: first-chunk 404 → full per-item loop fallback (no partial state)
- [ ] CI: typecheck + vitest run + lockfile integrity (test.yml workflow)
- [ ] Smoke: example workflow `docs/batch-example.yml` syntactically valid

## Cross-links

- atlasent-api#742 — V2-D3 `/v1-evaluate/batch` endpoint
- atlasent#204 — umbrella V2 decisions

https://claude.ai/code/session_01DGEzAyaErrZ1nQX2cYs5yi

---
_Generated by [Claude Code](https://claude.ai/code/session_01DGEzAyaErrZ1nQX2cYs5yi)_