### PR TITLE
Add evidence bundle builder for compliance audit trails

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -59,6 +59,14 @@ inputs:
     description: 'Currency code for the financial action value'
     required: false
     default: 'USD'
+  receipt-signing-key-id:
+    description: |
+      Key ID recorded in the evidence receipt for rotation tracking.
+      Paired with the ATLASENT_RECEIPT_SIGNING_SECRET Actions secret so
+      offline verifiers know which key to use. Omit if you do not rotate
+      signing keys or do not need signed receipts.
+    required: false
+    default: ''
   # ── Policy Sync ──────────────────────────────────────────────────────────────────
   policy-sync:
     description: |
@@ -125,6 +133,26 @@ outputs:
   audit-hash:
     description: 'SHA-256 audit chain hash'
     value: ${{ steps.gate.outputs.audit-hash }}
+  evidence-receipt:
+    description: |
+      Signed per-decision authorization receipt (JSON). Contains evaluation ID,
+      permit ID, audit-trail hash, actor, action, environment, repository, and
+      SHA. HMAC-SHA256 signed when ATLASENT_RECEIPT_SIGNING_SECRET is set as an
+      Actions secret; algorithm: "none" otherwise. Store alongside the
+      deployment record for offline verification. null on denial.
+  evidence-bundle:
+    description: |
+      Full compliance evidence bundle (JSON, v1 envelope). Wraps the receipt
+      with SOC 2 control coverage (CC7.2 audit trail, CC8.1 change management,
+      CC6.1 logical access, CC3.2 policy violations) and a bundle-level SHA-256
+      integrity hash. Upload as a job artifact for auditors:
+
+        - uses: actions/upload-artifact@v4
+          with:
+            name: atlasent-evidence-bundle
+            path: evidence-bundle.json
+
+      null on denial.
   # ── Policy Sync outputs ──────────────────────────────────────────────────────────
   sync-run-id:
     description: 'The policy sync run ID returned by v1-policy-sync. Set when policy-sync is "true".'

--- a/dist/index.js
+++ b/dist/index.js
@@ -789,6 +789,100 @@ function assessFinancialGovernance(input) {
   };
 }
 
