### PR TITLE
feat: R4 cosign keyless signing migration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,11 +10,16 @@ on:
         description: 'Branch or tag to build'
         default: 'main'
 
+permissions:
+  contents: write
+  id-token: write   # required for cosign keyless signing (Sigstore OIDC)
+
 jobs:
   build-and-release:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write   # required for cosign keyless signing (Sigstore OIDC)
     steps:
       - uses: actions/checkout@v6
         with:
@@ -35,3 +40,38 @@ jobs:
           git add dist/index.js
           git diff --staged --quiet || git commit -m "chore: build dist/index.js"
           git push
+
+      # ── R4: cosign keyless signing ────────────────────────────────────────
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+        with:
+          cosign-release: 'v2.4.1'
+
+      - name: Sign dist/index.js (keyless, Sigstore Fulcio + Rekor)
+        # cosign uses the GitHub Actions OIDC token — no long-lived key secret.
+        # The resulting bundle (dist/index.js.bundle) contains the certificate
+        # chain and transparency-log entry needed to verify the signature.
+        run: |
+          cosign sign-blob \
+            --yes \
+            --bundle=dist/index.js.bundle \
+            dist/index.js
+
+      - name: Verify signature
+        # Smoke-test: re-verify using the bundle we just produced.
+        run: |
+          cosign verify-blob \
+            --bundle=dist/index.js.bundle \
+            --certificate-identity-regexp='https://github.com/AtlaSent-Systems-Inc/atlasent-action/.github/workflows/release.yml@refs/tags/v.*' \
+            --certificate-oidc-issuer='https://token.actions.githubusercontent.com' \
+            dist/index.js
+
+      - name: Upload signature bundle to GitHub release
+        # Only upload when triggered by a tag push (i.e. a real release).
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "${{ github.ref_name }}" \
+            dist/index.js.bundle \
+            --clobber


### PR DESCRIPTION
## Summary

- Adds R4 cosign keyless signing to `release.yml` using `sigstore/cosign-installer@v3` (cosign v2.4.1)
- `dist/index.js` is signed with `cosign sign-blob --yes --bundle=dist/index.js.bundle` on every release tag push
- The signature bundle is uploaded to the GitHub release as `dist/index.js.bundle`
- A smoke-test `cosign verify-blob` step immediately validates the bundle before uploading
- `id-token: write` permission added at both the top-level and job level to enable OIDC token acquisition from GitHub Actions
- No long-lived key secrets are used; the signing identity is bound to the GitHub Actions OIDC token for this specific workflow run (Sigstore Fulcio CA + Rekor transparency log)

## What changed

**`.github/workflows/release.yml`**
- Added `id-token: write` to `permissions` (top-level and job-level)
- Added `sigstore/cosign-installer@v3` step (after build)
- Added `cosign sign-blob --yes --bundle=dist/index.js.bundle dist/index.js` step
- Added `cosign verify-blob` smoke-test step
- Added `gh release upload` step to attach the bundle to the GitHub release (tag-push only)

## Test plan

- [ ] Verify the workflow YAML is valid (`actionlint` or push to a feature branch and check the Actions syntax check)
- [ ] On next tag release (`v*.*.*`), confirm the `sign dist/index.js` step completes without error
- [ ] Confirm `dist/index.js.bundle` appears on the GitHub release page
- [ ] Manually verify: `cosign verify-blob --bundle=dist/index.js.bundle --certificate-identity-regexp='...' --certificate-oidc-issuer='https://token.actions.githubusercontent.com' dist/index.js`
- [ ] Confirm no `COSIGN_*` or signing-key secrets are referenced anywhere in the workflow

## Reference

Pattern matches `atlasent-gxp-starter` PR #58 (merged). No long-lived Ed25519/HMAC secrets involved.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GSYgxcbYLYRSheVxctZ1ss)_