### PR TITLE
docs(roadmap): normalize to phase-based framing — kill v2/v3 product labels

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,33 +1,56 @@
-# atlasent-action — v1 ship plan
+# atlasent-action — roadmap
 
-> **Reframing note (2026-05-18).** Per [`atlasent/VERSIONING_DOCTRINE.md`](https://github.com/AtlaSent-Systems-Inc/atlasent/blob/main/VERSIONING_DOCTRINE.md), platform generations were reframed: **v1** = pilot + cash-flowing capability layer (current scope of this repo's V2_ROLLOUT.md, preserved unchanged with a normalization header); **v2** = full enterprise surface ([`atlasent/ENTERPRISE_V2_ROLLOUT.md`](https://github.com/AtlaSent-Systems-Inc/atlasent/blob/main/ENTERPRISE_V2_ROLLOUT.md)); **v3** = execution assurance ([`atlasent/V3_ROLLOUT.md`](https://github.com/AtlaSent-Systems-Inc/atlasent/blob/main/V3_ROLLOUT.md), narrowed to Execution Assurance only). `V2-D#` decision IDs retained per doctrine 4; new decisions use `PROD-D#`. The full org matrix is in [`atlasent/ROADMAP.md`](https://github.com/AtlaSent-Systems-Inc/atlasent/blob/main/ROADMAP.md).
+> **Doctrine (2026-05-18 normalization).** This roadmap follows the
+> canonical phase framing in
+> [`atlasent/VERSIONING_DOCTRINE.md`](https://github.com/AtlaSent-Systems-Inc/atlasent/blob/claude/normalize-roadmap-versioning-NWPuP/VERSIONING_DOCTRINE.md).
+> The public/runtime contract is **AtlaSent v1** (stable). Roadmap
+> sequencing uses **Phase 1 / Phase 2 / Phase 3** (with `Wave` / `Pillar`
+> inside). There is no "v2 product" and no "v3 product"; Phase 2 and
+> Phase 3 ship additively on the `v1` contract. Historical filenames
+> (`V2_ROLLOUT.md`, `V2_PLAN.md`, `docs/DESIGN_V2.md`,
+> `docs/V2_PILLAR9_PROOF_SYSTEM.md`) and code-level identifiers
+> (`v2_proof_system`, `v2_batch`, `v2_streaming`, action input names
+> like `v2-batch`/`v2-streaming`) are preserved per Doctrine 4 — they
+> are schema-history and code artifacts, not platform-version labels.
 
-GitHub Action that gates CI deploys on an AtlaSent `allow` decision. Distributed via the GitHub Marketplace.
+GitHub Action that gates CI deploys on an AtlaSent `allow` decision.
+Distributed via the GitHub Marketplace. The action is a thin client
+over the stable `/v1/*` wire contract.
 
-## V1 Status — May 2026
+## Phase 1 — Stabilization & Pilot Readiness (must ship)
 
-✅ Items 1–3 complete (target-id input, four-value decision output, Marketplace listing polish)
-🔄 Item 4 (release-ops): PR #28 open with automated release workflow — ready to merge → tag v1.3.0
+Hardens the action against the frozen `v1` substrate (frozen 2026-05-17).
+All items below are additive on `v1`; no contract changes.
+
+### Status — May 2026
+
+- Items 1–3 complete (target-id input, four-value decision output, Marketplace listing polish)
+- Item 4 (release-ops): PR #28 open with automated release workflow — ready to merge → tag v1.3.0
 
 ### Marketplace status
+
 - Only **v1.0.0** is currently live on the Marketplace
 - **v1.3.0** is ready to ship once PR #28 merges
 - v1.3.0 includes everything since v1.0.0 (see below)
 
+Note: `v1.0.0` / `v1.3.0` here are the action's npm/Marketplace package
+SemVer (Doctrine 5), independent of the platform `v1` contract.
+
 ### What v1.3.0 includes vs v1.0.0
-- **Batch path** — `evaluations` / `wait-for-id` / `wait-timeout-ms` / `v2-batch` / `v2-streaming` inputs; `decisions` / `batch-id` outputs
+
+- **Batch path** — `evaluations` / `wait-for-id` / `wait-timeout-ms` / `v2-batch` / `v2-streaming` inputs; `decisions` / `batch-id` outputs (input names preserved per Doctrine 4)
 - **Verify-permit wiring** — `verify-permit` input is now meaningful (`verified` output populated)
 - **`target-id` input** — landed in v1.2.0 (2026-04-25)
 - **`risk-score` output** — landed in v1.2.0
 - **All bug fixes** — `transport.ts` ECONNRESET crash, polling not retrying network errors, `wait-for-id` allow path silently fail-closed, `decisions`/`batch-id` unset on batch error, raw `SyntaxError` on bad JSON inputs, `GateInfraError` mislabeled "Unexpected error"
 
-## GA (v1) — must ship
+### Phase 1 work items
 
-1. ~~**`target-id` input**~~ ✅ landed in v1.2.0 (CHANGELOG 2026-04-25). `action.yml` on main declares the input and threads it into both top-level `target_id` and `context.target_id`.
+1. ~~**`target-id` input**~~ landed in v1.2.0 (CHANGELOG 2026-04-25). `action.yml` on main declares the input and threads it into both top-level `target_id` and `context.target_id`.
 
-2. ~~**Four-value `decision` output**~~ ✅ landed. `action.yml` declares `decision: 'allow/deny/hold/escalate'`; the v2.1 batch path (`runV21`) and the `wait-for-id` poller surface hold/escalate end-to-end.
+2. ~~**Four-value `decision` output**~~ landed. `action.yml` declares `decision: 'allow/deny/hold/escalate'`; the batch path (`runV21`) and the `wait-for-id` poller surface hold/escalate end-to-end. (Module name `runV21` retained per Doctrine 4.)
 
-3. ~~**Marketplace listing polish**~~ ✅ branding in `action.yml` (`icon: shield`, `color: green`). README + LICENSE present on main. Listing itself still on v1.0.0 — see item 4.
+3. ~~**Marketplace listing polish**~~ branding in `action.yml` (`icon: shield`, `color: green`). README + LICENSE present on main. Listing itself still on v1.0.0 — see item 4.
 
 4. **Cut the v1.3.0 release** — **PR #28 open with automated release workflow — ready to merge → tag v1.3.0**. Code is on main but only v1.0.0 is tagged or released. The Marketplace listing customers see is v1.0.0, missing every change documented in CHANGELOG since 2026-04-17:
    - **v1.2.0** (2026-04-25): `target-id` input, `risk-score` output. CHANGELOG entry notes "Source-only release. `dist/index.js` must be rebuilt before tagging — release engineering tracks the rebuild step."
@@ -43,18 +66,48 @@ GitHub Action that gates CI deploys on an AtlaSent `allow` decision. Distributed
 
    Tracking issue: [#25](https://github.com/AtlaSent-Systems-Inc/atlasent-action/issues/25).
 
-## Post-GA — ordered by impact
+## Phase 1 — Post-stabilization, ordered by impact
 
 5. **Check-run mode** — in addition to exit-code pass/fail, create a GitHub Check with risk bullets and a link to the evaluation in the console.
 6. **Auto-comment on PRs** — summary comment when the action blocks.
 7. **Self-hosted runner compat** — document egress requirements (api.atlasent.io), IP allowlist considerations.
 8. **Matrix job support** — today one evaluation per job; allow batch eval for matrix fans. (Partially addressed by the v1.3.0 batch path, but the matrix-fan ergonomics aren't documented.)
 
+## Phase 2 — Enterprise Hardening & Runtime Expansion (additive on v1)
+
+Action-side hooks into Phase 2 enterprise capabilities (SSO/SCIM
+context propagation in CI evaluations, evidence bundle emission on
+deploy gates, Delta VQP context). Scope tracked alongside the umbrella
+Phase 2 plan; no action-side breaking change required.
+
+## Phase 3 — Execution Assurance & Operational Sovereignty (additive on v1)
+
+The verifiable proof system work documented in
+[`docs/V2_PILLAR9_PROOF_SYSTEM.md`](docs/V2_PILLAR9_PROOF_SYSTEM.md)
+(filename preserved per Doctrine 4) belongs to this phase: the action
+emits `proof-id` / `payload-hash` outputs, runs a post-job consume
+step, and links check-runs to public proof pages. Ships additively
+under the `v1` contract; flag-gated via control-plane `v2_proof_system`
+(flag name retained per Doctrine 4).
+
 ## Cross-repo dependencies
 
 - **atlasent-api**: the `decision` enum (`allow|deny|hold|escalate`) and the `/v1-verify-permit` endpoint are on `main` and surfaced here.
 - **atlasent-sdk**: no longer a runtime dep — `@atlasent/enforce` is a workspace package bundled into `dist/index.js` at build time. The pre-v1.3.0 "pin SDK version" item is moot.
 - **atlasent-docs**: needs a "CI gate" page pointing at Marketplace.
+- **atlasent-control-plane**: tenant flags `v2_batch`, `v2_streaming`, `v2_proof_system` (flag names retained per Doctrine 4).
+
+## Historical / preserved documents
+
+Per Doctrine 4, the following files retain their original filenames and
+substantive content; they carry normalization headers mapping their
+historical framing onto the current phase framing:
+
+- [`V2_ROLLOUT.md`](V2_ROLLOUT.md) — historical; substantive content describes Phase 1 capabilities (batch / streaming-wait / SDK pin).
+- [`docs/V2_ROLLOUT.md`](docs/V2_ROLLOUT.md) — historical; Wave B subset.
+- [`docs/DESIGN_V2.md`](docs/DESIGN_V2.md) — historical design doc for the action's remote-evaluator migration (now landed under `v1`).
+- [`docs/V2_PLAN.md`](docs/V2_PLAN.md) — historical; action workstreams mapped to old "pillar" structure.
+- [`docs/V2_PILLAR9_PROOF_SYSTEM.md`](docs/V2_PILLAR9_PROOF_SYSTEM.md) — historical; substantive content describes Phase 3 (Execution Assurance) work.
 
 ## Open questions
 

--- a/V2_ROLLOUT.md
+++ b/V2_ROLLOUT.md
@@ -1,5 +1,17 @@
 # atlasent-action — V2 Rollout
 
+> **Doctrine normalization header (2026-05-18).** This file is
+> preserved unchanged below per Doctrine 4 of
+> [`atlasent/VERSIONING_DOCTRINE.md`](https://github.com/AtlaSent-Systems-Inc/atlasent/blob/claude/normalize-roadmap-versioning-NWPuP/VERSIONING_DOCTRINE.md).
+> Under the current doctrine there is no "v2 product"; the work
+> described in this document is **Phase 1** (Stabilization & Pilot
+> Readiness — batch / streaming-wait / SDK pin) shipping additively on
+> the `AtlaSent v1` contract. The filename, `V2-D#` decision IDs, and
+> code-level identifiers (`v2_batch`, `v2_streaming`, action input
+> names) are retained per Doctrine 4. The body below — including the
+> earlier (now-superseded) reframing note — is left intact as
+> historical record.
+
 > **Reframing normalization header (2026-05-18).** This document
 > remains in scope and is preserved unchanged per the "do not rewrite
 > history" doctrine ([`atlasent/VERSIONING_DOCTRINE.md`](https://github.com/AtlaSent-Systems-Inc/atlasent/blob/main/VERSIONING_DOCTRINE.md)

--- a/docs/DESIGN_V2.md
+++ b/docs/DESIGN_V2.md
@@ -1,5 +1,16 @@
 # atlasent-action v2 Design
 
+> **Doctrine normalization header (2026-05-18).** This file is
+> preserved unchanged below per Doctrine 4 of
+> [`atlasent/VERSIONING_DOCTRINE.md`](https://github.com/AtlaSent-Systems-Inc/atlasent/blob/claude/normalize-roadmap-versioning-NWPuP/VERSIONING_DOCTRINE.md).
+> The "v2" in this filename and body refers to the action's
+> package-major SemVer (the bundled-evaluator → remote-evaluator
+> migration), not a platform-version `v2`. Under the current doctrine
+> there is no platform `v2`; the design described here ships on the
+> stable `AtlaSent v1` contract via the action's own major bump
+> (Doctrine 5 — per-package SemVer independent of the platform).
+> Filename retained per Doctrine 4.
+
 ## Breaking Change
 
 `atlasent-action` v2 removes its bundled evaluator and calls `POST /v1-evaluate`

--- a/docs/V2_PILLAR9_PROOF_SYSTEM.md
+++ b/docs/V2_PILLAR9_PROOF_SYSTEM.md
@@ -1,5 +1,14 @@
 # Pillar 9 — Verifiable Proof System: Action workstreams
 
+> **Doctrine normalization header (2026-05-18).** This file is
+> preserved unchanged below per Doctrine 4 of
+> [`atlasent/VERSIONING_DOCTRINE.md`](https://github.com/AtlaSent-Systems-Inc/atlasent/blob/claude/normalize-roadmap-versioning-NWPuP/VERSIONING_DOCTRINE.md).
+> Under the current doctrine there is no "v2 product"; the verifiable
+> proof system described here belongs to **Phase 3** (Execution
+> Assurance & Operational Sovereignty), shipping additively on the
+> `AtlaSent v1` contract. The filename, "Pillar 9" identifier, and
+> code-level flag name (`v2_proof_system`) are retained per Doctrine 4.
+
 Companion to
 [`atlasent-api/docs/V2_PILLAR9_PROOF_SYSTEM.md`](https://github.com/AtlaSent-Systems-Inc/atlasent-api/pull/116).
 

--- a/docs/V2_PLAN.md
+++ b/docs/V2_PLAN.md
@@ -1,5 +1,16 @@
 # atlasent-action V2 Plan
 
+> **Doctrine normalization header (2026-05-18).** This file is
+> preserved unchanged below per Doctrine 4 of
+> [`atlasent/VERSIONING_DOCTRINE.md`](https://github.com/AtlaSent-Systems-Inc/atlasent/blob/claude/normalize-roadmap-versioning-NWPuP/VERSIONING_DOCTRINE.md).
+> Under the current doctrine there is no "v2 product"; the action
+> workstreams described here are split between **Phase 1** (batch /
+> streaming / matrix-job ergonomics) and **Phase 2** (enterprise
+> distribution / GitHub App / check-run mode), all shipping additively
+> on the `AtlaSent v1` contract. The "Pillar 2/3/4" structure in the
+> body refers to the historical pre-reframing pillar layout. Filename
+> retained per Doctrine 4.
+
 > Companion to the canonical plan: **[atlasent-api/docs/V2_PLAN.md](https://github.com/AtlaSent-Systems-Inc/atlasent-api/blob/claude/v2-planning/docs/V2_PLAN.md)**.
 > This file enumerates only the GitHub Action workstreams. Product-level
 > rationale, non-goals, and timeline live in the canonical plan.

--- a/docs/V2_ROLLOUT.md
+++ b/docs/V2_ROLLOUT.md
@@ -1,5 +1,15 @@
 # atlasent-action — v2.1 rollout
 
+> **Doctrine normalization header (2026-05-18).** This file is
+> preserved unchanged below per Doctrine 4 of
+> [`atlasent/VERSIONING_DOCTRINE.md`](https://github.com/AtlaSent-Systems-Inc/atlasent/blob/claude/normalize-roadmap-versioning-NWPuP/VERSIONING_DOCTRINE.md).
+> Under the current doctrine there is no "v2 product"; the work
+> described here is **Phase 1** (additive on the `AtlaSent v1`
+> contract). The "v2.1" label is the action's npm/Marketplace SemVer
+> (Doctrine 5), not a platform version. Filenames and code identifiers
+> (`v2_batch`, `v2_streaming`, `src/v21.ts`) are retained per
+> Doctrine 4.
+
 > **Reframing normalization header (2026-05-18).** This document
 > remains in scope and is preserved unchanged per the "do not rewrite
 > history" doctrine ([`atlasent/VERSIONING_DOCTRINE.md`](https://github.com/AtlaSent-Systems-Inc/atlasent/blob/main/VERSIONING_DOCTRINE.md)


### PR DESCRIPTION
## Summary

Terminology-only normalization pass per the new canonical [atlasent/VERSIONING_DOCTRINE.md](https://github.com/AtlaSent-Systems-Inc/atlasent/blob/claude/normalize-roadmap-versioning-NWPuP/VERSIONING_DOCTRINE.md) (2026-05-18 revision).

The doctrine separates three previously-conflated concerns:

1. **Public contract versioning** — stable at `AtlaSent v1`.
2. **Roadmap sequencing** — `Phase 1` / `Phase 2` / `Phase 3` (with `Wave` / `Pillar` inside).
3. **Infrastructure / assurance maturity** — `execution assurance`, `operational sovereignty`.

There is no "v2 product" and no "v3 product". Phase 2 and Phase 3 ship additively on the `v1` contract.

## What changed in this repo

- `ROADMAP.md` — rewritten to use phase / wave vocabulary; doctrine link at top; substantive content (capabilities, dates, release status, PR #28 tracking, post-GA items, cross-repo deps) preserved.
- `V2_ROLLOUT.md`, `docs/V2_ROLLOUT.md`, `docs/DESIGN_V2.md`, `docs/V2_PLAN.md`, `docs/V2_PILLAR9_PROOF_SYSTEM.md` — top-of-file doctrine normalization header added. Bodies untouched per Doctrine 4.

## What did NOT change

- No code, `action.yml`, `package.json`, or `dist/` changes.
- No CHANGELOG / RELEASE_NOTES rewrites (historical).
- No filenames renamed (Doctrine 4).
- Code identifiers (`v2_proof_system`, `v2_batch`, `v2_streaming`, action inputs `v2-batch`/`v2-streaming`, `runV21`, `src/v21.ts`) retained per Doctrine 4 — they are code artifacts, not platform-version labels.

## Test plan

- [ ] Doctrine link resolves
- [ ] No code/build changes (CI green by inspection)
- [ ] Historical decision IDs (`V2-D#`, `B.AC#`) still findable

Draft until the umbrella atlasent normalization PR lands.

---
_Generated by [Claude Code](https://claude.ai/code/session_012DvLn1nGHR3RiKSR6ov62E)_