### PR TITLE
feat(action): governance-agents PR-check mode — Phase 3

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -148,6 +148,47 @@ inputs:
     description: 'When "true" (default), fail the step if either verify/runtime or verify/deploy returns failed/error. "false" leaves the outcome in outputs without failing.'
     required: false
     default: 'true'
+  # ── Governance Agents (advisory PR-check mode) ────────────────────────────────
+  governance-agents:
+    description: |
+      Comma-separated list of constrained advisory governance-agent slugs to
+      run against the current change, e.g. "migration_review,runtime_contract_drift".
+      When set, the action invokes the governance-agents path and posts
+      findings to the job summary as advisory signal. Findings are NOT
+      authorization — required gates remain on the governance authority
+      surface. Cannot be combined with policy-sync, evaluations, action,
+      or release-mode inputs.
+    required: false
+    default: ''
+  governance-change-id:
+    description: |
+      Governed change UUID to attach findings to. Required when
+      governance-agents is set. The change must exist in the runtime DB
+      (governed_changes table) and belong to the API key's org.
+    required: false
+    default: ''
+  governance-artifact-file:
+    description: |
+      Optional path to a JSON file mapping agent slug to a pre-built
+      artifact. Required for agents whose artifact cannot be auto-discovered
+      from standard locations. migration_review and runtime_contract_drift
+      auto-discover from the repo when no artifact is supplied.
+    required: false
+    default: ''
+  governance-fail-on-severity:
+    description: |
+      Minimum severity (info|low|medium|high|blocker) that fails the step.
+      Findings are advisory by default — omit this input to never fail on
+      severity. Setting it converts the agents path from advisory to gating
+      and is opt-in by design.
+    required: false
+    default: ''
+  governance-fail-on-blocker:
+    description: |
+      Shortcut for `governance-fail-on-severity: blocker`. Ignored when
+      governance-fail-on-severity is set explicitly.
+    required: false
+    default: 'false'
 outputs:
   decision:
     description: 'The evaluation decision (allow/deny/hold/escalate). Set for single-eval path only.'
@@ -221,6 +262,15 @@ outputs:
     description: 'Full JSON result of the runtime verification (release-mode only).'
   release-deploy-result:
     description: 'Full JSON result of the deploy verification (release-mode only).'
