### PR TITLE
feat(action): add optional evidence-bundle post-deploy step

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -189,6 +189,24 @@ inputs:
       governance-fail-on-severity is set explicitly.
     required: false
     default: 'false'
+  # ── Post-deploy compliance evidence bundle ────────────────────────────────
+  evidence-bundle:
+    description: |
+      When set to "true" or a regime identifier, call POST /v1/orgs/{orgId}/evidence-exports
+      after a successful authorization gate and expose the bundle SHA-256 and export ID as
+      step outputs. Set to "false" (default) to skip the call.
+      Accepted values: 'false' | 'true' | 'soc2_type_ii' | 'hipaa' | 'gdpr'
+      When 'true', defaults to 'soc2_type_ii'.
+      Requires the API key to have the evidence:write scope and the organization to be
+      on the enterprise plan (HTTP 402 degrades gracefully with a warning).
+    required: false
+    default: 'false'
+  evidence-bundle-days:
+    description: |
+      Lookback window in days for the evidence bundle (default: 90).
+      The window is [now - days, now].
+    required: false
+    default: '90'
 outputs:
   decision:
     description: 'The evaluation decision (allow/deny/hold/escalate). Set for single-eval path only.'
@@ -271,6 +289,15 @@ outputs:
     description: 'JSON array of evaluation summaries — one per invoked agent — with status, findings_count, and highest_severity (governance-agents path only).'
   governance-findings:
     description: 'JSON array of all findings across all invoked agents (governance-agents path only).'
