### PR TITLE
feat: open action type taxonomy and state transition builders

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -345,13 +345,20 @@ function normalizeProtectedAction(raw) {
   }
   return { canonical: raw, wasLegacyAlias: false };
 }
-function assertProtectedAction(raw) {
+var ACTION_TYPE_PATTERN = /^[a-z][a-z0-9]*(\.[a-z][a-z0-9]*){1,3}$/;
+function isValidActionType(raw) {
+  return ACTION_TYPE_PATTERN.test(raw);
+}
+function assertValidActionType(raw) {
   const { canonical } = normalizeProtectedAction(raw);
-  if (canonical !== PRODUCTION_DEPLOY_ACTION) {
+  if (!isValidActionType(canonical)) {
     throw new Error(
-      `Unsupported protected action "${raw}". Deploy Gate V1 only permits "${PRODUCTION_DEPLOY_ACTION}" (legacy alias "${LEGACY_PRODUCTION_DEPLOY_ALIAS}" is accepted during the V1 alias window).`
+      `Invalid action type "${raw}". Expected dot-separated lowercase identifiers, 2\u20134 segments (e.g. "production.deploy", "database.migration.apply").`
     );
   }
+}
+function assertProtectedAction(raw) {
+  assertValidActionType(raw);
 }
 
 // src/inputs.ts

--- a/src/canonicalAction.ts
+++ b/src/canonicalAction.ts
@@ -1,20 +1,45 @@
-// Canonical Deploy Gate V1 protected action — single source of truth
-// at the action's I/O boundary.
+// Canonical action type taxonomy for atlasent-action.
 //
-// Mirrors atlasent-api's `_shared/canonical-action.ts`: we accept the
-// legacy alias on input and normalize to the canonical before
-// forwarding to the server. The server itself is alias-tolerant per
-// atlasent-api PR #662, so this is belt-and-suspenders during the V1
-// alias window — both ends rewrite to the same string.
+// V1 framing: "protected actions"
+// V2 framing: authority over a consequential state transition
+//
+// The action_type is a label on the transition, not the whole story.
+// The state transition (current → proposed) is what the evaluator reasons about.
+// Policies govern the full action_type namespace — this file does not enumerate
+// every allowed value. It provides well-known constants and normalization helpers.
+//
+// Legacy alias window: LEGACY_PRODUCTION_DEPLOY_ALIAS ("deployment.production")
+// is accepted on input and normalized to the canonical "production.deploy".
+// Both ends rewrite — see atlasent-api PR #662.
+
+// ---------------------------------------------------------------------------
+// Well-known action type constants
+// ---------------------------------------------------------------------------
 
 export const PRODUCTION_DEPLOY_ACTION = "production.deploy";
+export const DATABASE_MIGRATION_ACTION = "database.migration.apply";
+export const DATABASE_SCHEMA_DROP_ACTION = "database.schema.drop";
+export const DATA_EXPORT_BULK_ACTION = "data.export.bulk";
+export const ADMIN_PERMISSION_GRANT_ACTION = "admin.permission.grant";
+export const AGENT_TOOL_CALL_ACTION = "agent.tool.call";
+export const SECRET_ROTATION_PRODUCTION_ACTION = "secret.rotation.production";
+
+/** Legacy alias — accepted during the V1 alias window, normalized on input. */
 export const LEGACY_PRODUCTION_DEPLOY_ALIAS = "deployment.production";
+
+// ---------------------------------------------------------------------------
+// Normalization
+// ---------------------------------------------------------------------------
 
 export interface NormalizedProtectedAction {
   canonical: string;
   wasLegacyAlias: boolean;
 }
 
+/**
+ * Normalize an action type string, resolving any known legacy aliases.
+ * Always returns the canonical form before forwarding to the control plane.
+ */
 export function normalizeProtectedAction(raw: string): NormalizedProtectedAction {
   if (raw === LEGACY_PRODUCTION_DEPLOY_ALIAS) {
     return { canonical: PRODUCTION_DEPLOY_ACTION, wasLegacyAlias: true };
@@ -22,12 +47,43 @@ export function normalizeProtectedAction(raw: string): NormalizedProtectedAction
   return { canonical: raw, wasLegacyAlias: false };
 }
 
-export function assertProtectedAction(raw: string): void {
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+const ACTION_TYPE_PATTERN = /^[a-z][a-z0-9]*(\.[a-z][a-z0-9]*){1,3}$/;
+
+/**
+ * Validate that a string is a well-formed action type.
+ * Format: dot-separated lowercase identifiers, 2–4 segments.
+ * Does NOT restrict to a fixed whitelist — policies are the authority.
+ */
+export function isValidActionType(raw: string): boolean {
+  return ACTION_TYPE_PATTERN.test(raw);
+}
+
+/**
+ * Assert that a string is a well-formed action type.
+ * Throws if the format is invalid. Does NOT restrict to a fixed whitelist.
+ *
+ * Previously assertProtectedAction() hard-coded V1 to "production.deploy" only.
+ * That constraint now lives in policy, not in this file.
+ */
+export function assertValidActionType(raw: string): void {
   const { canonical } = normalizeProtectedAction(raw);
-  if (canonical !== PRODUCTION_DEPLOY_ACTION) {
+  if (!isValidActionType(canonical)) {
     throw new Error(
-      `Unsupported protected action "${raw}". Deploy Gate V1 only permits "${PRODUCTION_DEPLOY_ACTION}" ` +
-        `(legacy alias "${LEGACY_PRODUCTION_DEPLOY_ALIAS}" is accepted during the V1 alias window).`,
+      `Invalid action type "${raw}". ` +
+        `Expected dot-separated lowercase identifiers, 2–4 segments ` +
+        `(e.g. "production.deploy", "database.migration.apply").`,
     );
   }
+}
+
+/**
+ * @deprecated Use assertValidActionType(). Retained for backward compatibility
+ * with existing callers during the V1 → V2 transition window.
+ */
+export function assertProtectedAction(raw: string): void {
+  assertValidActionType(raw);
 }

--- a/src/stateTransition.ts
+++ b/src/stateTransition.ts
@@ -1,0 +1,237 @@
+// State transition builders for atlasent-action.
+//
+// AtlaSent authorizes authority over a consequential state transition,
+// not just a named action. Providing current_state and proposed_state
+// enables state-aware evaluation: the control plane can reason about
+// WHAT IS CHANGING, not just what action was requested.
+//
+// The richer the transition, the more precise the policy decision:
+//   "deployment requested" → risk_class: high
+//   "v1.2.3 → v1.2.4, 0 breaking changes, all tests green" → risk_class: medium
+//   "v1.2.3 → v2.0.0, breaking API, migration required" → risk_class: critical
+
+// ---------------------------------------------------------------------------
+// Core types (mirrored from atlasent-api schema — keep in sync)
+// ---------------------------------------------------------------------------
+
+export interface StateSnapshot {
+  description: string;
+  attributes?: Record<string, unknown>;
+}
+
+export interface StateTransition {
+  current_state: StateSnapshot;
+  proposed_state: StateSnapshot;
+}
+
+// ---------------------------------------------------------------------------
+// Deployment state transitions
+// ---------------------------------------------------------------------------
+
+export interface DeploymentTransitionOptions {
+  service: string;
+  environment: string;
+  currentVersion?: string;
+  proposedVersion?: string;
+  /** Commit SHA being deployed */
+  commitSha?: string;
+  /** Number of breaking changes in the proposed version */
+  breakingChanges?: number;
+  /** Whether all CI checks passed */
+  testsGreen?: boolean;
+}
+
+/**
+ * Build a state transition for a production deployment.
+ * Passes version, environment, and CI state to the evaluator for risk scoring.
+ */
+export function deploymentTransition(opts: DeploymentTransitionOptions): StateTransition {
+  const {
+    service,
+    environment,
+    currentVersion = "unknown",
+    proposedVersion = "unknown",
+    commitSha,
+    breakingChanges,
+    testsGreen,
+  } = opts;
+
+  return {
+    current_state: {
+      description: `${service} ${currentVersion} running in ${environment}`,
+      attributes: {
+        service,
+        version: currentVersion,
+        environment,
+      },
+    },
+    proposed_state: {
+      description: `${service} ${proposedVersion} deployed to ${environment}`,
+      attributes: {
+        service,
+        version: proposedVersion,
+        environment,
+        ...(commitSha != null ? { commit_sha: commitSha } : {}),
+        ...(breakingChanges != null ? { breaking_changes: breakingChanges } : {}),
+        ...(testsGreen != null ? { tests_green: testsGreen } : {}),
+      },
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Database migration state transitions
+// ---------------------------------------------------------------------------
+
+export interface MigrationTransitionOptions {
+  database: string;
+  environment: string;
+  migrationName: string;
+  /** SQL statements in the migration — used for destructive op detection */
+  statements?: string[];
+  /** Whether a backup was confirmed before migration */
+  backupConfirmed?: boolean;
+  /** Estimated number of rows affected */
+  rowsAffected?: number;
+}
+
+/** Destructive SQL patterns that elevate risk_class to critical */
+const DESTRUCTIVE_PATTERNS = [
+  /\bDROP\s+TABLE\b/i,
+  /\bDROP\s+SCHEMA\b/i,
+  /\bDROP\s+COLUMN\b/i,
+  /\bTRUNCATE\b/i,
+  /\bDELETE\s+FROM\b/i,
+  /\bDROP\s+INDEX\b/i,
+  /\bALTER\s+TABLE\b.+\bDROP\b/i,
+];
+
+/**
+ * Detect whether SQL statements contain destructive operations.
+ * Destructive migrations require elevated approval regardless of action_type.
+ */
+export function detectDestructiveStatements(statements: string[]): {
+  hasDestructiveOps: boolean;
+  matched: string[];
+} {
+  const matched: string[] = [];
+  for (const stmt of statements) {
+    for (const pattern of DESTRUCTIVE_PATTERNS) {
+      if (pattern.test(stmt)) {
+        matched.push(stmt.trim().substring(0, 120));
+        break;
+      }
+    }
+  }
+  return { hasDestructiveOps: matched.length > 0, matched };
+}
+
+/**
+ * Build a state transition for a database migration.
+ * Automatically detects destructive operations and surfaces them in proposed_state
+ * so the evaluator can apply elevated risk scoring without manual intervention.
+ */
+export function migrationTransition(opts: MigrationTransitionOptions): StateTransition & {
+  hasDestructiveOps: boolean;
+  destructiveStatements: string[];
+} {
+  const { database, environment, migrationName, statements = [], backupConfirmed, rowsAffected } = opts;
+  const { hasDestructiveOps, matched } = detectDestructiveStatements(statements);
+
+  return {
+    current_state: {
+      description: `${database} schema at current state in ${environment}`,
+      attributes: {
+        database,
+        environment,
+        migration_pending: migrationName,
+        ...(backupConfirmed != null ? { backup_confirmed: backupConfirmed } : {}),
+      },
+    },
+    proposed_state: {
+      description: hasDestructiveOps
+        ? `${database} schema after DESTRUCTIVE migration ${migrationName} in ${environment}`
+        : `${database} schema after migration ${migrationName} applied in ${environment}`,
+      attributes: {
+        database,
+        environment,
+        migration_applied: migrationName,
+        destructive_ops: hasDestructiveOps,
+        ...(matched.length > 0 ? { destructive_statements: matched } : {}),
+        ...(rowsAffected != null ? { rows_affected: rowsAffected } : {}),
+        ...(backupConfirmed != null ? { backup_confirmed: backupConfirmed } : {}),
+      },
+    },
+    hasDestructiveOps,
+    destructiveStatements: matched,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Agent tool call state transitions
+// ---------------------------------------------------------------------------
+
+export interface AgentToolTransitionOptions {
+  toolName: string;
+  agentId?: string;
+  /** High-level description of what the tool will do */
+  effect?: string;
+  args?: Record<string, unknown>;
+}
+
+/**
+ * Build a state transition for an agent tool call.
+ * Used by AgentGuard when forwarding evaluation context.
+ */
+export function agentToolTransition(opts: AgentToolTransitionOptions): StateTransition {
+  const { toolName, agentId, effect, args } = opts;
+  const actor = agentId ? `agent:${agentId}` : "agent";
+
+  return {
+    current_state: {
+      description: `${actor} has not yet called ${toolName}`,
+      attributes: {
+        tool_name: toolName,
+        ...(agentId != null ? { agent_id: agentId } : {}),
+        called: false,
+      },
+    },
+    proposed_state: {
+      description: effect ?? `${actor} calls ${toolName}`,
+      attributes: {
+        tool_name: toolName,
+        ...(agentId != null ? { agent_id: agentId } : {}),
+        called: true,
+        ...(args != null ? { args_summary: Object.keys(args) } : {}),
+      },
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Generic state transition builder for custom action types
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a freeform state transition when no typed builder applies.
+ * Use this for custom action types not covered by the built-in builders.
+ */
+export function stateTransition(
+  currentDescription: string,
+  proposedDescription: string,
+  options?: {
+    currentAttributes?: Record<string, unknown>;
+    proposedAttributes?: Record<string, unknown>;
+  },
+): StateTransition {
+  return {
+    current_state: {
+      description: currentDescription,
+      attributes: options?.currentAttributes,
+    },
+    proposed_state: {
+      description: proposedDescription,
+      attributes: options?.proposedAttributes,
+    },
+  };
+}


### PR DESCRIPTION
## What this does

Two changes corresponding to the execution-authority architecture in `atlasent-control-plane` PR #feat/action-contract.

---

## 1. Open action type taxonomy (`canonicalAction.ts`)

**Before:** `assertProtectedAction()` hard-coded V1 to `production.deploy` only. Any other action type threw.

**After:** `assertValidActionType()` validates format (dot-separated lowercase, 2–4 segments) rather than identity. The full taxonomy is policy-governed, not code-governed.

The constraint "only production.deploy is allowed" moves from this file to AtlaSent policy — where it belongs. The code enforces *format*, policy enforces *authorization*.

`assertProtectedAction()` is retained as a deprecated alias for backward compatibility during the V1 → V2 transition window.

Well-known constants added:
```
PRODUCTION_DEPLOY_ACTION          = "production.deploy"
DATABASE_MIGRATION_ACTION         = "database.migration.apply"
DATABASE_SCHEMA_DROP_ACTION       = "database.schema.drop"
DATA_EXPORT_BULK_ACTION           = "data.export.bulk"
ADMIN_PERMISSION_GRANT_ACTION     = "admin.permission.grant"
AGENT_TOOL_CALL_ACTION            = "agent.tool.call"
SECRET_ROTATION_PRODUCTION_ACTION = "secret.rotation.production"
```

Legacy alias `"deployment.production"` → `"production.deploy"` preserved.

---

## 2. State transition builders (`stateTransition.ts`)

Builders for constructing `current_state` / `proposed_state` pairs for the most common action types. State context is forwarded to the control plane so evaluators can reason about WHAT IS CHANGING, not just what action was requested.

### `deploymentTransition()`
Version, environment, commit SHA, breaking change count, CI status. A `v1→v2` deploy with breaking changes gets scored differently than a `v1.2.3→v1.2.4` patch with green CI.

### `migrationTransition()`
Migration name, SQL statements, backup confirmation, rows affected. **Automatically detects destructive operations** — `DROP TABLE`, `TRUNCATE`, `DELETE FROM`, `DROP COLUMN`, etc. — and surfaces them in `proposed_state.attributes.destructive_statements`. Policies can apply elevated `risk_class` automatically without requiring manual override from the operator.

```ts
const transition = migrationTransition({
  database: "prod-db",
  environment: "production",
  migrationName: "20260529_drop_users_table",
  statements: ["DROP TABLE users;"],
  backupConfirmed: true,
});
// transition.hasDestructiveOps === true
// transition.proposed_state.description === "prod-db schema after DESTRUCTIVE migration..."
```

### `agentToolTransition()`
Tool name, agent ID, effect description. Used by `AgentGuard` when forwarding evaluation context.

### `stateTransition()`
Generic builder for custom action types not covered by the typed builders.

---

## Pair with

`atlasent-control-plane` — Action Contract schema (migration 024, new `actionContract.ts`, extended `permits.ts` and `evaluate.ts`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ST41Z1gcc8oXQ2hGwsfro3)_