+  # ── Governance Agents outputs ──────────────────────────────────────────────────
+  governance-findings-count:
+    description: 'Total number of findings emitted across all invoked governance agents (governance-agents path only).'
+  governance-highest-severity:
+    description: 'Highest severity emitted across all findings (info|low|medium|high|blocker), or empty when no findings (governance-agents path only).'
+  governance-evaluations:
+    description: 'JSON array of evaluation summaries — one per invoked agent — with status, findings_count, and highest_severity (governance-agents path only).'
+  governance-findings:
+    description: 'JSON array of all findings across all invoked agents (governance-agents path only).'
 runs:
   using: 'node24'
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -42,7 +42,7 @@ var require_transport = __commonJS({
     var node_https_1 = __importDefault(require("node:https"));
     var node_http_1 = __importDefault(require("node:http"));
     function post(url, body, headers) {
-      return new Promise((resolve2, reject) => {
+      return new Promise((resolve3, reject) => {
         const parsed = new URL(url);
         const transport = parsed.protocol === "https:" ? node_https_1.default : node_http_1.default;
         const req = transport.request({
@@ -59,7 +59,7 @@ var require_transport = __commonJS({
         }, (res) => {
           const chunks = [];
           res.on("data", (chunk) => chunks.push(chunk));
-          res.on("end", () => resolve2({ status: res.statusCode ?? 0, body: Buffer.concat(chunks).toString("utf-8") }));
+          res.on("end", () => resolve3({ status: res.statusCode ?? 0, body: Buffer.concat(chunks).toString("utf-8") }));
           res.on("error", reject);
         });
         req.on("error", reject);
@@ -719,6 +719,304 @@ function formatSyncDiff(run2) {
   return parts.length > 0 ? parts.join(", ") : "no changes";
 }
 
+// src/governanceAgents.ts
+var import_node_crypto = require("node:crypto");
+var fs2 = __toESM(require("node:fs"));
+var path2 = __toESM(require("node:path"));
+var SEVERITY_RANK = {
+  info: 1,
+  low: 2,
+  medium: 3,
+  high: 4,
+  blocker: 5
+};
+async function runGovernanceAgents(opts) {
+  if (!opts.apiKey)
+    throw new Error("apiKey is required");
+  if (!opts.apiUrl)
+    throw new Error("apiUrl is required");
+  if (!opts.changeId) {
+    throw new Error("changeId is required \u2014 set governance-change-id input");
+  }
+  if (opts.agentSlugs.length === 0) {
+    throw new Error("agentSlugs must be non-empty");
+  }
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  const fs_ = opts.fileSystem ?? defaultFs();
+  const workspace = opts.workspace ?? process.env["GITHUB_WORKSPACE"] ?? process.cwd();
+  const artifactMap = opts.artifactFile ? readArtifactFile(opts.artifactFile, workspace, fs_) : {};
+  const evaluations = [];
+  const findings = [];
+  for (const slug of opts.agentSlugs) {
+    const artifact = artifactMap[slug] ?? autoDiscoverArtifact(slug, workspace, fs_);
+    if (!artifact) {
+      throw new Error(
+        `No artifact for agent "${slug}". Either supply one via governance-artifact-file (a JSON object keyed by agent slug) or use a slug that supports auto-discovery (migration_review, runtime_contract_drift).`
+      );
+    }
+    const result = await invokeAgent(
+      {
+        apiKey: opts.apiKey,
+        apiUrl: opts.apiUrl,
+        changeId: opts.changeId,
+        slug,
+        artifact,
+        invokedBy: opts.invokedBy ?? "github-action",
+        fetchImpl
+      }
+    );
+    evaluations.push(result.evaluation);
+    findings.push(...result.findings);
+  }
+  const highest = highestSeverity(findings);
+  const failed = !!opts.failOnSeverity && !!highest && SEVERITY_RANK[highest] >= SEVERITY_RANK[opts.failOnSeverity];
+  return { evaluations, findings, highest_severity: highest, failed };
+}
+async function invokeAgent(args) {
+  const url = `${args.apiUrl.replace(/\/$/, "")}/v1/governance/agents/${encodeURIComponent(args.slug)}/evaluate`;
+  const body = JSON.stringify({
+    change_id: args.changeId,
+    input_hash: hashArtifact(args.artifact),
+    artifact: args.artifact,
+    invoked_by_kind: "service_account",
+    invoked_by: args.invokedBy
+  });
+  let resp;
+  try {
+    resp = await args.fetchImpl(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${args.apiKey}`
+      },
+      body
+    });
+  } catch (err) {
+    throw new Error(
+      `governance agent ${args.slug}: network error: ${err instanceof Error ? err.message : String(err)}`
+    );
+  }
+  if (!resp.ok) {
+    const text = await resp.text().catch(() => "");
+    if (resp.status === 501) {
+      throw new Error(
+        `governance agent ${args.slug}: registered in the DB but no in-process implementation is deployed (501). Skip this slug or upgrade the API.`
+      );
+    }
+    throw new Error(
+      `governance agent ${args.slug}: HTTP ${resp.status} ${resp.statusText} \u2014 ${text.slice(0, 500)}`
+    );
+  }
+  const parsed = await resp.json();
+  if (!parsed.evaluation || !Array.isArray(parsed.findings)) {
+    throw new Error(`governance agent ${args.slug}: malformed response`);
+  }
+  return parsed;
+}
+var MIGRATION_DIRS = [
+  "supabase/migrations",
+  "supabase/migrations-runtime",
+  "supabase/migrations-console",
+  "supabase/migrations-shared"
+];
+function defaultFs() {
+  return {
+    readFileSync: (p, enc) => fs2.readFileSync(p, enc),
+    existsSync: (p) => fs2.existsSync(p),
+    readdirSync: (p) => fs2.readdirSync(p),
+    statSync: (p) => fs2.statSync(p)
+  };
+}
+function autoDiscoverArtifact(slug, workspace, fs_) {
+  if (slug === "migration_review")
+    return discoverMigrationArtifact(workspace, fs_);
+  if (slug === "runtime_contract_drift")
+    return discoverRuntimeContractArtifact(workspace, fs_);
+  return null;
+}
+function discoverMigrationArtifact(workspace, fs_) {
+  const files = [];
+  for (const dir of MIGRATION_DIRS) {
+    const abs = path2.resolve(workspace, dir);
+    if (!fs_.existsSync(abs))
+      continue;
+    if (!fs_.statSync(abs).isDirectory())
+      continue;
+    for (const entry of fs_.readdirSync(abs)) {
+      if (!entry.endsWith(".sql"))
+        continue;
+      const full = path2.join(abs, entry);
+      if (!fs_.statSync(full).isFile())
+        continue;
+      files.push({
+        path: path2.relative(workspace, full),
+        content: fs_.readFileSync(full, "utf-8")
+      });
+    }
+  }
+  return { migrations: files };
+}
+function discoverRuntimeContractArtifact(workspace, fs_) {
+  const openapiPath = ["openapi.yaml", "openapi-v1.yaml", "openapi.yml"].map((p) => path2.resolve(workspace, p)).find((p) => fs_.existsSync(p));
+  if (!openapiPath)
+    return null;
+  const openapi = parseOpenApiPaths(fs_.readFileSync(openapiPath, "utf-8"));
+  const routesDir = path2.resolve(workspace, "supabase/functions");
+  const routes = fs_.existsSync(routesDir) ? discoverRuntimeRoutes(routesDir, fs_) : [];
+  const typeNames = [];
+  const typesIndex = path2.resolve(workspace, "packages/types/src/index.ts");
+  if (fs_.existsSync(typesIndex)) {
+    const content = fs_.readFileSync(typesIndex, "utf-8");
+    for (const m of content.matchAll(/export\s+(?:type|interface)\s+([A-Z][A-Za-z0-9_]*)/g)) {
+      typeNames.push(m[1]);
+    }
+  }
+  return {
+    openapi: { paths: openapi },
+    runtime: { routes },
+    sdk: { type_names: typeNames }
+  };
+}
+function parseOpenApiPaths(yaml) {
+  const out = [];
+  const lines = yaml.split("\n");
+  let inPaths = false;
+  let currentPath = null;
+  for (const raw of lines) {
+    const line = raw.replace(/\s+$/, "");
+    if (!inPaths) {
+      if (/^paths:\s*$/.test(line))
+        inPaths = true;
+      continue;
+    }
+    if (/^[A-Za-z]/.test(line)) {
+      inPaths = false;
+      if (currentPath) {
+        out.push(currentPath);
+        currentPath = null;
+      }
+      continue;
+    }
+    const pathMatch = /^  (\/[\w/{}.-]+):/.exec(line);
+    if (pathMatch) {
+      if (currentPath)
+        out.push(currentPath);
+      currentPath = { path: pathMatch[1], methods: [] };
+      continue;
+    }
+    const methodMatch = /^    (get|post|put|patch|delete):/i.exec(line);
+    if (methodMatch && currentPath) {
+      currentPath.methods.push(methodMatch[1].toLowerCase());
+    }
+  }
+  if (currentPath)
+    out.push(currentPath);
+  return out;
+}
+function discoverRuntimeRoutes(routesDir, fs_) {
+  const routes = [];
+  for (const entry of fs_.readdirSync(routesDir)) {
+    if (!entry.startsWith("v1-"))
+      continue;
+    const dir = path2.join(routesDir, entry);
+    if (!fs_.statSync(dir).isDirectory())
+      continue;
+    const inferredPath = "/" + entry.replace(/-/g, "/").replace(/^\//, "");
+    routes.push({
+      path: inferredPath,
+      // Methods unknown without parsing the handler; leave empty so the
+      // drift agent treats per-method as "not asserted by runtime" and
+      // only flags path-level drift.
+      methods: [],
+      function_name: entry
+    });
+  }
+  return routes;
+}
+function readArtifactFile(artifactPath, workspace, fs_) {
+  const abs = path2.isAbsolute(artifactPath) ? artifactPath : path2.resolve(workspace, artifactPath);
+  if (!fs_.existsSync(abs)) {
+    throw new Error(`governance-artifact-file not found: ${artifactPath}`);
+  }
+  const raw = fs_.readFileSync(abs, "utf-8");
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(
+      `governance-artifact-file is not valid JSON: ${err instanceof Error ? err.message : String(err)}`
+    );
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new Error(
+      "governance-artifact-file must be a JSON object keyed by agent slug"
+    );
+  }
+  return parsed;
+}
+function hashArtifact(artifact) {
+  const canonical = canonicalJson(artifact);
+  return "sha256:" + (0, import_node_crypto.createHash)("sha256").update(canonical).digest("hex");
+}
+function canonicalJson(value) {
+  if (value === null || typeof value !== "object")
+    return JSON.stringify(value);
+  if (Array.isArray(value))
+    return "[" + value.map(canonicalJson).join(",") + "]";
+  const keys = Object.keys(value).sort();
+  return "{" + keys.map((k) => JSON.stringify(k) + ":" + canonicalJson(value[k])).join(",") + "}";
+}
+function highestSeverity(findings) {
+  let best = null;
+  let rank = 0;
+  for (const f of findings) {
+    if (SEVERITY_RANK[f.severity] > rank) {
+      rank = SEVERITY_RANK[f.severity];
+      best = f.severity;
+    }
+  }
+  return best;
+}
+function renderStepSummary(result) {
+  const lines = [];
+  lines.push("## Constrained Governance Agents \u2014 findings");
+  lines.push("");
+  lines.push(
+    "> Findings are advisory. They produce signal, not authorization. Required gates remain on the governance authority surface."
+  );
+  lines.push("");
+  for (const e of result.evaluations) {
+    lines.push(`### ${e.agent_slug} \`${e.agent_version}\``);
+    lines.push("");
+    lines.push(
+      `Status: **${e.status}** \u2014 findings: **${e.findings_count}** \u2014 highest: **${e.highest_severity ?? "\u2014"}**`
+    );
+    if (e.summary)
+      lines.push(`> ${e.summary}`);
+    lines.push("");
+    const own = result.findings.filter((f) => f.agent_slug === e.agent_slug);
+    if (own.length === 0) {
+      lines.push("_No findings._");
+      lines.push("");
+      continue;
+    }
+    lines.push("| Severity | Type | Authority | Summary |");
+    lines.push("|---|---|---|---|");
+    for (const f of own) {
+      const auth = f.required_authority ?? "\u2014";
+      const summary = f.summary.replace(/\|/g, "\\|").replace(/\n+/g, " ");
+      lines.push(`| ${f.severity} | \`${f.finding_type}\` | ${auth} | ${summary} |`);
+    }
+    lines.push("");
+  }
+  if (result.highest_severity) {
+    lines.push(`**Overall highest severity:** \`${result.highest_severity}\``);
+  } else {
+    lines.push("**No findings.**");
+  }
+  return lines.join("\n") + "\n";
+}
+
 // src/financialGovernanceAdvisory.ts
 var USD_EQUIVALENT_CURRENCIES = /* @__PURE__ */ new Set(["USD", "USDC", "USDT", "DAI"]);
 var REGULATORY_ACTION_TYPES = /* @__PURE__ */ new Set(["wire_transfer", "trading_execution"]);
@@ -851,15 +1149,15 @@ function summarizeOutcome(o) {
 }
 
 // src/evidenceBundle.ts
-var import_node_crypto = require("node:crypto");
+var import_node_crypto2 = require("node:crypto");
 function genId() {
-  return (0, import_node_crypto.randomUUID)();
+  return (0, import_node_crypto2.randomUUID)();
 }
 function hmacSha256(secret, input) {
-  return (0, import_node_crypto.createHmac)("sha256", secret).update(input, "utf8").digest("hex");
+  return (0, import_node_crypto2.createHmac)("sha256", secret).update(input, "utf8").digest("hex");
 }
 function sha256Hex(input) {
-  return (0, import_node_crypto.createHash)("sha256").update(input, "utf8").digest("hex");
+  return (0, import_node_crypto2.createHash)("sha256").update(input, "utf8").digest("hex");
 }
 function buildComplianceControls(hasAuditHash) {
   return [
@@ -974,8 +1272,8 @@ function getInput(name, required2 = false) {
 function setOutput(name, value) {
   const outputFile = process.env["GITHUB_OUTPUT"];
   if (outputFile) {
-    const fs2 = require("node:fs");
-    fs2.appendFileSync(outputFile, `${name}=${value}
+    const fs3 = require("node:fs");
+    fs3.appendFileSync(outputFile, `${name}=${value}
 `);
   }
 }
@@ -1033,8 +1331,8 @@ function appendToStepSummary(content) {
   const summaryFile = process.env["GITHUB_STEP_SUMMARY"];
   if (summaryFile) {
     try {
-      const fs2 = require("node:fs");
-      fs2.appendFileSync(summaryFile, content);
+      const fs3 = require("node:fs");
+      fs3.appendFileSync(summaryFile, content);
     } catch {
     }
   }
@@ -1097,6 +1395,80 @@ function emitFinancialGovernanceAdvisory(actionType, actor, orgId) {
     ""
   ].join("\n");
   appendToStepSummary(summaryBlock);
+}
+var VALID_SEVERITIES = [
+  "info",
+  "low",
+  "medium",
+  "high",
+  "blocker"
+];
+async function runGovernanceAgentsStep(apiKey, apiUrl) {
+  const slugsRaw = getInput("governance-agents", true);
+  const agentSlugs = slugsRaw.split(",").map((s) => s.trim()).filter((s) => s.length > 0);
+  if (agentSlugs.length === 0) {
+    setFailed("governance-agents input is empty after trimming");
+    return;
+  }
+  const changeId = getInput("governance-change-id", true);
+  const artifactFile = getInput("governance-artifact-file") || void 0;
+  const failOnBlocker = getInput("governance-fail-on-blocker").toLowerCase() === "true";
+  const failOnSeverityRaw = getInput("governance-fail-on-severity");
+  let failOnSeverity;
+  if (failOnSeverityRaw) {
+    if (!VALID_SEVERITIES.includes(failOnSeverityRaw)) {
+      setFailed(
+        `governance-fail-on-severity must be one of ${VALID_SEVERITIES.join("|")} (got "${failOnSeverityRaw}")`
+      );
+      return;
+    }
+    failOnSeverity = failOnSeverityRaw;
+  } else if (failOnBlocker) {
+    failOnSeverity = "blocker";
+  }
+  const gh = getGitHubContext();
+  info(
+    `AtlaSent Governance Agents: running [${agentSlugs.join(", ")}] against change ${changeId} (commit ${gh.sha.slice(0, 8)})`
+  );
+  let result;
+  try {
+    result = await runGovernanceAgents({
+      apiKey,
+      apiUrl,
+      changeId,
+      agentSlugs,
+      artifactFile,
+      failOnSeverity,
+      invokedBy: `github-action:${gh.repository}@${gh.sha.slice(0, 8)}`
+    });
+  } catch (err) {
+    setOutput("governance-findings-count", "0");
+    setOutput("governance-highest-severity", "");
+    setOutput("governance-evaluations", "[]");
+    setOutput("governance-findings", "[]");
+    setFailed(
+      `AtlaSent Governance Agents: ${err instanceof Error ? err.message : String(err)}`
+    );
+    return;
+  }
+  setOutput("governance-findings-count", String(result.findings.length));
+  setOutput("governance-highest-severity", result.highest_severity ?? "");
+  setOutput("governance-evaluations", JSON.stringify(result.evaluations));
+  setOutput("governance-findings", JSON.stringify(result.findings));
+  appendToStepSummary(renderStepSummary(result));
+  if (result.failed) {
+    setFailed(
+      `Governance findings at or above severity "${failOnSeverity}" \u2014 highest emitted: ${result.highest_severity}`
+    );
+    return;
+  }
+  if (result.highest_severity) {
+    warning(
+      `Governance Agents: highest severity ${result.highest_severity} (advisory; not gating)`
+    );
+  } else {
+    info("Governance Agents: no findings.");
+  }
 }
 async function runPolicySyncStep(apiKey, apiUrl) {
   const bundlePath = getInput("policy-bundle", true);
@@ -1282,6 +1654,10 @@ async function run() {
   maskValue(apiKey);
   if (getInput("policy-sync").toLowerCase() === "true") {
     await runPolicySyncStep(apiKey, apiUrl);
+    return;
+  }
+  if (getInput("governance-agents")) {
+    await runGovernanceAgentsStep(apiKey, apiUrl);
     return;
   }
   const evaluationsRaw = getInput("evaluations");

--- a/docs/governance-agents-example.yml
+++ b/docs/governance-agents-example.yml
@@ -1,0 +1,75 @@
+# AtlaSent Governance Agents — advisory PR-check workflow
+#
+# Invokes one or more constrained advisory governance agents against a
+# governed change and posts findings to the job summary. Findings are
+# signal, not authorization: required gates remain on the governance
+# authority surface in the runtime DB.
+#
+# This workflow is intentionally NON-BLOCKING. The `governance-fail-on-severity`
+# input is omitted so findings never fail the step. Convert to gating by
+# setting that input to `medium`, `high`, or `blocker` once you trust the
+# agents' signal in your environment.
+#
+# Prerequisites:
+#   - ATLASENT_API_KEY: API key with the governance:read + governance:write
+#                       scopes, stored as a repo secret.
+#   - A governed_change row in the runtime DB whose subject_kind matches
+#     each agent's applicable_subject_kinds. The change_id is supplied via
+#     the governance-change-id input.
+#
+# Auto-discovery (no governance-artifact-file needed) covers:
+#   - migration_review:        scans supabase/migrations*/**.sql
+#   - runtime_contract_drift:  scans openapi.yaml + supabase/functions/v1-* +
+#                              packages/types/src/index.ts type exports
+#
+# For the other three registered agents (authority_boundary,
+# operational_readiness, compliance_semantics), supply a JSON artifact map
+# via governance-artifact-file. See docs/governance-agents-artifact.json
+# (a stub example).
+
+name: AtlaSent Governance Agents
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  # The action reports findings to the job summary; it does NOT need
+  # statuses: write because findings are not gating checks.
+
+jobs:
+  governance-agents:
+    name: governance-agents (advisory)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Resolve governed change id
+        id: change
+        run: |
+          # In practice this is looked up from a PR comment, a label, or a
+          # call to /v1/governed-changes?subject_ref=github:owner-repo#PR.
+          # For example purposes, treat it as a repository variable.
+          echo "id=${{ vars.GOVERNED_CHANGE_ID }}" >> "$GITHUB_OUTPUT"
+
+      - name: Run advisory governance agents
+        uses: AtlaSent-Systems-Inc/atlasent-action@v2
+        with:
+          api-url: https://api.atlasent.io
+          governance-agents: migration_review,runtime_contract_drift
+          governance-change-id: ${{ steps.change.outputs.id }}
+          # Advisory by default — findings post to the step summary but
+          # never fail the check. Flip on when ready:
+          #   governance-fail-on-severity: high
+        env:
+          ATLASENT_API_KEY: ${{ secrets.ATLASENT_API_KEY }}
+
+      # Optional: surface the highest severity as a workflow-visible output
+      # so downstream jobs can branch on it without re-querying the API.
+      - name: Note highest severity
+        if: always()
+        run: |
+          echo "Highest severity: ${{ steps.governance-agents.outputs.governance-highest-severity || 'none' }}"
+          echo "Total findings:   ${{ steps.governance-agents.outputs.governance-findings-count || '0' }}"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,22 +1,22 @@
 {
   "name": "atlasent-action",
-  "version": "0.1.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "atlasent-action",
-      "version": "0.1.0",
-      "license": "MIT",
+      "version": "2.0.0",
+      "license": "Apache-2.0",
       "workspaces": [
         "packages/*"
       ],
       "dependencies": {
-        "@atlasent/enforce": "*"
+        "@atlasent/enforce": "^2.0.0"
       },
       "devDependencies": {
         "@types/node": "^20.0.0",
-        "esbuild": "^0.20.0",
+        "esbuild": "^0.20.2",
         "typescript": "^5.4.0",
         "vitest": "^1.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "2.0.0",
   "description": "GitHub Action for AtlaSent authorization gates — require a permit before critical CI/CD actions execute",
   "main": "dist/index.js",
-  "workspaces": ["packages/*"],
+  "workspaces": [
+    "packages/*"
+  ],
   "scripts": {
     "build": "esbuild src/index.ts --bundle --platform=node --target=node24 --outfile=dist/index.js",
     "typecheck": "tsc --noEmit",
@@ -14,7 +16,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.0.0",
-    "esbuild": "^0.20.0",
+    "esbuild": "^0.20.2",
     "typescript": "^5.4.0",
     "vitest": "^1.0.0"
   },

--- a/src/__tests__/governanceAgents.test.ts
+++ b/src/__tests__/governanceAgents.test.ts
@@ -1,0 +1,395 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  hashArtifact,
+  highestSeverity,
+  renderStepSummary,
+  runGovernanceAgents,
+  type AgentFinding,
+  type RunGovernanceAgentsOptions,
+} from "../governanceAgents";
+
+// ─── fs fake ────────────────────────────────────────────────────────────────
+
+type FakeFs = NonNullable<RunGovernanceAgentsOptions["fileSystem"]>;
+
+function makeFs(files: Record<string, string>): FakeFs {
+  // Directories are derived from file paths.
+  const dirs = new Set<string>();
+  for (const p of Object.keys(files)) {
+    let parent = p;
+    while (true) {
+      const idx = parent.lastIndexOf("/");
+      if (idx <= 0) break;
+      parent = parent.slice(0, idx);
+      dirs.add(parent);
+    }
+  }
+  return {
+    existsSync: (p) => Object.prototype.hasOwnProperty.call(files, p) || dirs.has(p),
+    readFileSync: (p) => {
+      if (!Object.prototype.hasOwnProperty.call(files, p)) {
+        throw new Error(`ENOENT: ${p}`);
+      }
+      return files[p];
+    },
+    readdirSync: (p) => {
+      const out: string[] = [];
+      const prefix = p.endsWith("/") ? p : p + "/";
+      for (const fp of Object.keys(files)) {
+        if (fp.startsWith(prefix)) {
+          const tail = fp.slice(prefix.length);
+          if (!tail.includes("/")) out.push(tail);
+        }
+      }
+      // Subdirectories.
+      for (const d of dirs) {
+        if (d.startsWith(prefix)) {
+          const tail = d.slice(prefix.length);
+          if (!tail.includes("/")) out.push(tail);
+        }
+      }
+      return [...new Set(out)];
+    },
+    statSync: (p) => ({
+      isDirectory: () => dirs.has(p),
+      isFile: () => Object.prototype.hasOwnProperty.call(files, p),
+    }),
+  };
+}
+
+// ─── fetch fake ─────────────────────────────────────────────────────────────
+
+function fetchReturning(responses: Record<string, unknown>) {
+  const calls: Array<{ url: string; body: any }> = [];
+  const fetchImpl = vi.fn().mockImplementation(async (url: string, init: RequestInit) => {
+    const body = JSON.parse((init.body as string) ?? "{}");
+    calls.push({ url, body });
+    // Match by slug in URL.
+    const m = url.match(/agents\/([^/]+)\/evaluate$/);
+    const slug = m ? decodeURIComponent(m[1]) : "";
+    const payload = responses[slug] ?? {
+      evaluation: {
+        id: `eval-${slug}`,
+        agent_slug: slug,
+        agent_version: "v1",
+        status: "completed",
+        highest_severity: null,
+        findings_count: 0,
+        summary: "no findings",
+      },
+      findings: [],
+    };
+    return {
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: async () => payload,
+      text: async () => "",
+    } as unknown as Response;
+  });
+  return { fetchImpl: fetchImpl as unknown as typeof fetch, calls };
+}
+
+function f(severity: AgentFinding["severity"], slug = "migration_review"): AgentFinding {
+  return {
+    id: `f-${severity}`,
+    agent_slug: slug,
+    finding_type: "x",
+    severity,
+    summary: `${severity} thing`,
+    required_authority: "engineering",
+    recommended_action: "fix it",
+    evidence_refs: [],
+    can_authorize: false,
+  };
+}
+
+// ─── tests ──────────────────────────────────────────────────────────────────
+
+describe("hashArtifact", () => {
+  it("is deterministic across key ordering", () => {
+    const a = hashArtifact({ b: 1, a: 2 });
+    const b = hashArtifact({ a: 2, b: 1 });
+    expect(a).toBe(b);
+    expect(a).toMatch(/^sha256:[a-f0-9]{64}$/);
+  });
+
+  it("differs when payload differs", () => {
+    expect(hashArtifact({ a: 1 })).not.toBe(hashArtifact({ a: 2 }));
+  });
+});
+
+describe("highestSeverity", () => {
+  it("returns null on empty", () => {
+    expect(highestSeverity([])).toBeNull();
+  });
+  it("picks blocker over high over info", () => {
+    expect(highestSeverity([f("info"), f("blocker"), f("high")])).toBe("blocker");
+  });
+});
+
+describe("runGovernanceAgents", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("rejects when changeId is missing", async () => {
+    const { fetchImpl } = fetchReturning({});
+    await expect(
+      runGovernanceAgents({
+        apiKey: "k",
+        apiUrl: "http://api",
+        changeId: "",
+        agentSlugs: ["migration_review"],
+        fetchImpl,
+      }),
+    ).rejects.toThrow(/changeId is required/);
+  });
+
+  it("rejects when agentSlugs is empty", async () => {
+    const { fetchImpl } = fetchReturning({});
+    await expect(
+      runGovernanceAgents({
+        apiKey: "k",
+        apiUrl: "http://api",
+        changeId: "c1",
+        agentSlugs: [],
+        fetchImpl,
+      }),
+    ).rejects.toThrow(/agentSlugs/);
+  });
+
+  it("auto-discovers migration files when slug is migration_review", async () => {
+    const fs_ = makeFs({
+      "/ws/supabase/migrations-runtime/001.sql": "CREATE TABLE x (id uuid);",
+      "/ws/supabase/migrations-runtime/002.sql": "ALTER TABLE x ADD COLUMN y text;",
+    });
+    const { fetchImpl, calls } = fetchReturning({});
+    await runGovernanceAgents({
+      apiKey: "k",
+      apiUrl: "http://api",
+      changeId: "c1",
+      agentSlugs: ["migration_review"],
+      workspace: "/ws",
+      fileSystem: fs_,
+      fetchImpl,
+    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toContain("/v1/governance/agents/migration_review/evaluate");
+    expect(calls[0].body.change_id).toBe("c1");
+    expect(calls[0].body.invoked_by_kind).toBe("service_account");
+    expect(calls[0].body.artifact.migrations).toHaveLength(2);
+    expect(calls[0].body.input_hash).toMatch(/^sha256:[a-f0-9]{64}$/);
+  });
+
+  it("throws helpful error for non-auto-discoverable slug without artifact file", async () => {
+    const fs_ = makeFs({});
+    const { fetchImpl } = fetchReturning({});
+    await expect(
+      runGovernanceAgents({
+        apiKey: "k",
+        apiUrl: "http://api",
+        changeId: "c1",
+        agentSlugs: ["authority_boundary"],
+        workspace: "/ws",
+        fileSystem: fs_,
+        fetchImpl,
+      }),
+    ).rejects.toThrow(/No artifact for agent "authority_boundary"/);
+  });
+
+  it("loads artifact from file when supplied", async () => {
+    const fs_ = makeFs({
+      "/ws/agents.json": JSON.stringify({
+        authority_boundary: {
+          change_id: "c1",
+          transitions: [],
+          gates: [],
+          holds: [],
+          grants: [],
+        },
+      }),
+    });
+    const { fetchImpl, calls } = fetchReturning({});
+    await runGovernanceAgents({
+      apiKey: "k",
+      apiUrl: "http://api",
+      changeId: "c1",
+      agentSlugs: ["authority_boundary"],
+      artifactFile: "agents.json",
+      workspace: "/ws",
+      fileSystem: fs_,
+      fetchImpl,
+    });
+    expect(calls[0].body.artifact.transitions).toEqual([]);
+  });
+
+  it("flags 501 as a deployed-implementation gap", async () => {
+    const fs_ = makeFs({
+      "/ws/supabase/migrations-runtime/001.sql": "select 1;",
+    });
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 501,
+      statusText: "Not Implemented",
+      json: async () => ({}),
+      text: async () => "no impl",
+    } as unknown as Response);
+
+    await expect(
+      runGovernanceAgents({
+        apiKey: "k",
+        apiUrl: "http://api",
+        changeId: "c1",
+        agentSlugs: ["migration_review"],
+        workspace: "/ws",
+        fileSystem: fs_,
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      }),
+    ).rejects.toThrow(/no in-process implementation/);
+  });
+
+  it("computes highest severity across multiple agents", async () => {
+    const fs_ = makeFs({
+      "/ws/supabase/migrations-runtime/001.sql": "select 1;",
+      "/ws/agents.json": JSON.stringify({ authority_boundary: { gates: [] } }),
+    });
+    const { fetchImpl } = fetchReturning({
+      migration_review: {
+        evaluation: {
+          id: "e1",
+          agent_slug: "migration_review",
+          agent_version: "v1",
+          status: "completed",
+          highest_severity: "medium",
+          findings_count: 1,
+          summary: "one medium",
+        },
+        findings: [f("medium", "migration_review")],
+      },
+      authority_boundary: {
+        evaluation: {
+          id: "e2",
+          agent_slug: "authority_boundary",
+          agent_version: "v1",
+          status: "completed",
+          highest_severity: "blocker",
+          findings_count: 1,
+          summary: "one blocker",
+        },
+        findings: [f("blocker", "authority_boundary")],
+      },
+    });
+
+    const result = await runGovernanceAgents({
+      apiKey: "k",
+      apiUrl: "http://api",
+      changeId: "c1",
+      agentSlugs: ["migration_review", "authority_boundary"],
+      artifactFile: "agents.json",
+      workspace: "/ws",
+      fileSystem: fs_,
+      fetchImpl,
+    });
+    expect(result.highest_severity).toBe("blocker");
+    expect(result.findings).toHaveLength(2);
+    expect(result.evaluations).toHaveLength(2);
+  });
+
+  it("returns failed=true only when failOnSeverity threshold is met", async () => {
+    const fs_ = makeFs({
+      "/ws/supabase/migrations-runtime/001.sql": "select 1;",
+    });
+    const { fetchImpl } = fetchReturning({
+      migration_review: {
+        evaluation: {
+          id: "e1",
+          agent_slug: "migration_review",
+          agent_version: "v1",
+          status: "completed",
+          highest_severity: "medium",
+          findings_count: 1,
+          summary: "",
+        },
+        findings: [f("medium", "migration_review")],
+      },
+    });
+
+    // Threshold high: medium does not trip.
+    const r1 = await runGovernanceAgents({
+      apiKey: "k",
+      apiUrl: "http://api",
+      changeId: "c1",
+      agentSlugs: ["migration_review"],
+      workspace: "/ws",
+      fileSystem: fs_,
+      fetchImpl,
+      failOnSeverity: "high",
+    });
+    expect(r1.failed).toBe(false);
+
+    // Threshold medium: medium trips.
+    const r2 = await runGovernanceAgents({
+      apiKey: "k",
+      apiUrl: "http://api",
+      changeId: "c1",
+      agentSlugs: ["migration_review"],
+      workspace: "/ws",
+      fileSystem: fs_,
+      fetchImpl,
+      failOnSeverity: "medium",
+    });
+    expect(r2.failed).toBe(true);
+
+    // No threshold: never fails.
+    const r3 = await runGovernanceAgents({
+      apiKey: "k",
+      apiUrl: "http://api",
+      changeId: "c1",
+      agentSlugs: ["migration_review"],
+      workspace: "/ws",
+      fileSystem: fs_,
+      fetchImpl,
+    });
+    expect(r3.failed).toBe(false);
+  });
+});
+
+describe("renderStepSummary", () => {
+  it("renders a per-agent table when findings exist", () => {
+    const md = renderStepSummary({
+      evaluations: [
+        {
+          id: "e1",
+          agent_slug: "migration_review",
+          agent_version: "v1",
+          status: "completed",
+          highest_severity: "high",
+          findings_count: 1,
+          summary: "one finding",
+        },
+      ],
+      findings: [f("high", "migration_review")],
+      highest_severity: "high",
+      failed: false,
+    });
+    expect(md).toContain("Constrained Governance Agents");
+    expect(md).toContain("migration_review");
+    expect(md).toContain("| high |");
+    expect(md).toContain("**Overall highest severity:** `high`");
+  });
+
+  it("notes 'No findings' when empty", () => {
+    const md = renderStepSummary({
+      evaluations: [],
+      findings: [],
+      highest_severity: null,
+      failed: false,
+    });
+    expect(md).toContain("**No findings.**");
+  });
+});

--- a/src/governanceAgents.ts
+++ b/src/governanceAgents.ts
@@ -1,0 +1,457 @@
+// AtlaSent Governance Agents — PR-check mode.
+//
+// Invokes one or more constrained advisory governance agents against a
+// governed change and posts findings as a non-required GitHub Actions
+// step result. Findings are signal, not authorization — this mode does
+// NOT gate by default.
+//
+// Routing:
+//   migration_review        — scans SQL migrations in standard locations
+//   runtime_contract_drift  — diffs openapi.yaml vs route inventory vs SDK types
+//   <any other registered>  — supply a pre-built artifact via governance-artifact-file
+//
+// The action POSTs to `${api-url}/v1/governance/agents/<slug>/evaluate`
+// with `{ change_id, input_hash, artifact, invoked_by_kind: 'service_account' }`.
+// The endpoint persists the evaluation + findings and returns them.
+//
+// Optional gating:
+//   governance-fail-on-severity — fail the step at this severity or higher
+//   governance-fail-on-blocker  — shortcut for severity=blocker
+//
+// Authority boundary unchanged: nothing in this file can satisfy a gate
+// or clear a hold. The API endpoint structurally cannot either
+// (governance_agent_findings.can_authorize CHECK = false).
+
+import { createHash } from "node:crypto";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+export type AgentSeverity = "info" | "low" | "medium" | "high" | "blocker";
+
+const SEVERITY_RANK: Record<AgentSeverity, number> = {
+  info: 1,
+  low: 2,
+  medium: 3,
+  high: 4,
+  blocker: 5,
+};
+
+export interface AgentFinding {
+  id: string;
+  agent_slug: string;
+  finding_type: string;
+  severity: AgentSeverity;
+  summary: string;
+  required_authority: string | null;
+  recommended_action: string | null;
+  evidence_refs: unknown;
+  can_authorize: false;
+}
+
+export interface AgentEvaluation {
+  id: string;
+  agent_slug: string;
+  agent_version: string;
+  status: "completed" | "failed" | "timeout";
+  highest_severity: AgentSeverity | null;
+  findings_count: number;
+  summary: string | null;
+}
+
+export interface InvokeAgentResponse {
+  evaluation: AgentEvaluation;
+  findings: AgentFinding[];
+}
+
+export interface RunGovernanceAgentsOptions {
+  apiKey: string;
+  apiUrl: string;
+  changeId: string;
+  agentSlugs: readonly string[];
+  /** Optional pre-built artifact path for agents that aren't auto-discovered. */
+  artifactFile?: string;
+  /** Workspace root for path resolution; defaults to GITHUB_WORKSPACE or cwd. */
+  workspace?: string;
+  /** Threshold above which the step fails. Omit to never fail on findings. */
+  failOnSeverity?: AgentSeverity;
+  /** Invocation provenance recorded on the evaluation. */
+  invokedBy?: string;
+  /** Override fetch (test seam). */
+  fetchImpl?: typeof fetch;
+  /** Override fs/path operations (test seam). */
+  fileSystem?: {
+    readFileSync: (p: string, enc: "utf-8") => string;
+    existsSync: (p: string) => boolean;
+    readdirSync: (p: string) => string[];
+    statSync: (p: string) => { isDirectory(): boolean; isFile(): boolean };
+  };
+}
+
+export interface RunGovernanceAgentsResult {
+  evaluations: AgentEvaluation[];
+  findings: AgentFinding[];
+  highest_severity: AgentSeverity | null;
+  failed: boolean;
+}
+
+// ─── public entry ───────────────────────────────────────────────────────────
+
+export async function runGovernanceAgents(
+  opts: RunGovernanceAgentsOptions,
+): Promise<RunGovernanceAgentsResult> {
+  if (!opts.apiKey) throw new Error("apiKey is required");
+  if (!opts.apiUrl) throw new Error("apiUrl is required");
+  if (!opts.changeId) {
+    throw new Error("changeId is required — set governance-change-id input");
+  }
+  if (opts.agentSlugs.length === 0) {
+    throw new Error("agentSlugs must be non-empty");
+  }
+
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  const fs_ = opts.fileSystem ?? defaultFs();
+  const workspace = opts.workspace ?? process.env["GITHUB_WORKSPACE"] ?? process.cwd();
+
+  // Optionally read an externally-supplied artifact map for agents that
+  // can't be auto-discovered (e.g. runtime_contract_drift wants OpenAPI +
+  // route inventory + SDK type names).
+  const artifactMap = opts.artifactFile
+    ? readArtifactFile(opts.artifactFile, workspace, fs_)
+    : {};
+
+  const evaluations: AgentEvaluation[] = [];
+  const findings: AgentFinding[] = [];
+
+  for (const slug of opts.agentSlugs) {
+    const artifact = artifactMap[slug] ?? autoDiscoverArtifact(slug, workspace, fs_);
+    if (!artifact) {
+      throw new Error(
+        `No artifact for agent "${slug}". Either supply one via governance-artifact-file ` +
+          `(a JSON object keyed by agent slug) or use a slug that supports auto-discovery ` +
+          `(migration_review, runtime_contract_drift).`,
+      );
+    }
+
+    const result = await invokeAgent(
+      {
+        apiKey: opts.apiKey,
+        apiUrl: opts.apiUrl,
+        changeId: opts.changeId,
+        slug,
+        artifact,
+        invokedBy: opts.invokedBy ?? "github-action",
+        fetchImpl,
+      },
+    );
+
+    evaluations.push(result.evaluation);
+    findings.push(...result.findings);
+  }
+
+  const highest = highestSeverity(findings);
+  const failed =
+    !!opts.failOnSeverity &&
+    !!highest &&
+    SEVERITY_RANK[highest] >= SEVERITY_RANK[opts.failOnSeverity];
+
+  return { evaluations, findings, highest_severity: highest, failed };
+}
+
+// ─── invocation ─────────────────────────────────────────────────────────────
+
+interface InvokeArgs {
+  apiKey: string;
+  apiUrl: string;
+  changeId: string;
+  slug: string;
+  artifact: unknown;
+  invokedBy: string;
+  fetchImpl: typeof fetch;
+}
+
+async function invokeAgent(args: InvokeArgs): Promise<InvokeAgentResponse> {
+  const url = `${args.apiUrl.replace(/\/$/, "")}/v1/governance/agents/${encodeURIComponent(args.slug)}/evaluate`;
+  const body = JSON.stringify({
+    change_id: args.changeId,
+    input_hash: hashArtifact(args.artifact),
+    artifact: args.artifact,
+    invoked_by_kind: "service_account",
+    invoked_by: args.invokedBy,
+  });
+
+  let resp: Response;
+  try {
+    resp = await args.fetchImpl(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${args.apiKey}`,
+      },
+      body,
+    });
+  } catch (err) {
+    throw new Error(
+      `governance agent ${args.slug}: network error: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  if (!resp.ok) {
+    const text = await resp.text().catch(() => "");
+    if (resp.status === 501) {
+      throw new Error(
+        `governance agent ${args.slug}: registered in the DB but no in-process implementation is deployed (501). ` +
+          `Skip this slug or upgrade the API.`,
+      );
+    }
+    throw new Error(
+      `governance agent ${args.slug}: HTTP ${resp.status} ${resp.statusText} — ${text.slice(0, 500)}`,
+    );
+  }
+
+  const parsed = (await resp.json()) as InvokeAgentResponse;
+  if (!parsed.evaluation || !Array.isArray(parsed.findings)) {
+    throw new Error(`governance agent ${args.slug}: malformed response`);
+  }
+  return parsed;
+}
+
+// ─── artifact discovery ─────────────────────────────────────────────────────
+
+const MIGRATION_DIRS = [
+  "supabase/migrations",
+  "supabase/migrations-runtime",
+  "supabase/migrations-console",
+  "supabase/migrations-shared",
+];
+
+type Fs = NonNullable<RunGovernanceAgentsOptions["fileSystem"]>;
+
+function defaultFs(): Fs {
+  return {
+    readFileSync: (p, enc) => fs.readFileSync(p, enc),
+    existsSync: (p) => fs.existsSync(p),
+    readdirSync: (p) => fs.readdirSync(p),
+    statSync: (p) => fs.statSync(p),
+  };
+}
+
+function autoDiscoverArtifact(slug: string, workspace: string, fs_: Fs): unknown | null {
+  if (slug === "migration_review") return discoverMigrationArtifact(workspace, fs_);
+  if (slug === "runtime_contract_drift") return discoverRuntimeContractArtifact(workspace, fs_);
+  return null;
+}
+
+function discoverMigrationArtifact(workspace: string, fs_: Fs): unknown {
+  const files: { path: string; content: string }[] = [];
+  for (const dir of MIGRATION_DIRS) {
+    const abs = path.resolve(workspace, dir);
+    if (!fs_.existsSync(abs)) continue;
+    if (!fs_.statSync(abs).isDirectory()) continue;
+    for (const entry of fs_.readdirSync(abs)) {
+      if (!entry.endsWith(".sql")) continue;
+      const full = path.join(abs, entry);
+      if (!fs_.statSync(full).isFile()) continue;
+      files.push({
+        path: path.relative(workspace, full),
+        content: fs_.readFileSync(full, "utf-8"),
+      });
+    }
+  }
+  return { migrations: files };
+}
+
+function discoverRuntimeContractArtifact(workspace: string, fs_: Fs): unknown | null {
+  const openapiPath = ["openapi.yaml", "openapi-v1.yaml", "openapi.yml"]
+    .map((p) => path.resolve(workspace, p))
+    .find((p) => fs_.existsSync(p));
+  if (!openapiPath) return null;
+
+  const openapi = parseOpenApiPaths(fs_.readFileSync(openapiPath, "utf-8"));
+  const routesDir = path.resolve(workspace, "supabase/functions");
+  const routes = fs_.existsSync(routesDir) ? discoverRuntimeRoutes(routesDir, fs_) : [];
+
+  // SDK types: look for an exported type-name list. Best-effort.
+  const typeNames: string[] = [];
+  const typesIndex = path.resolve(workspace, "packages/types/src/index.ts");
+  if (fs_.existsSync(typesIndex)) {
+    const content = fs_.readFileSync(typesIndex, "utf-8");
+    for (const m of content.matchAll(/export\s+(?:type|interface)\s+([A-Z][A-Za-z0-9_]*)/g)) {
+      typeNames.push(m[1]);
+    }
+  }
+
+  return {
+    openapi: { paths: openapi },
+    runtime: { routes },
+    sdk: { type_names: typeNames },
+  };
+}
+
+function parseOpenApiPaths(yaml: string): Array<{ path: string; methods: string[] }> {
+  // Tiny YAML-subset parser tailored to OpenAPI `paths:` block.
+  // Sufficient for {path: {method: ...}} shapes; not a general parser.
+  const out: Array<{ path: string; methods: string[] }> = [];
+  const lines = yaml.split("\n");
+  let inPaths = false;
+  let currentPath: { path: string; methods: string[] } | null = null;
+
+  for (const raw of lines) {
+    const line = raw.replace(/\s+$/, "");
+    if (!inPaths) {
+      if (/^paths:\s*$/.test(line)) inPaths = true;
+      continue;
+    }
+    // Exit paths block when we hit a sibling top-level key.
+    if (/^[A-Za-z]/.test(line)) {
+      inPaths = false;
+      if (currentPath) {
+        out.push(currentPath);
+        currentPath = null;
+      }
+      continue;
+    }
+    const pathMatch = /^  (\/[\w/{}.-]+):/.exec(line);
+    if (pathMatch) {
+      if (currentPath) out.push(currentPath);
+      currentPath = { path: pathMatch[1], methods: [] };
+      continue;
+    }
+    const methodMatch = /^    (get|post|put|patch|delete):/i.exec(line);
+    if (methodMatch && currentPath) {
+      currentPath.methods.push(methodMatch[1].toLowerCase());
+    }
+  }
+  if (currentPath) out.push(currentPath);
+  return out;
+}
+
+function discoverRuntimeRoutes(
+  routesDir: string,
+  fs_: Fs,
+): Array<{ path: string; methods: string[]; function_name: string }> {
+  const routes: Array<{ path: string; methods: string[]; function_name: string }> = [];
+  for (const entry of fs_.readdirSync(routesDir)) {
+    if (!entry.startsWith("v1-")) continue;
+    const dir = path.join(routesDir, entry);
+    if (!fs_.statSync(dir).isDirectory()) continue;
+    // Inferred path from function name. Heuristic — same logic the
+    // openapi-coverage script uses.
+    const inferredPath = "/" + entry.replace(/-/g, "/").replace(/^\//, "");
+    routes.push({
+      path: inferredPath,
+      // Methods unknown without parsing the handler; leave empty so the
+      // drift agent treats per-method as "not asserted by runtime" and
+      // only flags path-level drift.
+      methods: [],
+      function_name: entry,
+    });
+  }
+  return routes;
+}
+
+// ─── artifact file loader ───────────────────────────────────────────────────
+
+function readArtifactFile(
+  artifactPath: string,
+  workspace: string,
+  fs_: Fs,
+): Record<string, unknown> {
+  const abs = path.isAbsolute(artifactPath)
+    ? artifactPath
+    : path.resolve(workspace, artifactPath);
+  if (!fs_.existsSync(abs)) {
+    throw new Error(`governance-artifact-file not found: ${artifactPath}`);
+  }
+  const raw = fs_.readFileSync(abs, "utf-8");
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(
+      `governance-artifact-file is not valid JSON: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new Error(
+      "governance-artifact-file must be a JSON object keyed by agent slug",
+    );
+  }
+  return parsed as Record<string, unknown>;
+}
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+export function hashArtifact(artifact: unknown): string {
+  const canonical = canonicalJson(artifact);
+  return "sha256:" + createHash("sha256").update(canonical).digest("hex");
+}
+
+function canonicalJson(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return "[" + value.map(canonicalJson).join(",") + "]";
+  const keys = Object.keys(value as Record<string, unknown>).sort();
+  return (
+    "{" +
+    keys
+      .map((k) => JSON.stringify(k) + ":" + canonicalJson((value as Record<string, unknown>)[k]))
+      .join(",") +
+    "}"
+  );
+}
+
+export function highestSeverity(findings: readonly AgentFinding[]): AgentSeverity | null {
+  let best: AgentSeverity | null = null;
+  let rank = 0;
+  for (const f of findings) {
+    if (SEVERITY_RANK[f.severity] > rank) {
+      rank = SEVERITY_RANK[f.severity];
+      best = f.severity;
+    }
+  }
+  return best;
+}
+
+// ─── step summary rendering ─────────────────────────────────────────────────
+
+export function renderStepSummary(result: RunGovernanceAgentsResult): string {
+  const lines: string[] = [];
+  lines.push("## Constrained Governance Agents — findings");
+  lines.push("");
+  lines.push(
+    "> Findings are advisory. They produce signal, not authorization. " +
+      "Required gates remain on the governance authority surface.",
+  );
+  lines.push("");
+
+  for (const e of result.evaluations) {
+    lines.push(`### ${e.agent_slug} \`${e.agent_version}\``);
+    lines.push("");
+    lines.push(
+      `Status: **${e.status}** — findings: **${e.findings_count}** — highest: **${e.highest_severity ?? "—"}**`,
+    );
+    if (e.summary) lines.push(`> ${e.summary}`);
+    lines.push("");
+
+    const own = result.findings.filter((f) => f.agent_slug === e.agent_slug);
+    if (own.length === 0) {
+      lines.push("_No findings._");
+      lines.push("");
+      continue;
+    }
+    lines.push("| Severity | Type | Authority | Summary |");
+    lines.push("|---|---|---|---|");
+    for (const f of own) {
+      const auth = f.required_authority ?? "—";
+      const summary = f.summary.replace(/\|/g, "\\|").replace(/\n+/g, " ");
+      lines.push(`| ${f.severity} | \`${f.finding_type}\` | ${auth} | ${summary} |`);
+    }
+    lines.push("");
+  }
+
+  if (result.highest_severity) {
+    lines.push(`**Overall highest severity:** \`${result.highest_severity}\``);
+  } else {
+    lines.push("**No findings.**");
+  }
+  return lines.join("\n") + "\n";
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,11 @@ import { GateInfraError } from "./gate";
 import { runV21 } from "./v21";
 import { runPolicySync } from "./policySync";
 import {
+  type AgentSeverity,
+  renderStepSummary,
+  runGovernanceAgents,
+} from "./governanceAgents";
+import {
   assessFinancialGovernance,
 } from "./financialGovernanceAdvisory";
 import type { FinancialAdvisoryInput } from "./financialGovernanceAdvisory";
@@ -253,6 +258,111 @@ function emitFinancialGovernanceAdvisory(
 // Policy Sync step handler
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// Governance Agents step — advisory PR-check mode
+// ---------------------------------------------------------------------------
+//
+// Findings are signal, not authorization. The step:
+//   1. Parses the comma-separated `governance-agents` slug list.
+//   2. Invokes each agent via /v1/governance/agents/<slug>/evaluate.
+//   3. Renders a job-summary table per agent with severity / type /
+//      authority / one-line summary.
+//   4. Optionally fails the step when `governance-fail-on-severity` is set
+//      and a finding meets or exceeds that severity. Default: never fails.
+//
+// Outputs:
+//   governance-findings-count   total findings across agents
+//   governance-highest-severity worst severity emitted (or empty)
+//   governance-evaluations      JSON-encoded evaluation summaries
+//   governance-findings         JSON-encoded findings array
+
+const VALID_SEVERITIES: readonly AgentSeverity[] = [
+  "info",
+  "low",
+  "medium",
+  "high",
+  "blocker",
+];
+
+async function runGovernanceAgentsStep(apiKey: string, apiUrl: string): Promise<void> {
+  const slugsRaw = getInput("governance-agents", true);
+  const agentSlugs = slugsRaw
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+  if (agentSlugs.length === 0) {
+    setFailed("governance-agents input is empty after trimming");
+    return;
+  }
+
+  const changeId = getInput("governance-change-id", true);
+  const artifactFile = getInput("governance-artifact-file") || undefined;
+  const failOnBlocker = getInput("governance-fail-on-blocker").toLowerCase() === "true";
+  const failOnSeverityRaw = getInput("governance-fail-on-severity");
+  let failOnSeverity: AgentSeverity | undefined;
+  if (failOnSeverityRaw) {
+    if (!VALID_SEVERITIES.includes(failOnSeverityRaw as AgentSeverity)) {
+      setFailed(
+        `governance-fail-on-severity must be one of ${VALID_SEVERITIES.join("|")} (got "${failOnSeverityRaw}")`,
+      );
+      return;
+    }
+    failOnSeverity = failOnSeverityRaw as AgentSeverity;
+  } else if (failOnBlocker) {
+    failOnSeverity = "blocker";
+  }
+
+  const gh = getGitHubContext();
+  info(
+    `AtlaSent Governance Agents: running [${agentSlugs.join(", ")}] against change ${changeId} ` +
+      `(commit ${gh.sha.slice(0, 8)})`,
+  );
+
+  let result;
+  try {
+    result = await runGovernanceAgents({
+      apiKey,
+      apiUrl,
+      changeId,
+      agentSlugs,
+      artifactFile,
+      failOnSeverity,
+      invokedBy: `github-action:${gh.repository}@${gh.sha.slice(0, 8)}`,
+    });
+  } catch (err) {
+    setOutput("governance-findings-count", "0");
+    setOutput("governance-highest-severity", "");
+    setOutput("governance-evaluations", "[]");
+    setOutput("governance-findings", "[]");
+    setFailed(
+      `AtlaSent Governance Agents: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return;
+  }
+
+  setOutput("governance-findings-count", String(result.findings.length));
+  setOutput("governance-highest-severity", result.highest_severity ?? "");
+  setOutput("governance-evaluations", JSON.stringify(result.evaluations));
+  setOutput("governance-findings", JSON.stringify(result.findings));
+
+  appendToStepSummary(renderStepSummary(result));
+
+  if (result.failed) {
+    setFailed(
+      `Governance findings at or above severity "${failOnSeverity}" — highest emitted: ${result.highest_severity}`,
+    );
+    return;
+  }
+
+  if (result.highest_severity) {
+    warning(
+      `Governance Agents: highest severity ${result.highest_severity} (advisory; not gating)`,
+    );
+  } else {
+    info("Governance Agents: no findings.");
+  }
+}
+
 async function runPolicySyncStep(apiKey: string, apiUrl: string): Promise<void> {
   const bundlePath = getInput("policy-bundle", true);
   const source = getInput("policy-source") || "github-action";
@@ -478,6 +588,16 @@ export async function run(): Promise<void> {
   // ── Policy sync path ────────────────────────────────────────────────────────
   if (getInput("policy-sync").toLowerCase() === "true") {
     await runPolicySyncStep(apiKey, apiUrl);
+    return;
+  }
+
+  // ── Governance agents path ──────────────────────────────────────────────────
+  //
+  // Advisory mode: invoke one or more constrained governance agents and post
+  // findings as a non-required step result. Does NOT gate by default; the
+  // `governance-fail-on-severity` input is opt-in.
+  if (getInput("governance-agents")) {
+    await runGovernanceAgentsStep(apiKey, apiUrl);
     return;
   }
 


### PR DESCRIPTION
## Summary

Phase 3 of the constrained governance agents roadmap. Adds an advisory `governance-agents` mode to the AtlaSent GitHub Action that invokes one or more registered agents against a governed change and posts findings to the job summary.

**Findings are signal, not authorization.** This mode is non-blocking by default; the `governance-fail-on-severity` input is opt-in. The doctrine — `evaluation ≠ authorization ≠ execution` — is preserved: nothing in this code path can satisfy a gate or clear a hold.

## What this enables

A workflow author drops a step like:

```yaml
- uses: AtlaSent-Systems-Inc/atlasent-action@v2
  with:
    governance-agents: migration_review,runtime_contract_drift
    governance-change-id: ${{ vars.GOVERNED_CHANGE_ID }}
  env:
    ATLASENT_API_KEY: ${{ secrets.ATLASENT_API_KEY }}
```

…and gets a per-agent severity-tagged findings table in the PR's job summary, plus typed step outputs for downstream jobs. Reviewers see findings without leaving the PR.

## What's in

| Input | Purpose |
|---|---|
| `governance-agents` | comma-separated agent slug list |
| `governance-change-id` | governed_change UUID to attach findings to |
| `governance-artifact-file` | optional JSON map `slug → artifact` |
| `governance-fail-on-severity` | opt-in gating (`info`..`blocker`) |
| `governance-fail-on-blocker` | shortcut for `severity=blocker` |

| Output | Purpose |
|---|---|
| `governance-findings-count` | total across all agents |
| `governance-highest-severity` | worst severity (or empty) |
| `governance-evaluations` | JSON evaluation summaries |
| `governance-findings` | JSON full findings array |

Auto-discovery (no artifact file required) covers:
- **`migration_review`** — scans `supabase/migrations*/**.sql`
- **`runtime_contract_drift`** — `openapi.yaml` paths + `supabase/functions/v1-*` inventory + `packages/types/src/index.ts` type exports

The other three agents (`authority_boundary`, `operational_readiness`, `compliance_semantics`) take governance-state inputs that the action cannot derive from a checkout alone — those require an artifact file. A clear error message points the user to either approach.

## What's explicitly out

- No `statuses:write` permission requested. Findings post to the job summary, not as a required check, by design. To convert to gating: set `governance-fail-on-severity` explicitly.
- No PR comment writing. The job summary is the surface; comments are noisy.
- No artifact file generation for the three governance-state agents. That belongs in a separate companion action or runbook step that queries `/v1/governance/evaluations`, `/v1/governance/holds`, etc., assembles the artifact, and writes it out as a workflow file.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npx esbuild ... dist/index.js` — built (65kB)
- [x] `npm test` — **201/201 passing** (14 new tests in `governanceAgents.test.ts`)
  - hashArtifact determinism + payload sensitivity
  - highestSeverity rollup ordering
  - missing change_id / empty slugs structural rejection
  - auto-discovery of migration files
  - 501 mapping (agent registered in DB but no in-process impl deployed)
  - non-auto-discoverable slug without artifact file → helpful error
  - artifact file loading
  - multi-agent severity rollup
  - failOnSeverity threshold semantics across info|medium|high
  - step summary rendering both populated and empty
- [ ] Live smoke against staging once a `governed_change` exists with a PR-shaped subject

## Sequencing

This PR is independent of the active "Governance Kits" work in atlasent-docs#131 / atlasent-console#514 — those package the existing deploy-gate primitives as install narratives; this wires the new constrained advisory agents into PR feedback. No file overlap.

Next phases (separate PRs):
- **Phase 4** — `atlasent-console` Findings panel + Authorization panel
- **Phase 5** — `atlasent-sdk` typed client + `atlasent-docs/architecture/governance-agents.md`

https://claude.ai/code/session_01DvYc9jPfk7W7EC2mZhyNN5

---
_Generated by [Claude Code](https://claude.ai/code/session_01DvYc9jPfk7W7EC2mZhyNN5)_