### PR TITLE
feat(action): release-mode for post-deploy candidate verification

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -97,6 +97,49 @@ inputs:
     description: 'Number of sessions for the subject, used by session_count trigger campaigns.'
     required: false
     default: ''
+  # ── Release-candidate post-deploy verification ────────────────────────────────
+  release-mode:
+    description: |
+      When "register-and-verify", run as a POST-deploy step against the
+      atlasent-control-plane release-verification surface:
+        1. POST /v1/release/candidates           (register the candidate)
+        2. POST /v1/release/candidates/:id/verify/runtime
+        3. POST /v1/release/candidates/:id/verify/deploy
+      Mutually exclusive with the evaluate/policy-sync paths — when set,
+      single-eval and batch inputs are ignored.
+    required: false
+    default: ''
+  control-plane-url:
+    description: 'atlasent-control-plane base URL (release-mode only).'
+    required: false
+  control-plane-token:
+    description: |
+      Bearer token for the control-plane. Either set this input or the
+      ATLASENT_CP_TOKEN env var. Distinct from ATLASENT_API_KEY (which
+      authenticates against the runtime). Required when release-mode is set.
+    required: false
+  release-target-runtime-url:
+    description: 'URL of the deployed atlasent-api runtime to probe (release-mode only).'
+    required: false
+  release-repo:
+    description: 'Repository identifier registered with the candidate. Defaults to ${{ github.repository }}.'
+    required: false
+  release-commit-sha:
+    description: 'Commit SHA registered with the candidate. Defaults to ${{ github.sha }}.'
+    required: false
+  release-image-digest:
+    description: 'Optional image digest (e.g. sha256:...) registered with the candidate.'
+    required: false
+  release-semver:
+    description: 'Optional semver string registered with the candidate.'
+    required: false
+  release-environment:
+    description: 'preview | staging | production. Required when release-mode is set.'
+    required: false
+  release-fail-on-verify:
+    description: 'When "true" (default), fail the step if either verify/runtime or verify/deploy returns failed/error. "false" leaves the outcome in outputs without failing.'
+    required: false
+    default: 'true'
 outputs:
   decision:
     description: 'The evaluation decision (allow/deny/hold/escalate). Set for single-eval path only.'
@@ -139,6 +182,17 @@ outputs:
     description: 'JSON array of behavior insights campaigns that fired for the subject. Empty array when insights-org-id is not set or the feature flag is disabled.'
   insights-skipped:
     description: 'JSON array of behavior insights campaigns that were skipped, with reasons.'
+  # ── Release-candidate outputs ────────────────────────────────────────────────
+  release-candidate-id:
+    description: 'Candidate ID returned by POST /v1/release/candidates (release-mode only).'
+  release-runtime-status:
+    description: 'Outcome status of the runtime verification: passed | failed | partial | error (release-mode only).'
+  release-deploy-status:
+    description: 'Outcome status of the deploy verification: passed | failed | partial | error (release-mode only).'
+  release-runtime-result:
+    description: 'Full JSON result of the runtime verification (release-mode only).'
+  release-deploy-result:
+    description: 'Full JSON result of the deploy verification (release-mode only).'
 runs:
   using: 'node24'
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -789,6 +789,67 @@ function assessFinancialGovernance(input) {
   };
 }
 
