### PR TITLE
ci: canonical-action-drift guard (closes atlasent-api#720)

### DIFF
--- a/.github/workflows/canonical-action-drift.yml
+++ b/.github/workflows/canonical-action-drift.yml
@@ -1,0 +1,97 @@
+name: canonical-action-drift
+
+# Drift-prevention gate (atlasent-api#720).
+#
+# Fails if the bare legacy literal `deployment.production` (not followed
+# by a dot) appears in any *.ts, *.sql, or *.md file outside the explicit
+# allowlist below.
+#
+# The canonical action is `production.deploy`; `deployment.production` is
+# the legacy alias accepted during the V1 alias window. New code must use
+# the canonical form. Only the alias-window helper file and its tests are
+# permitted to contain the legacy string.
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  canonical-action-drift:
+    name: canonical-action-drift
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check for unsanctioned bare deployment.production usage
+        run: |
+          set -euo pipefail
+
+          # ── Allowlisted files ────────────────────────────────────────────
+          # These are the ONLY files permitted to contain the bare legacy
+          # literal `deployment.production` (not followed by a dot).
+          # src/canonicalAction.ts is the alias-window helper — single
+          # source of truth for the LEGACY_PRODUCTION_DEPLOY_ALIAS constant.
+          # Its tests and the input normalisation module are also allowlisted
+          # because they test that the alias is correctly accepted and
+          # rewritten to the canonical form.
+          ALLOWLIST=(
+            # Alias-window helper — defines LEGACY_PRODUCTION_DEPLOY_ALIAS
+            "src/canonicalAction.ts"
+            # Source files that reference the alias for normalization / tests
+            "src/inputs.ts"
+            "src/index.ts"
+            # Test files
+            "src/__tests__/inputs.test.ts"
+            "src/__tests__/index.test.ts"
+          )
+
+          # ── Grep for bare deployment.production (not sub-actions) ─────────
+          HITS=$(grep -rn \
+            --include='*.ts' \
+            --include='*.sql' \
+            --include='*.md' \
+            'deployment\.production' . 2>/dev/null \
+            | grep -v 'deployment\.production\.' \
+            || true)
+
+          if [ -z "$HITS" ]; then
+            echo "No bare deployment.production hits found."
+            exit 0
+          fi
+
+          # ── Filter out allowlisted files ──────────────────────────────────
+          UNSANCTIONED=""
+          while IFS= read -r line; do
+            filepath=$(echo "$line" | cut -d: -f1 | sed 's|^\./||')
+            allowed=false
+            for allowed_file in "${ALLOWLIST[@]}"; do
+              if [ "$filepath" = "$allowed_file" ]; then
+                allowed=true
+                break
+              fi
+            done
+            if ! $allowed; then
+              UNSANCTIONED+="$line\n"
+            fi
+          done <<< "$HITS"
+
+          if [ -n "$UNSANCTIONED" ]; then
+            echo "::error::Unsanctioned bare deployment.production literal found outside the alias-window allowlist."
+            echo ""
+            echo "Hits:"
+            echo -e "$UNSANCTIONED"
+            echo ""
+            echo "To fix: update the file to use the canonical 'production.deploy' string."
+            echo "If this file is a new alias-window helper, add it to ALLOWLIST in"
+            echo ".github/workflows/canonical-action-drift.yml and get a review."
+            exit 1
+          fi
+
+          echo "All bare deployment.production hits are within the allowlist. Gate passed."


### PR DESCRIPTION
## Summary

Implements the grep-based CI drift-prevention gate from atlasent-api#720.

- Adds `.github/workflows/canonical-action-drift.yml` with a single job `canonical-action-drift`
- Greps `*.ts`, `*.sql`, and `*.md` files for the bare legacy literal `deployment.production` (not followed by a dot)
- Fails the build if any hit is found outside the per-repo allowlist
- The allowlist covers: `src/canonicalAction.ts` (defines `LEGACY_PRODUCTION_DEPLOY_ALIAS`), `src/inputs.ts` and `src/index.ts` (normalize the alias), and their test files
- Verified against current `main`: all existing bare `deployment.production` hits are within the allowlist

## Allowlist rationale

| File | Reason |
|------|--------|
| `src/canonicalAction.ts` | Alias-window helper — single source of truth for `LEGACY_PRODUCTION_DEPLOY_ALIAS = "deployment.production"` |
| `src/inputs.ts` | Normalization entry point — accepts and rewrites the legacy alias to canonical |
| `src/index.ts` | Action entry point — documents and handles the alias normalization |
| `src/__tests__/inputs.test.ts` | Tests that the alias is correctly accepted |
| `src/__tests__/index.test.ts` | Tests that the alias is forwarded as canonical |

## Test plan

- [ ] Verify the `canonical-action-drift` job appears in CI on this PR
- [ ] Confirm the job passes (no unsanctioned hits on current `main`)
- [ ] Manually test that adding a bare `deployment.production` string to a non-allowlisted file causes the job to fail

---
_Generated by [Claude Code](https://claude.ai/code/session_01UkRccQuvny1F16nbXgoL7E)_