+  # ── Post-deploy compliance evidence bundle outputs ─────────────────────────
+  evidence-bundle-sha256:
+    description: |
+      SHA-256 hex digest of the generated compliance evidence bundle.
+      Empty string when evidence-bundle is 'false' or the call was skipped / failed.
+  evidence-bundle-id:
+    description: |
+      Evidence export record ID returned by POST /v1/orgs/{orgId}/evidence-exports.
+      Empty string when evidence-bundle is 'false' or the call was skipped / failed.
 runs:
   using: 'node24'
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -1242,6 +1242,69 @@ ${JSON.stringify(receiptPayload)}`;
   return { ...bundleBody, bundle_hash: bundleHash };
 }
 
+// src/postDeployEvidenceBundle.ts
+var VALID_EVIDENCE_REGIMES = /* @__PURE__ */ new Set([
+  "soc2_type_ii",
+  "hipaa",
+  "gdpr"
+]);
+function isoNow() {
+  return (/* @__PURE__ */ new Date()).toISOString();
+}
+function isoOffsetDays(days) {
+  return new Date(Date.now() - days * 24 * 60 * 60 * 1e3).toISOString();
+}
+async function callPostDeployEvidenceBundle(args, log, timeoutMs = 3e4) {
+  const empty = { sha256: "", exportId: "" };
+  const url = `${args.apiUrl.replace(/\/$/, "")}/v1/orgs/${encodeURIComponent(args.orgId)}/evidence-exports`;
+  const windowTo = isoNow();
+  const windowFrom = isoOffsetDays(args.days);
+  const body = {
+    regime: args.regime,
+    window: { from: windowFrom, to: windowTo }
+  };
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Authorization": `Bearer ${args.apiKey}`,
+        "Content-Type": "application/json",
+        ...args.actor ? { "X-AtlaSent-Actor": args.actor } : {}
+      },
+      body: JSON.stringify(body),
+      signal: controller.signal
+    });
+    if (res.status === 402) {
+      log.warning(
+        "AtlaSent evidence-bundle: organization is not on the enterprise plan (HTTP 402). Upgrade to generate compliance evidence bundles from CI."
+      );
+      return empty;
+    }
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      log.warning(
+        `AtlaSent evidence-bundle: POST ${url} \u2192 HTTP ${res.status} (advisory; build not affected). ${text}`.trim()
+      );
+      return empty;
+    }
+    const data = await res.json();
+    const exportId = data.export?.id ?? "";
+    const sha256 = data.sha256 ?? data.export?.bundle_sha256 ?? "";
+    log.info(`AtlaSent evidence-bundle: export ${exportId} sha256=${sha256}`);
+    return { sha256, exportId };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log.warning(
+      `AtlaSent evidence-bundle: request failed (advisory; build not affected): ${msg}`
+    );
+    return empty;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 // src/index.ts
 function getApiKey() {
   const apiKey = (process.env["ATLASENT_API_KEY"] ?? "").trim();
@@ -1912,6 +1975,47 @@ async function run() {
     );
   }
   emitFinancialGovernanceAdvisory(actionType, actor, orgId);
+  await runPostDeployEvidenceBundleStep(apiKey, apiUrl, orgId, actor);
+}
+async function runPostDeployEvidenceBundleStep(apiKey, apiUrl, orgId, actor) {
+  const bundleInput = getInput("evidence-bundle").toLowerCase();
+  const setEmptyBundleOutputs = () => {
+    setOutput("evidence-bundle-sha256", "");
+    setOutput("evidence-bundle-id", "");
+  };
+  if (!bundleInput || bundleInput === "false") {
+    setEmptyBundleOutputs();
+    return;
+  }
+  const regime = bundleInput === "true" ? "soc2_type_ii" : bundleInput;
+  if (!VALID_EVIDENCE_REGIMES.has(regime)) {
+    warning(
+      `AtlaSent evidence-bundle: unrecognized regime "${regime}". Expected one of: ${Array.from(VALID_EVIDENCE_REGIMES).join(", ")}. Skipping.`
+    );
+    setEmptyBundleOutputs();
+    return;
+  }
+  const rawDays = getInput("evidence-bundle-days") || "90";
+  const days = parseInt(rawDays, 10);
+  if (Number.isNaN(days) || days < 1) {
+    warning(
+      `AtlaSent evidence-bundle: evidence-bundle-days must be a positive integer (got "${rawDays}"). Skipping.`
+    );
+    setEmptyBundleOutputs();
+    return;
+  }
+  info(
+    `AtlaSent evidence-bundle: generating ${regime} bundle (${days}-day window) for org ${orgId}`
+  );
+  const result = await callPostDeployEvidenceBundle(
+    { apiUrl, apiKey, orgId, regime, days, actor: `github:${actor}` },
+    { info, warning }
+  );
+  setOutput("evidence-bundle-sha256", result.sha256);
+  setOutput("evidence-bundle-id", result.exportId);
+  if (result.sha256) {
+    info(`AtlaSent evidence-bundle: bundle_sha256=${result.sha256}`);
+  }
 }
 if (require.main === module) {
   run().catch((err) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,11 @@ import { emitEvidenceEvent } from "./evidenceClient";
 import { registerAndVerify, summarizeOutcome } from "./releaseCandidate";
 import { buildEvidenceBundle } from "./evidenceBundle";
 import {
+  callPostDeployEvidenceBundle,
+  VALID_EVIDENCE_REGIMES,
+  type EvidenceBundleRegime,
+} from "./postDeployEvidenceBundle";
+import {
   LEGACY_PRODUCTION_DEPLOY_ALIAS,
   PRODUCTION_DEPLOY_ACTION,
   normalizeProtectedAction,
@@ -891,6 +896,76 @@ export async function run(): Promise<void> {
   }
 
   emitFinancialGovernanceAdvisory(actionType, actor, orgId);
+
+  // ── Post-deploy compliance evidence bundle (optional) ───────────────────
+  // Only fires when the gate passed (decision=allow + verified=true).
+  // Gracefully degrades on 402 (enterprise only) or network errors.
+  await runPostDeployEvidenceBundleStep(apiKey, apiUrl, orgId, actor);
+}
+
+// ---------------------------------------------------------------------------
+// Post-deploy evidence bundle step
+// ---------------------------------------------------------------------------
+
+async function runPostDeployEvidenceBundleStep(
+  apiKey: string,
+  apiUrl: string,
+  orgId: string,
+  actor: string,
+): Promise<void> {
+  const bundleInput = getInput("evidence-bundle").toLowerCase();
+
+  // Always set outputs so downstream steps can reference them unconditionally.
+  const setEmptyBundleOutputs = (): void => {
+    setOutput("evidence-bundle-sha256", "");
+    setOutput("evidence-bundle-id", "");
+  };
+
+  if (!bundleInput || bundleInput === "false") {
+    setEmptyBundleOutputs();
+    return;
+  }
+
+  // Resolve regime: 'true' → 'soc2_type_ii', else treat as literal regime id.
+  const regime: EvidenceBundleRegime =
+    bundleInput === "true"
+      ? "soc2_type_ii"
+      : (bundleInput as EvidenceBundleRegime);
+
+  if (!VALID_EVIDENCE_REGIMES.has(regime)) {
+    warning(
+      `AtlaSent evidence-bundle: unrecognized regime "${regime}". ` +
+        `Expected one of: ${Array.from(VALID_EVIDENCE_REGIMES).join(", ")}. Skipping.`,
+    );
+    setEmptyBundleOutputs();
+    return;
+  }
+
+  const rawDays = getInput("evidence-bundle-days") || "90";
+  const days = parseInt(rawDays, 10);
+  if (Number.isNaN(days) || days < 1) {
+    warning(
+      `AtlaSent evidence-bundle: evidence-bundle-days must be a positive integer (got "${rawDays}"). Skipping.`,
+    );
+    setEmptyBundleOutputs();
+    return;
+  }
+
+  info(
+    `AtlaSent evidence-bundle: generating ${regime} bundle (${days}-day window) for org ${orgId}`,
+  );
+
+  const result = await callPostDeployEvidenceBundle(
+    { apiUrl, apiKey, orgId, regime, days, actor: `github:${actor}` },
+    { info, warning },
+  );
+
+  setOutput("evidence-bundle-sha256", result.sha256);
+  setOutput("evidence-bundle-id", result.exportId);
+
+  if (result.sha256) {
+    info(`AtlaSent evidence-bundle: bundle_sha256=${result.sha256}`);
+  }
 }
 
 if (require.main === module) {

--- a/src/postDeployEvidenceBundle.ts
+++ b/src/postDeployEvidenceBundle.ts
@@ -1,0 +1,129 @@
+/**
+ * Post-deploy compliance evidence bundle generator.
+ *
+ * Calls POST /v1/orgs/{orgId}/evidence-exports after a successful
+ * authorization gate to build a canonical compliance envelope and
+ * record its SHA-256 for audit purposes.
+ *
+ * The call is gracefully degraded:
+ *   - 402 Payment Required → org is not on enterprise; emits a warning
+ *     and sets empty outputs (never fails the build)
+ *   - Network / timeout errors → emits a warning, sets empty outputs
+ *
+ * Auth: uses Authorization: Bearer — same api-key input already present.
+ */
+
+export type EvidenceBundleRegime = "soc2_type_ii" | "hipaa" | "gdpr";
+
+export const VALID_EVIDENCE_REGIMES = new Set<EvidenceBundleRegime>([
+  "soc2_type_ii",
+  "hipaa",
+  "gdpr",
+]);
+
+export interface PostDeployEvidenceBundleArgs {
+  apiUrl: string;
+  apiKey: string;
+  /** Organisation ID derived from GITHUB_REPOSITORY owner segment. */
+  orgId: string;
+  regime: EvidenceBundleRegime;
+  /** Lookback window length in days (default: 90). */
+  days: number;
+  /** Actor label written into the generated_by field. */
+  actor?: string;
+}
+
+export interface PostDeployEvidenceBundleResult {
+  /** SHA-256 hex digest of the canonical bundle bytes, or empty string. */
+  sha256: string;
+  /** Evidence export record ID, or empty string. */
+  exportId: string;
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function isoNow(): string {
+  return new Date().toISOString();
+}
+
+function isoOffsetDays(days: number): string {
+  return new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
+}
+
+// ─── Main caller ──────────────────────────────────────────────────────────────
+
+/**
+ * Call POST /v1/orgs/{orgId}/evidence-exports and return the export ID and
+ * bundle SHA-256.  Returns empty strings on any non-fatal error so the action
+ * output is always set regardless of outcome.
+ */
+export async function callPostDeployEvidenceBundle(
+  args: PostDeployEvidenceBundleArgs,
+  log: { info: (m: string) => void; warning: (m: string) => void },
+  timeoutMs = 30_000,
+): Promise<PostDeployEvidenceBundleResult> {
+  const empty: PostDeployEvidenceBundleResult = { sha256: "", exportId: "" };
+
+  const url = `${args.apiUrl.replace(/\/$/, "")}/v1/orgs/${encodeURIComponent(args.orgId)}/evidence-exports`;
+
+  const windowTo = isoNow();
+  const windowFrom = isoOffsetDays(args.days);
+
+  const body = {
+    regime: args.regime,
+    window: { from: windowFrom, to: windowTo },
+  };
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const res = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Authorization": `Bearer ${args.apiKey}`,
+        "Content-Type": "application/json",
+        ...(args.actor ? { "X-AtlaSent-Actor": args.actor } : {}),
+      },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+
+    if (res.status === 402) {
+      // Org not on enterprise tier — degrade gracefully
+      log.warning(
+        "AtlaSent evidence-bundle: organization is not on the enterprise plan (HTTP 402). " +
+          "Upgrade to generate compliance evidence bundles from CI.",
+      );
+      return empty;
+    }
+
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      log.warning(
+        `AtlaSent evidence-bundle: POST ${url} → HTTP ${res.status} (advisory; build not affected). ${text}`.trim(),
+      );
+      return empty;
+    }
+
+    // Shape: { export: EvidenceExportRecord; bundle: EvidenceBundle; sha256: string }
+    const data = (await res.json()) as {
+      export?: { id?: string; bundle_sha256?: string };
+      sha256?: string;
+    };
+
+    const exportId = data.export?.id ?? "";
+    const sha256 = data.sha256 ?? data.export?.bundle_sha256 ?? "";
+
+    log.info(`AtlaSent evidence-bundle: export ${exportId} sha256=${sha256}`);
+    return { sha256, exportId };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log.warning(
+      `AtlaSent evidence-bundle: request failed (advisory; build not affected): ${msg}`,
+    );
+    return empty;
+  } finally {
+    clearTimeout(timer);
+  }
+}


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Add optional `evidence-bundle` input (`'false'` | `'true'` | `'soc2_type_ii'` | `'hipaa'` | `'gdpr'`, default `'false'`) that calls `POST /v1/orgs/{orgId}/evidence-exports` after a **successful** authorization gate (allow + verified)
- Add optional `evidence-bundle-days` input (lookback window in days, default `'90'`)
- Add `evidence-bundle-sha256` and `evidence-bundle-id` step outputs (always set; empty string when not generated)
- HTTP 402 (org not on enterprise plan) degrades gracefully with a `::warning::` — never fails the build
- New source module `src/postDeployEvidenceBundle.ts` follows the same pattern established in `atlasent-gxp-starter/scripts/post-deploy-evidence-bundle.ts`
- `dist/index.js` rebuilt from source; all 201 existing tests pass

## Test plan

- [ ] Set `evidence-bundle: soc2_type_ii` in a workflow that uses the action after a successful deploy gate — confirm `evidence-bundle-sha256` and `evidence-bundle-id` outputs are populated
- [ ] Set `evidence-bundle: true` — confirm it defaults to `soc2_type_ii` regime
- [ ] Set `evidence-bundle: false` (or omit) — confirm outputs are empty strings and no API call is made
- [ ] Test with an org not on enterprise (API returns 402) — confirm the step emits a `::warning::` and does not fail the workflow
- [ ] Test with an invalid regime string — confirm warning is emitted and outputs are empty
- [ ] Verify backward compatibility: existing workflows with no `evidence-bundle` input are unaffected

https://claude.ai/code/session_016R8cKXs4qx9CovhwFyNj5R
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_016R8cKXs4qx9CovhwFyNj5R)_