### PR TITLE
docs: reframe platform generations (v1=cash-flow, v2=enterprise, v3=execution assurance)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to `atlasent-action` are documented here.
 
+## [unreleased] — 2026-05-18
+
+### Platform-generation reframing (doc-only, no code change)
+
+Mirrors the umbrella reframing in [`atlasent/CHANGELOG.md`](https://github.com/AtlaSent-Systems-Inc/atlasent/blob/main/CHANGELOG.md). Platform generations: **v1** = pilot + cash-flowing capability layer (this repo's V2_ROLLOUT.md is preserved with a normalization header and continues to apply); **v2** = full enterprise surface ([`atlasent/ENTERPRISE_V2_ROLLOUT.md`](https://github.com/AtlaSent-Systems-Inc/atlasent/blob/main/ENTERPRISE_V2_ROLLOUT.md)); **v3** = execution assurance. `V2-D#` identifiers retained; new decisions use `PROD-D#`. Package SemVer (e.g. `@atlasent/sdk@2.x`) is decoupled from platform generation labels per [`atlasent/VERSIONING_DOCTRINE.md`](https://github.com/AtlaSent-Systems-Inc/atlasent/blob/main/VERSIONING_DOCTRINE.md) doctrine 1.
+
 ## [0.1.0] — 2026-05-01 — initial public release
 
 This is the first version-stable release. Earlier internal tags

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,5 +1,7 @@
 # atlasent-action — v1 ship plan
 
+> **Reframing note (2026-05-18).** Per [`atlasent/VERSIONING_DOCTRINE.md`](https://github.com/AtlaSent-Systems-Inc/atlasent/blob/main/VERSIONING_DOCTRINE.md), platform generations were reframed: **v1** = pilot + cash-flowing capability layer (current scope of this repo's V2_ROLLOUT.md, preserved unchanged with a normalization header); **v2** = full enterprise surface ([`atlasent/ENTERPRISE_V2_ROLLOUT.md`](https://github.com/AtlaSent-Systems-Inc/atlasent/blob/main/ENTERPRISE_V2_ROLLOUT.md)); **v3** = execution assurance ([`atlasent/V3_ROLLOUT.md`](https://github.com/AtlaSent-Systems-Inc/atlasent/blob/main/V3_ROLLOUT.md), narrowed to Execution Assurance only). `V2-D#` decision IDs retained per doctrine 4; new decisions use `PROD-D#`. The full org matrix is in [`atlasent/ROADMAP.md`](https://github.com/AtlaSent-Systems-Inc/atlasent/blob/main/ROADMAP.md).
+
 GitHub Action that gates CI deploys on an AtlaSent `allow` decision. Distributed via the GitHub Marketplace.
 
 ## V1 Status — May 2026

--- a/V2_ROLLOUT.md
+++ b/V2_ROLLOUT.md
@@ -1,5 +1,21 @@
 # atlasent-action — V2 Rollout
 
+> **Reframing normalization header (2026-05-18).** This document
+> remains in scope and is preserved unchanged per the "do not rewrite
+> history" doctrine ([`atlasent/VERSIONING_DOCTRINE.md`](https://github.com/AtlaSent-Systems-Inc/atlasent/blob/main/VERSIONING_DOCTRINE.md)
+> doctrine 4). Under the 2026-05-18 platform-generation reframing,
+> the work described here is reclassified as the **v1.x capability
+> layer** — additive cash-flowing capabilities on top of the V1 GA
+> substrate. The platform-generation label **v2** now refers to the
+> full enterprise surface, planned in
+> [`atlasent/ENTERPRISE_V2_ROLLOUT.md`](https://github.com/AtlaSent-Systems-Inc/atlasent/blob/main/ENTERPRISE_V2_ROLLOUT.md).
+> Filename and `V2-D#` identifiers are retained for reference
+> stability; "V2" in this document refers to the historical pre-reframing
+> framing, not the post-reframing platform-generation v2. New
+> decisions use the **`PROD-D#`** namespace. See
+> [`atlasent/ROADMAP.md`](https://github.com/AtlaSent-Systems-Inc/atlasent/blob/main/ROADMAP.md)
+> for the current generation matrix.
+
 **Status:** plan · **Wave:** B (action SDK pin + batch + streaming-wait) · **Updated:** 2026-04-26
 
 > **V1 GA — 2026-05-17.** V1 substrate frozen — the canonical foundation

--- a/docs/V2_ROLLOUT.md
+++ b/docs/V2_ROLLOUT.md
@@ -1,5 +1,21 @@
 # atlasent-action — v2.1 rollout
 
+> **Reframing normalization header (2026-05-18).** This document
+> remains in scope and is preserved unchanged per the "do not rewrite
+> history" doctrine ([`atlasent/VERSIONING_DOCTRINE.md`](https://github.com/AtlaSent-Systems-Inc/atlasent/blob/main/VERSIONING_DOCTRINE.md)
+> doctrine 4). Under the 2026-05-18 platform-generation reframing,
+> the work described here is reclassified as the **v1.x capability
+> layer** — additive cash-flowing capabilities on top of the V1 GA
+> substrate. The platform-generation label **v2** now refers to the
+> full enterprise surface, planned in
+> [`atlasent/ENTERPRISE_V2_ROLLOUT.md`](https://github.com/AtlaSent-Systems-Inc/atlasent/blob/main/ENTERPRISE_V2_ROLLOUT.md).
+> Filename and `V2-D#` identifiers are retained for reference
+> stability; "V2" in this document refers to the historical pre-reframing
+> framing, not the post-reframing platform-generation v2. New
+> decisions use the **`PROD-D#`** namespace. See
+> [`atlasent/ROADMAP.md`](https://github.com/AtlaSent-Systems-Inc/atlasent/blob/main/ROADMAP.md)
+> for the current generation matrix.
+
 Wave B of the [umbrella v2 rollout](https://github.com/AtlaSent-Systems-Inc/atlasent/blob/claude/plan-v2-rollout-5IPGF/V2_ROLLOUT.md). Companion implementation to plan PR #15.
 
 ## Status


### PR DESCRIPTION
## Summary

Per-repo doc-only update reflecting the umbrella reframing in `atlasent` (see `atlasent/VERSIONING_DOCTRINE.md`).

- Normalization headers on `V2_ROLLOUT.md` and `docs/V2_ROLLOUT.md`.
- Reframing pointer note on `ROADMAP.md`.
- `CHANGELOG.md` entry.

Action `v2.x` package SemVer is independent of platform-generation labels per doctrine 1 — the action stays at its current major.

## Test plan

- [ ] Doc-only PR. CI should pass.

https://claude.ai/code/session_01MjYedBVTaqJ6d4cHH5wJ5u

---
_Generated by [Claude Code](https://claude.ai/code/session_01MjYedBVTaqJ6d4cHH5wJ5u)_