+// src/evidenceBundle.ts
+var import_node_crypto = require("node:crypto");
+function genId() {
+  return (0, import_node_crypto.randomUUID)();
+}
+function hmacSha256(secret, input) {
+  return (0, import_node_crypto.createHmac)("sha256", secret).update(input, "utf8").digest("hex");
+}
+function sha256Hex(input) {
+  return (0, import_node_crypto.createHash)("sha256").update(input, "utf8").digest("hex");
+}
+function buildComplianceControls(hasAuditHash) {
+  return [
+    {
+      control_id: "CC7.2",
+      framework: "SOC2",
+      satisfied: true,
+      evidence_type: "audit_trail"
+    },
+    {
+      control_id: "CC8.1",
+      framework: "SOC2",
+      satisfied: true,
+      evidence_type: "change_management_gate"
+    },
+    {
+      control_id: "CC6.1",
+      framework: "SOC2",
+      satisfied: true,
+      evidence_type: "logical_access_control"
+    },
+    {
+      control_id: "CC3.2",
+      framework: "SOC2",
+      // CC3.2 (policy violations) requires the audit hash to be present.
+      satisfied: hasAuditHash,
+      evidence_type: "policy_evaluation_evidence"
+    }
+  ];
+}
+function buildEvidenceBundle(args) {
+  const receiptId = genId();
+  const bundleId = genId();
+  const generatedAt = (/* @__PURE__ */ new Date()).toISOString();
+  const receiptPayload = {
+    receipt_id: receiptId,
+    evaluation_id: args.evaluationId,
+    permit_id: args.permitToken || null,
+    audit_hash: args.auditHash ?? null,
+    issued_at: generatedAt,
+    action: args.action,
+    actor: args.actor,
+    environment: args.environment,
+    repository: args.repository,
+    sha: args.sha,
+    run_id: args.runId,
+    decision: "allow"
+  };
+  let signature = null;
+  let algorithm = "none";
+  if (args.signingSecret) {
+    const sigInput = `${receiptId}
+${generatedAt}
+${JSON.stringify(receiptPayload)}`;
+    signature = hmacSha256(args.signingSecret, sigInput);
+    algorithm = "hmac-sha256";
+  }
+  const receipt = {
+    ...receiptPayload,
+    algorithm,
+    signature,
+    signing_key_id: args.signingKeyId ?? null
+  };
+  const hasAuditHash = Boolean(args.auditHash);
+  const complianceControls = buildComplianceControls(hasAuditHash);
+  const bundleBody = {
+    v: 1,
+    bundle_id: bundleId,
+    action: args.action,
+    actor: args.actor,
+    decision: "allow",
+    environment: args.environment,
+    repository: args.repository,
+    sha: args.sha,
+    run_id: args.runId,
+    run_url: args.runUrl,
+    receipt,
+    compliance_controls: complianceControls,
+    generated_at: generatedAt
+  };
+  const bundleHash = sha256Hex(JSON.stringify(bundleBody));
+  return { ...bundleBody, bundle_hash: bundleHash };
+}
+
 // src/index.ts
 function getApiKey() {
   const apiKey = (process.env["ATLASENT_API_KEY"] ?? "").trim();
@@ -1143,6 +1237,8 @@ async function run() {
         setOutput("audit-hash", "");
       }
       setOutput("verified", "false");
+      setOutput("evidence-receipt", JSON.stringify(null));
+      setOutput("evidence-bundle", JSON.stringify(null));
       emitFinancialGovernanceAdvisory(actionType, actor, orgId);
       if (err.phase === "verify" && !failOnDeny) {
         switch (err.decision?.decision) {
@@ -1204,6 +1300,8 @@ async function run() {
     setOutput("snapshot", JSON.stringify(null));
     setOutput("audit-hash", "");
     setOutput("verified", "false");
+    setOutput("evidence-receipt", JSON.stringify(null));
+    setOutput("evidence-bundle", JSON.stringify(null));
     emitFinancialGovernanceAdvisory(actionType, actor, orgId);
     setFailed(
       `AtlaSent Gate: Unexpected error: ${err instanceof Error ? err.message : String(err)}`
@@ -1220,6 +1318,36 @@ async function run() {
   if (d.riskScore !== void 0)
     info(`  Risk score:   ${d.riskScore}`);
   info(`  Verify:       ${verifyOutcome ?? "verified"}`);
+  try {
+    const receiptSigningSecret = process.env["ATLASENT_RECEIPT_SIGNING_SECRET"];
+    const receiptSigningKeyId = getInput("receipt-signing-key-id");
+    const runUrl = `${gh.server_url}/${gh.repository}/actions/runs/${gh.run_id}`;
+    const bundle = buildEvidenceBundle({
+      evaluationId: d.evaluationId ?? "",
+      permitToken: d.permitToken ?? "",
+      auditHash: d.auditHash,
+      action: actionType,
+      actor: `github:${actor}`,
+      environment,
+      repository: gh.repository,
+      sha: gh.sha,
+      runId: gh.run_id,
+      runUrl,
+      signingSecret: receiptSigningSecret || void 0,
+      signingKeyId: receiptSigningKeyId || void 0
+    });
+    setOutput("evidence-receipt", JSON.stringify(bundle.receipt));
+    setOutput("evidence-bundle", JSON.stringify(bundle));
+    info(
+      `  Evidence:     receipt=${bundle.receipt.receipt_id} algorithm=${bundle.receipt.algorithm}`
+    );
+  } catch (bundleErr) {
+    warning(
+      `AtlaSent: evidence bundle build failed (advisory; gate decision unaffected): ${bundleErr instanceof Error ? bundleErr.message : String(bundleErr)}`
+    );
+    setOutput("evidence-receipt", JSON.stringify(null));
+    setOutput("evidence-bundle", JSON.stringify(null));
+  }
   if (d.permitToken && d.evaluationId) {
     await emitEvidenceEvent(
       { apiKey, apiUrl },

--- a/src/evidenceBundle.ts
+++ b/src/evidenceBundle.ts
@@ -1,0 +1,202 @@
+/**
+ * Evidence bundle builder for the AtlaSent GitHub Action.
+ *
+ * After a successful enforce(), assemble a compliance-ready evidence
+ * bundle from the decision data and emit it as GitHub Actions outputs.
+ * The bundle can be uploaded as a job artifact for audit purposes.
+ *
+ * This module is intentionally self-contained — no workspace package
+ * dependencies, only node:crypto. It mirrors the ActionEvidenceBundle
+ * type from the SDK's evidenceEngine.ts so bundles from both sources
+ * are structurally compatible.
+ */
+
+import { createHash, createHmac, randomUUID } from "node:crypto";
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+export interface EvidenceReceiptPayload {
+  receipt_id: string;
+  evaluation_id: string;
+  permit_id: string | null;
+  audit_hash: string | null;
+  issued_at: string;
+  action: string;
+  actor: string;
+  environment: string;
+  repository: string;
+  sha: string;
+  run_id: string;
+  decision: "allow";
+}
+
+export interface EvidenceReceipt extends EvidenceReceiptPayload {
+  algorithm: "hmac-sha256" | "none";
+  signature: string | null;
+  signing_key_id: string | null;
+}
+
+export interface ComplianceControl {
+  control_id: string;
+  framework: "SOC2";
+  satisfied: boolean;
+  evidence_type: string;
+}
+
+export interface ActionEvidenceBundle {
+  v: 1;
+  bundle_id: string;
+  action: string;
+  actor: string;
+  decision: "allow";
+  environment: string;
+  repository: string;
+  sha: string;
+  run_id: string;
+  run_url: string;
+  receipt: EvidenceReceipt;
+  compliance_controls: ComplianceControl[];
+  generated_at: string;
+  bundle_hash: string;
+}
+
+export interface BuildEvidenceBundleArgs {
+  evaluationId: string;
+  /** Permit token (already consumed by verifyPermit; stored as an ID reference). */
+  permitToken: string;
+  auditHash?: string | null;
+  action: string;
+  actor: string;
+  environment: string;
+  repository: string;
+  sha: string;
+  runId: string;
+  runUrl: string;
+  /** HMAC-SHA256 signing secret. Omit for unsigned receipts. */
+  signingSecret?: string;
+  /** Key ID paired with signingSecret for rotation tracking. */
+  signingKeyId?: string;
+}
+
+// ── Crypto helpers ─────────────────────────────────────────────────────────
+
+function genId(): string {
+  return randomUUID();
+}
+
+function hmacSha256(secret: string, input: string): string {
+  return createHmac("sha256", secret).update(input, "utf8").digest("hex");
+}
+
+function sha256Hex(input: string): string {
+  return createHash("sha256").update(input, "utf8").digest("hex");
+}
+
+// ── Compliance controls ────────────────────────────────────────────────────
+
+function buildComplianceControls(hasAuditHash: boolean): ComplianceControl[] {
+  return [
+    {
+      control_id: "CC7.2",
+      framework: "SOC2",
+      satisfied: true,
+      evidence_type: "audit_trail",
+    },
+    {
+      control_id: "CC8.1",
+      framework: "SOC2",
+      satisfied: true,
+      evidence_type: "change_management_gate",
+    },
+    {
+      control_id: "CC6.1",
+      framework: "SOC2",
+      satisfied: true,
+      evidence_type: "logical_access_control",
+    },
+    {
+      control_id: "CC3.2",
+      framework: "SOC2",
+      // CC3.2 (policy violations) requires the audit hash to be present.
+      satisfied: hasAuditHash,
+      evidence_type: "policy_evaluation_evidence",
+    },
+  ];
+}
+
+// ── Main builder ───────────────────────────────────────────────────────────
+
+/**
+ * Build a compliance-ready evidence bundle from a successful enforce()
+ * result. Returns the bundle as a plain object; callers serialize to
+ * JSON and emit as GitHub Actions outputs or upload as artifacts.
+ *
+ * The `bundle_hash` field is a SHA-256 of the entire bundle (with
+ * `bundle_hash` omitted from the hash input) so tampering is detectable.
+ */
+export function buildEvidenceBundle(
+  args: BuildEvidenceBundleArgs,
+): ActionEvidenceBundle {
+  const receiptId = genId();
+  const bundleId = genId();
+  const generatedAt = new Date().toISOString();
+
+  // ── Receipt ───────────────────────────────────────────────────────────────
+  const receiptPayload: EvidenceReceiptPayload = {
+    receipt_id: receiptId,
+    evaluation_id: args.evaluationId,
+    permit_id: args.permitToken || null,
+    audit_hash: args.auditHash ?? null,
+    issued_at: generatedAt,
+    action: args.action,
+    actor: args.actor,
+    environment: args.environment,
+    repository: args.repository,
+    sha: args.sha,
+    run_id: args.runId,
+    decision: "allow",
+  };
+
+  let signature: string | null = null;
+  let algorithm: "hmac-sha256" | "none" = "none";
+
+  if (args.signingSecret) {
+    // Signing input: receipt_id + "\n" + issued_at + "\n" + JSON(payload)
+    // Matches the convention in the SDK's evidenceEngine.ts so receipts
+    // from both sources verify with the same offline verifier.
+    const sigInput = `${receiptId}\n${generatedAt}\n${JSON.stringify(receiptPayload)}`;
+    signature = hmacSha256(args.signingSecret, sigInput);
+    algorithm = "hmac-sha256";
+  }
+
+  const receipt: EvidenceReceipt = {
+    ...receiptPayload,
+    algorithm,
+    signature,
+    signing_key_id: args.signingKeyId ?? null,
+  };
+
+  // ── Bundle (hash computed last) ───────────────────────────────────────────
+  const hasAuditHash = Boolean(args.auditHash);
+  const complianceControls = buildComplianceControls(hasAuditHash);
+
+  const bundleBody = {
+    v: 1 as const,
+    bundle_id: bundleId,
+    action: args.action,
+    actor: args.actor,
+    decision: "allow" as const,
+    environment: args.environment,
+    repository: args.repository,
+    sha: args.sha,
+    run_id: args.runId,
+    run_url: args.runUrl,
+    receipt,
+    compliance_controls: complianceControls,
+    generated_at: generatedAt,
+  };
+
+  const bundleHash = sha256Hex(JSON.stringify(bundleBody));
+
+  return { ...bundleBody, bundle_hash: bundleHash };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ import {
 } from "./financialGovernanceAdvisory";
 import type { FinancialAdvisoryInput } from "./financialGovernanceAdvisory";
 import { emitEvidenceEvent } from "./evidenceClient";
+import { buildEvidenceBundle } from "./evidenceBundle";
 import {
   LEGACY_PRODUCTION_DEPLOY_ALIAS,
   PRODUCTION_DEPLOY_ACTION,
@@ -491,6 +492,8 @@ export async function run(): Promise<void> {
         setOutput("audit-hash", "");
       }
       setOutput("verified", "false");
+      setOutput("evidence-receipt", JSON.stringify(null));
+      setOutput("evidence-bundle", JSON.stringify(null));
 
       emitFinancialGovernanceAdvisory(actionType, actor, orgId);
 
@@ -556,6 +559,8 @@ export async function run(): Promise<void> {
     setOutput("snapshot", JSON.stringify(null));
     setOutput("audit-hash", "");
     setOutput("verified", "false");
+    setOutput("evidence-receipt", JSON.stringify(null));
+    setOutput("evidence-bundle", JSON.stringify(null));
 
     emitFinancialGovernanceAdvisory(actionType, actor, orgId);
 
@@ -575,6 +580,43 @@ export async function run(): Promise<void> {
   info(`  Evaluation:   ${d.evaluationId ?? ""}`);
   if (d.riskScore !== undefined) info(`  Risk score:   ${d.riskScore}`);
   info(`  Verify:       ${verifyOutcome ?? "verified"}`);
+
+  // ── Build evidence bundle ─────────────────────────────────────────────────
+  // Best-effort: evidence output failures must never block the gate decision.
+  try {
+    const receiptSigningSecret = process.env["ATLASENT_RECEIPT_SIGNING_SECRET"];
+    const receiptSigningKeyId = getInput("receipt-signing-key-id");
+    const runUrl = `${gh.server_url}/${gh.repository}/actions/runs/${gh.run_id}`;
+
+    const bundle = buildEvidenceBundle({
+      evaluationId: d.evaluationId ?? "",
+      permitToken: d.permitToken ?? "",
+      auditHash: d.auditHash,
+      action: actionType,
+      actor: `github:${actor}`,
+      environment,
+      repository: gh.repository,
+      sha: gh.sha,
+      runId: gh.run_id,
+      runUrl,
+      signingSecret: receiptSigningSecret || undefined,
+      signingKeyId: receiptSigningKeyId || undefined,
+    });
+
+    setOutput("evidence-receipt", JSON.stringify(bundle.receipt));
+    setOutput("evidence-bundle", JSON.stringify(bundle));
+    info(
+      `  Evidence:     receipt=${bundle.receipt.receipt_id} algorithm=${bundle.receipt.algorithm}`,
+    );
+  } catch (bundleErr) {
+    warning(
+      `AtlaSent: evidence bundle build failed (advisory; gate decision unaffected): ${
+        bundleErr instanceof Error ? bundleErr.message : String(bundleErr)
+      }`,
+    );
+    setOutput("evidence-receipt", JSON.stringify(null));
+    setOutput("evidence-bundle", JSON.stringify(null));
+  }
 
   // ── B7: emit execution_started evidence event ────────────────────────────
   // Best-effort, fire-and-forget. Build outcome is already determined above.


### PR DESCRIPTION
## Summary

Adds a new `evidenceBundle.ts` module that builds compliance-ready evidence bundles from successful gate enforcement decisions. The bundle includes:

- **Evidence Receipt**: A per-decision authorization record containing evaluation ID, permit ID, audit hash, actor, action, environment, repository, and commit SHA
- **HMAC-SHA256 Signing**: Optional cryptographic signing via `ATLASENT_RECEIPT_SIGNING_SECRET` environment variable for offline verification
- **SOC 2 Control Coverage**: Compliance controls (CC7.2 audit trail, CC8.1 change management, CC6.1 logical access, CC3.2 policy violations)
- **Bundle Integrity Hash**: SHA-256 hash of the entire bundle for tamper detection

The module is intentionally self-contained (only `node:crypto` dependency) and mirrors the `ActionEvidenceBundle` type from the SDK's `evidenceEngine.ts` so bundles from both sources are structurally compatible.

Integration into the main gate flow:
- Emits `evidence-receipt` and `evidence-bundle` outputs on successful enforcement
- Outputs `null` on denial or error
- Failures in bundle building are non-blocking (advisory warnings only; gate decision unaffected)
- New optional input `receipt-signing-key-id` for key rotation tracking

## Test plan

- Existing unit tests pass
- Manual verification: successful gate enforcement produces valid JSON in both outputs
- Verify signing works when `ATLASENT_RECEIPT_SIGNING_SECRET` is set
- Verify outputs are `null` on denial/error paths

https://claude.ai/code/session_0197RmSBLzBJZpXcp8o4e1rk