### PR TITLE
docs(readme): identify Action as the CI/CD wedge of the AtlaSent runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # AtlaSent Gate Action
 
+GitHub Action for the **CI/CD deployment authorization** domain of [AtlaSent](https://www.atlasent.io/) — execution-time authorization infrastructure for governed computational action.
+
 Require execution-time authorization before critical CI/CD actions run. Drop AtlaSent into any GitHub Actions workflow with a single step.
 
 ```


### PR DESCRIPTION
## Summary

Adds a one-line frame at the top of the README clarifying that this GitHub Action is the **CI/CD deployment authorization** wedge of the broader AtlaSent execution-time authorization runtime, with a link back to the marketing site. Everything below is unchanged.

## Test plan
- [x] README only — no code touched. Action behavior unchanged.

https://claude.ai/code/session_01QmtY3fVz6zWQ3kXFA9D2ou

---
_Generated by [Claude Code](https://claude.ai/code/session_01QmtY3fVz6zWQ3kXFA9D2ou)_