+// src/releaseCandidate.ts
+async function postJson(url, token, body, fetchFn = globalThis.fetch) {
+  const res = await fetchFn(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`
+    },
+    body: JSON.stringify(body)
+  });
+  const text = await res.text();
+  if (!res.ok) {
+    throw new Error(`POST ${url} failed (${res.status}): ${text.slice(0, 400)}`);
+  }
+  try {
+    const parsed = JSON.parse(text);
+    if (parsed && typeof parsed === "object" && "data" in parsed && parsed.success) {
+      return parsed.data;
+    }
+    return parsed;
+  } catch {
+    throw new Error(`POST ${url} returned non-JSON body: ${text.slice(0, 200)}`);
+  }
+}
+async function registerAndVerify(inputs, fetchFn = globalThis.fetch) {
+  const base = inputs.controlPlaneUrl.replace(/\/$/, "");
+  const registered = await postJson(
+    `${base}/v1/release/candidates`,
+    inputs.controlPlaneToken,
+    {
+      repo: inputs.repo,
+      commitSha: inputs.commitSha,
+      imageDigest: inputs.imageDigest,
+      semver: inputs.semver,
+      environment: inputs.environment,
+      targetRuntimeUrl: inputs.targetRuntimeUrl
+    },
+    fetchFn
+  );
+  const runtime = await postJson(
+    `${base}/v1/release/candidates/${registered.candidateId}/verify/runtime`,
+    inputs.controlPlaneToken,
+    {},
+    fetchFn
+  );
+  const deploy = await postJson(
+    `${base}/v1/release/candidates/${registered.candidateId}/verify/deploy`,
+    inputs.controlPlaneToken,
+    {},
+    fetchFn
+  );
+  return { candidateId: registered.candidateId, runtime, deploy };
+}
+function summarizeOutcome(o) {
+  if (o.status === "passed")
+    return { ok: true, level: "passed" };
+  if (o.status === "partial")
+    return { ok: true, level: "warned" };
+  return { ok: false, level: "failed" };
+}
+
 // src/index.ts
 function getApiKey() {
   const apiKey = (process.env["ATLASENT_API_KEY"] ?? "").trim();
@@ -1017,7 +1078,109 @@ async function runPolicySyncStep(apiKey, apiUrl) {
     info(`  Run ID: ${run2.id}`);
   }
 }
+async function runReleaseModeStep() {
+  const cpUrl = getInput("control-plane-url", true);
+  const cpToken = getInput("control-plane-token") || (process.env["ATLASENT_CP_TOKEN"] ?? "").trim();
+  if (!cpToken) {
+    setFailed(
+      "release-mode: control-plane-token input or ATLASENT_CP_TOKEN env var is required"
+    );
+    return;
+  }
+  maskValue(cpToken);
+  const targetUrl = getInput("release-target-runtime-url", true);
+  const gh = getGitHubContext();
+  const repo = getInput("release-repo") || gh.repository;
+  const commitSha = getInput("release-commit-sha") || gh.sha;
+  if (!commitSha) {
+    setFailed("release-mode: commit SHA is required (set release-commit-sha or GITHUB_SHA)");
+    return;
+  }
+  const imageDigest = getInput("release-image-digest") || void 0;
+  const semver = getInput("release-semver") || void 0;
+  const environment = getInput("release-environment", true);
+  if (!["preview", "staging", "production"].includes(environment)) {
+    setFailed(
+      `release-mode: release-environment must be preview | staging | production (got "${environment}")`
+    );
+    return;
+  }
+  const failOnVerify = getInput("release-fail-on-verify").toLowerCase() !== "false";
+  info(
+    `AtlaSent release: registering candidate for ${repo}@${commitSha.slice(0, 8)} in ${environment} against ${targetUrl}`
+  );
+  let result;
+  try {
+    result = await registerAndVerify({
+      controlPlaneUrl: cpUrl,
+      controlPlaneToken: cpToken,
+      targetRuntimeUrl: targetUrl,
+      repo,
+      commitSha,
+      imageDigest,
+      semver,
+      environment
+    });
+  } catch (err) {
+    setOutput("release-candidate-id", "");
+    setOutput("release-runtime-status", "error");
+    setOutput("release-deploy-status", "error");
+    setOutput("release-runtime-result", "{}");
+    setOutput("release-deploy-result", "{}");
+    setFailed(
+      `AtlaSent release: ${err instanceof Error ? err.message : String(err)}`
+    );
+    return;
+  }
+  setOutput("release-candidate-id", result.candidateId);
+  setOutput("release-runtime-status", result.runtime.status);
+  setOutput("release-deploy-status", result.deploy.status);
+  setOutput("release-runtime-result", JSON.stringify(result.runtime));
+  setOutput("release-deploy-result", JSON.stringify(result.deploy));
+  const runtimeSummary = summarizeOutcome(result.runtime);
+  const deploySummary = summarizeOutcome(result.deploy);
+  info(`  Candidate: ${result.candidateId}`);
+  info(`  Runtime verify: ${result.runtime.status}`);
+  for (const c of result.runtime.checks) {
+    info(`    \u2022 ${c.name}: ${c.status}${c.detail ? ` \u2014 ${c.detail}` : ""}`);
+  }
+  info(`  Deploy verify: ${result.deploy.status}`);
+  for (const c of result.deploy.checks) {
+    info(`    \u2022 ${c.name}: ${c.status}${c.detail ? ` \u2014 ${c.detail}` : ""}`);
+  }
+  appendToStepSummary(
+    [
+      "",
+      "## \u{1F680} AtlaSent Release Candidate",
+      "",
+      `| Field | Value |`,
+      `|---|---|`,
+      `| Candidate ID | \`${result.candidateId}\` |`,
+      `| Repo | \`${repo}\` |`,
+      `| Commit | \`${commitSha.slice(0, 8)}\` |`,
+      `| Environment | \`${environment}\` |`,
+      `| Runtime verify | ${runtimeSummary.level === "passed" ? "\u2705" : runtimeSummary.level === "warned" ? "\u26A0\uFE0F" : "\u274C"} \`${result.runtime.status}\` |`,
+      `| Deploy verify | ${deploySummary.level === "passed" ? "\u2705" : deploySummary.level === "warned" ? "\u26A0\uFE0F" : "\u274C"} \`${result.deploy.status}\` |`,
+      ""
+    ].join("\n")
+  );
+  if (failOnVerify && (!runtimeSummary.ok || !deploySummary.ok)) {
+    const failed = [];
+    if (!runtimeSummary.ok)
+      failed.push(`runtime=${result.runtime.status}`);
+    if (!deploySummary.ok)
+      failed.push(`deploy=${result.deploy.status}`);
+    setFailed(
+      `AtlaSent release: verification failed (${failed.join(", ")}). Promotion should not proceed.`
+    );
+    return;
+  }
+}
 async function run() {
+  if (getInput("release-mode") === "register-and-verify") {
+    await runReleaseModeStep();
+    return;
+  }
   const apiKey = getApiKey();
   maskValue(apiKey);
   const apiUrl = getInput("api-url") || "https://api.atlasent.io";

--- a/src/__tests__/releaseCandidate.test.ts
+++ b/src/__tests__/releaseCandidate.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it, vi } from "vitest";
+import { registerAndVerify, summarizeOutcome } from "../releaseCandidate";
+
+describe("registerAndVerify", () => {
+  it("registers candidate then calls runtime + deploy verify in sequence", async () => {
+    const calls: Array<{ url: string; body: unknown }> = [];
+    const fetchFn = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      const body = init?.body ? JSON.parse(init.body as string) : undefined;
+      calls.push({ url, body });
+      if (url.endsWith("/v1/release/candidates")) {
+        return new Response(
+          JSON.stringify({ success: true, data: { candidateId: "cand-1" } }),
+          { status: 200 },
+        );
+      }
+      if (url.endsWith("/cand-1/verify/runtime")) {
+        return new Response(
+          JSON.stringify({
+            success: true,
+            data: {
+              verificationId: "v-rt",
+              status: "passed",
+              checks: [{ name: "status", status: "passed" }],
+              summary: {},
+            },
+          }),
+          { status: 200 },
+        );
+      }
+      if (url.endsWith("/cand-1/verify/deploy")) {
+        return new Response(
+          JSON.stringify({
+            success: true,
+            data: {
+              verificationId: "v-dp",
+              status: "passed",
+              checks: [{ name: "deploy.commit_sha", status: "passed" }],
+              summary: {},
+            },
+          }),
+          { status: 200 },
+        );
+      }
+      throw new Error(`unexpected: ${url}`);
+    });
+
+    const result = await registerAndVerify(
+      {
+        controlPlaneUrl: "https://cp.example",
+        controlPlaneToken: "cp-tok",
+        targetRuntimeUrl: "https://rt.example",
+        repo: "org/repo",
+        commitSha: "abcdef0",
+        imageDigest: "sha256:x",
+        semver: "1.0.0",
+        environment: "staging",
+      },
+      fetchFn as unknown as typeof fetch,
+    );
+
+    expect(result.candidateId).toBe("cand-1");
+    expect(result.runtime.status).toBe("passed");
+    expect(result.deploy.status).toBe("passed");
+    expect(calls.map((c) => c.url)).toEqual([
+      "https://cp.example/v1/release/candidates",
+      "https://cp.example/v1/release/candidates/cand-1/verify/runtime",
+      "https://cp.example/v1/release/candidates/cand-1/verify/deploy",
+    ]);
+    // First call carries the candidate identity.
+    expect(calls[0]?.body).toMatchObject({
+      repo: "org/repo",
+      commitSha: "abcdef0",
+      imageDigest: "sha256:x",
+      semver: "1.0.0",
+      environment: "staging",
+      targetRuntimeUrl: "https://rt.example",
+    });
+  });
+
+  it("throws on non-2xx from the registration call", async () => {
+    const fetchFn = vi.fn(async () =>
+      new Response("not authorized", { status: 401 }),
+    );
+    await expect(
+      registerAndVerify(
+        {
+          controlPlaneUrl: "https://cp.example",
+          controlPlaneToken: "bad",
+          targetRuntimeUrl: "https://rt.example",
+          repo: "org/repo",
+          commitSha: "abcdef0",
+          environment: "staging",
+        },
+        fetchFn as unknown as typeof fetch,
+      ),
+    ).rejects.toThrow(/POST .* failed \(401\)/);
+  });
+
+  it("strips trailing slash from controlPlaneUrl", async () => {
+    const seen: string[] = [];
+    const fetchFn = vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString();
+      seen.push(url);
+      if (url.endsWith("/v1/release/candidates")) {
+        return new Response(
+          JSON.stringify({ success: true, data: { candidateId: "c" } }),
+        );
+      }
+      return new Response(
+        JSON.stringify({
+          success: true,
+          data: { verificationId: "v", status: "passed", checks: [], summary: {} },
+        }),
+      );
+    });
+    await registerAndVerify(
+      {
+        controlPlaneUrl: "https://cp.example/",
+        controlPlaneToken: "t",
+        targetRuntimeUrl: "https://rt",
+        repo: "r",
+        commitSha: "s",
+        environment: "preview",
+      },
+      fetchFn as unknown as typeof fetch,
+    );
+    // No double-slashes after the host.
+    for (const u of seen) {
+      const afterScheme = u.replace(/^https?:\/\//, "");
+      expect(afterScheme).not.toMatch(/\/\//);
+    }
+  });
+});
+
+describe("summarizeOutcome", () => {
+  it("passed → ok=true level=passed", () => {
+    expect(summarizeOutcome({ status: "passed", checks: [], summary: {}, verificationId: "v" }))
+      .toEqual({ ok: true, level: "passed" });
+  });
+  it("partial → ok=true level=warned", () => {
+    expect(summarizeOutcome({ status: "partial", checks: [], summary: {}, verificationId: "v" }))
+      .toEqual({ ok: true, level: "warned" });
+  });
+  it("failed → ok=false level=failed", () => {
+    expect(summarizeOutcome({ status: "failed", checks: [], summary: {}, verificationId: "v" }))
+      .toEqual({ ok: false, level: "failed" });
+  });
+  it("error → ok=false level=failed", () => {
+    expect(summarizeOutcome({ status: "error", checks: [], summary: {}, verificationId: "v" }))
+      .toEqual({ ok: false, level: "failed" });
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,8 @@
 // AtlaSent Gate Action — GitHub Actions entry point.
 //
 // Routing (in priority order):
+//   release-mode set      → POST-deploy candidate registration + verify
+//                           against atlasent-control-plane /v1/release/*
 //   policy-sync=true      → v1-policy-sync (post bundle, fail CI on rejection)
 //   evaluations input set → v2.1 batch path via runV21()
 //   single action input   → @atlasent/enforce (canonical enforcement wrapper)
@@ -20,6 +22,7 @@ import {
 } from "./financialGovernanceAdvisory";
 import type { FinancialAdvisoryInput } from "./financialGovernanceAdvisory";
 import { emitEvidenceEvent } from "./evidenceClient";
+import { registerAndVerify, summarizeOutcome } from "./releaseCandidate";
 import {
   LEGACY_PRODUCTION_DEPLOY_ALIAS,
   PRODUCTION_DEPLOY_ACTION,
@@ -336,10 +339,132 @@ async function runPolicySyncStep(apiKey: string, apiUrl: string): Promise<void> 
 }
 
 // ---------------------------------------------------------------------------
+// Release-candidate post-deploy mode
+// ---------------------------------------------------------------------------
+
+async function runReleaseModeStep(): Promise<void> {
+  const cpUrl = getInput("control-plane-url", true);
+  const cpToken =
+    getInput("control-plane-token") || (process.env["ATLASENT_CP_TOKEN"] ?? "").trim();
+  if (!cpToken) {
+    setFailed(
+      "release-mode: control-plane-token input or ATLASENT_CP_TOKEN env var is required",
+    );
+    return;
+  }
+  maskValue(cpToken);
+
+  const targetUrl = getInput("release-target-runtime-url", true);
+  const gh = getGitHubContext();
+  const repo = getInput("release-repo") || gh.repository;
+  const commitSha = getInput("release-commit-sha") || gh.sha;
+  if (!commitSha) {
+    setFailed("release-mode: commit SHA is required (set release-commit-sha or GITHUB_SHA)");
+    return;
+  }
+  const imageDigest = getInput("release-image-digest") || undefined;
+  const semver = getInput("release-semver") || undefined;
+  const environment = getInput("release-environment", true) as
+    | "preview"
+    | "staging"
+    | "production";
+  if (!["preview", "staging", "production"].includes(environment)) {
+    setFailed(
+      `release-mode: release-environment must be preview | staging | production (got "${environment}")`,
+    );
+    return;
+  }
+  const failOnVerify = getInput("release-fail-on-verify").toLowerCase() !== "false";
+
+  info(
+    `AtlaSent release: registering candidate for ${repo}@${commitSha.slice(0, 8)} in ${environment} against ${targetUrl}`,
+  );
+
+  let result;
+  try {
+    result = await registerAndVerify({
+      controlPlaneUrl: cpUrl,
+      controlPlaneToken: cpToken,
+      targetRuntimeUrl: targetUrl,
+      repo,
+      commitSha,
+      imageDigest,
+      semver,
+      environment,
+    });
+  } catch (err) {
+    setOutput("release-candidate-id", "");
+    setOutput("release-runtime-status", "error");
+    setOutput("release-deploy-status", "error");
+    setOutput("release-runtime-result", "{}");
+    setOutput("release-deploy-result", "{}");
+    setFailed(
+      `AtlaSent release: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return;
+  }
+
+  setOutput("release-candidate-id", result.candidateId);
+  setOutput("release-runtime-status", result.runtime.status);
+  setOutput("release-deploy-status", result.deploy.status);
+  setOutput("release-runtime-result", JSON.stringify(result.runtime));
+  setOutput("release-deploy-result", JSON.stringify(result.deploy));
+
+  const runtimeSummary = summarizeOutcome(result.runtime);
+  const deploySummary = summarizeOutcome(result.deploy);
+
+  info(`  Candidate: ${result.candidateId}`);
+  info(`  Runtime verify: ${result.runtime.status}`);
+  for (const c of result.runtime.checks) {
+    info(`    • ${c.name}: ${c.status}${c.detail ? ` — ${c.detail}` : ""}`);
+  }
+  info(`  Deploy verify: ${result.deploy.status}`);
+  for (const c of result.deploy.checks) {
+    info(`    • ${c.name}: ${c.status}${c.detail ? ` — ${c.detail}` : ""}`);
+  }
+
+  appendToStepSummary(
+    [
+      "",
+      "## 🚀 AtlaSent Release Candidate",
+      "",
+      `| Field | Value |`,
+      `|---|---|`,
+      `| Candidate ID | \`${result.candidateId}\` |`,
+      `| Repo | \`${repo}\` |`,
+      `| Commit | \`${commitSha.slice(0, 8)}\` |`,
+      `| Environment | \`${environment}\` |`,
+      `| Runtime verify | ${runtimeSummary.level === "passed" ? "✅" : runtimeSummary.level === "warned" ? "⚠️" : "❌"} \`${result.runtime.status}\` |`,
+      `| Deploy verify | ${deploySummary.level === "passed" ? "✅" : deploySummary.level === "warned" ? "⚠️" : "❌"} \`${result.deploy.status}\` |`,
+      "",
+    ].join("\n"),
+  );
+
+  if (failOnVerify && (!runtimeSummary.ok || !deploySummary.ok)) {
+    const failed: string[] = [];
+    if (!runtimeSummary.ok) failed.push(`runtime=${result.runtime.status}`);
+    if (!deploySummary.ok) failed.push(`deploy=${result.deploy.status}`);
+    setFailed(
+      `AtlaSent release: verification failed (${failed.join(", ")}). Promotion should not proceed.`,
+    );
+    return;
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
 
 export async function run(): Promise<void> {
+  // ── Release-mode path (post-deploy verification) ───────────────────────────
+  // Runs against the control-plane, not the runtime — does NOT require
+  // ATLASENT_API_KEY. Routed first so it can short-circuit before the other
+  // paths' input requirements.
+  if (getInput("release-mode") === "register-and-verify") {
+    await runReleaseModeStep();
+    return;
+  }
+
   // 1. Read shared inputs
   const apiKey = getApiKey();
   maskValue(apiKey);

--- a/src/releaseCandidate.ts
+++ b/src/releaseCandidate.ts
@@ -1,0 +1,122 @@
+// Post-deploy release candidate registration + verification.
+//
+// Wires into the atlasent-control-plane release surface added in
+// AtlaSent-Systems-Inc/atlasent-control-plane#65:
+//   POST   /v1/release/candidates
+//   POST   /v1/release/candidates/:id/verify/runtime
+//   POST   /v1/release/candidates/:id/verify/deploy
+//
+// Runs as a separate workflow step AFTER the deploy completes. The
+// gate step (single-eval / batch) still runs BEFORE deploy; this is
+// purely post-deploy attestation against the running runtime.
+//
+// Fail-closed: any transport or HTTP error throws so the workflow
+// step fails. Verification failures (non-2xx OR outcome status
+// "failed"/"error") fail the step unless fail-on-verify=false.
+
+export interface ReleaseInputs {
+  controlPlaneUrl: string;
+  controlPlaneToken: string;
+  targetRuntimeUrl: string;
+  repo: string;
+  commitSha: string;
+  imageDigest?: string;
+  semver?: string;
+  environment: "preview" | "staging" | "production";
+}
+
+export interface VerificationOutcome {
+  status: "passed" | "failed" | "partial" | "error";
+  checks: Array<{ name: string; status: string; detail?: string }>;
+  summary: Record<string, unknown>;
+  verificationId: string;
+}
+
+export interface ReleaseResult {
+  candidateId: string;
+  runtime: VerificationOutcome;
+  deploy: VerificationOutcome;
+}
+
+interface Envelope<T> {
+  success: true;
+  data: T;
+}
+
+async function postJson<T>(
+  url: string,
+  token: string,
+  body: unknown,
+  fetchFn: typeof fetch = globalThis.fetch,
+): Promise<T> {
+  const res = await fetchFn(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify(body),
+  });
+  const text = await res.text();
+  if (!res.ok) {
+    throw new Error(`POST ${url} failed (${res.status}): ${text.slice(0, 400)}`);
+  }
+  try {
+    const parsed = JSON.parse(text) as Envelope<T> | T;
+    if (parsed && typeof parsed === "object" && "data" in parsed && (parsed as Envelope<T>).success) {
+      return (parsed as Envelope<T>).data;
+    }
+    return parsed as T;
+  } catch {
+    throw new Error(`POST ${url} returned non-JSON body: ${text.slice(0, 200)}`);
+  }
+}
+
+export async function registerAndVerify(
+  inputs: ReleaseInputs,
+  fetchFn: typeof fetch = globalThis.fetch,
+): Promise<ReleaseResult> {
+  const base = inputs.controlPlaneUrl.replace(/\/$/, "");
+
+  const registered = await postJson<{ candidateId: string }>(
+    `${base}/v1/release/candidates`,
+    inputs.controlPlaneToken,
+    {
+      repo: inputs.repo,
+      commitSha: inputs.commitSha,
+      imageDigest: inputs.imageDigest,
+      semver: inputs.semver,
+      environment: inputs.environment,
+      targetRuntimeUrl: inputs.targetRuntimeUrl,
+    },
+    fetchFn,
+  );
+
+  const runtime = await postJson<VerificationOutcome>(
+    `${base}/v1/release/candidates/${registered.candidateId}/verify/runtime`,
+    inputs.controlPlaneToken,
+    {},
+    fetchFn,
+  );
+
+  const deploy = await postJson<VerificationOutcome>(
+    `${base}/v1/release/candidates/${registered.candidateId}/verify/deploy`,
+    inputs.controlPlaneToken,
+    {},
+    fetchFn,
+  );
+
+  return { candidateId: registered.candidateId, runtime, deploy };
+}
+
+// Treats both "passed" outcomes as success. "partial" passes
+// (runtime didn't report a comparable field) but emits a warning. Any
+// "failed" or "error" outcome ⇒ failure.
+export function summarizeOutcome(o: VerificationOutcome): {
+  ok: boolean;
+  level: "passed" | "warned" | "failed";
+} {
+  if (o.status === "passed") return { ok: true, level: "passed" };
+  if (o.status === "partial") return { ok: true, level: "warned" };
+  return { ok: false, level: "failed" };
+}


### PR DESCRIPTION
## Summary

Adds a new `release-mode` to atlasent-action that runs as a **post-deploy** step against the control-plane's new release-verification surface (AtlaSent-Systems-Inc/atlasent-control-plane#65).

```yaml
- uses: AtlaSent-Systems-Inc/atlasent-action@v2
  with:
    release-mode: register-and-verify
    control-plane-url: https://cp.atlasent.io
    control-plane-token: ${{ secrets.ATLASENT_CP_TOKEN }}
    release-target-runtime-url: https://api.atlasent.io
    release-environment: production
    release-image-digest: ${{ steps.build.outputs.digest }}
    release-semver: ${{ steps.meta.outputs.version }}
    # release-repo and release-commit-sha default to github.repository / github.sha
```

Flow:
1. `POST /v1/release/candidates` — register the candidate
2. `POST /v1/release/candidates/:id/verify/runtime` — probe the deployed runtime
3. `POST /v1/release/candidates/:id/verify/deploy` — confirm runtime's reported build identity matches the registered candidate

This is the canonical caller of the new endpoints — the gate step (single-eval / batch / policy-sync) still runs **before** deploy as today; `release-mode` is a **separate post-deploy step** that produces attestation evidence.

### Routing
- New `release-mode` branch is routed **first** in `run()` (before `policy-sync`/batch/single-eval). It talks to the control-plane via `control-plane-token`, **not** the runtime — so `ATLASENT_API_KEY` is neither required nor read in this mode.
- All other existing paths are unchanged.

### Outputs

| Output | Meaning |
|---|---|
| `release-candidate-id` | Candidate ID from POST `/v1/release/candidates` |
| `release-runtime-status` | `passed` \| `partial` \| `failed` \| `error` |
| `release-deploy-status` | `passed` \| `partial` \| `failed` \| `error` |
| `release-runtime-result` | Full JSON outcome |
| `release-deploy-result` | Full JSON outcome |

### Fail-closed semantics

- Transport / HTTP errors fail the step.
- `failed` or `error` verification outcome fails the step unless `release-fail-on-verify: 'false'`.
- `partial` outcome (runtime didn't report a comparable field — e.g. `build.commit_sha` is null) passes with a warning rather than blocking promotion. Once atlasent-api PR #818 lands and deploys export the build env vars, this becomes `passed`.

## Test plan

- [x] `npm test` — 187/187 (7 new releaseCandidate tests + 180 pre-existing)
- [x] `npm run typecheck` — clean
- [x] `npm run build` — dist/index.js rebuilt (47.6kb)
- [ ] End-to-end smoke from a workflow against staging once the CP branch is deployed
- [ ] Confirm `release-mode` short-circuits before `getApiKey()` (so no API key needed) — covered by the routing structure but not yet by an integration test

---
_Generated by [Claude Code](https://claude.ai/code/session_01EZXKis2rrnJRnDyix4vunz)_