### PR TITLE
feat(enforce): forward state transition context — close end-to-end pipeline gap

### DIFF
--- a/packages/enforce/src/__tests__/evaluate.test.ts
+++ b/packages/enforce/src/__tests__/evaluate.test.ts
@@ -111,4 +111,83 @@ describe("evaluate", () => {
     await evaluate({ ...BASE_CONFIG, apiUrl: "https://api.test/" });
     expect(mockPost.mock.calls[0][0]).toBe("https://api.test/v1-evaluate");
   });
+
+  // ── State transition context forwarding ────────────────────────────────────
+
+  it("forwards current_state and proposed_state as top-level POST body fields", async () => {
+    mockResponse(200, { decision: "allow" });
+    await evaluate({
+      ...BASE_CONFIG,
+      current_state: { description: "running v1.2", attributes: { sha: "abc" } },
+      proposed_state: { description: "running v1.3", attributes: { sha: "def" } },
+    });
+    const body = JSON.parse(mockPost.mock.calls[0][1] as string) as Record<string, unknown>;
+    expect(body["current_state"]).toEqual({ description: "running v1.2", attributes: { sha: "abc" } });
+    expect(body["proposed_state"]).toEqual({ description: "running v1.3", attributes: { sha: "def" } });
+  });
+
+  it("forwards resource as top-level field and omits target_id when resource is set", async () => {
+    mockResponse(200, { decision: "allow" });
+    await evaluate({
+      ...BASE_CONFIG,
+      resource: { type: "database", id: "prod-db", attributes: { region: "us-east-1" } },
+    });
+    const body = JSON.parse(mockPost.mock.calls[0][1] as string) as Record<string, unknown>;
+    expect(body["resource"]).toEqual({ type: "database", id: "prod-db", attributes: { region: "us-east-1" } });
+    expect(body["target_id"]).toBeUndefined();
+  });
+
+  it("falls back to target_id when resource is absent (backward compat)", async () => {
+    mockResponse(200, { decision: "allow" });
+    await evaluate({ ...BASE_CONFIG, targetId: "svc-legacy" });
+    const body = JSON.parse(mockPost.mock.calls[0][1] as string) as Record<string, unknown>;
+    expect(body["target_id"]).toBe("svc-legacy");
+    expect(body["resource"]).toBeUndefined();
+  });
+
+  it("forwards execution_binding as a top-level POST body field", async () => {
+    mockResponse(200, { decision: "allow" });
+    await evaluate({
+      ...BASE_CONFIG,
+      execution_binding: { kind: "supabase-migration", adapter_version: "1.0.0", resource_id: "prod-db" },
+    });
+    const body = JSON.parse(mockPost.mock.calls[0][1] as string) as Record<string, unknown>;
+    expect(body["execution_binding"]).toEqual({
+      kind: "supabase-migration",
+      adapter_version: "1.0.0",
+      resource_id: "prod-db",
+    });
+  });
+
+  // ── Response field extraction ──────────────────────────────────────────────
+
+  it("surfaces risk_class and authority_basis from the response", async () => {
+    mockResponse(200, {
+      decision: "allow",
+      risk_class: "high",
+      authority_basis: { kind: "quorum", reference: "qr-001", granted_by: "approver@org" },
+    });
+    const d = await evaluate(BASE_CONFIG);
+    expect(d.risk_class).toBe("high");
+    expect(d.authority_basis).toEqual({ kind: "quorum", reference: "qr-001", granted_by: "approver@org" });
+  });
+
+  it("surfaces escalation_id from a hold response", async () => {
+    mockResponse(200, {
+      decision: "hold",
+      hold_reason: "awaiting quorum",
+      escalation_id: "esc-abc123",
+    });
+    const d = await evaluate(BASE_CONFIG);
+    expect(d.decision).toBe("hold");
+    expect(d.escalation_id).toBe("esc-abc123");
+  });
+
+  it("leaves risk_class, authority_basis, escalation_id undefined when absent", async () => {
+    mockResponse(200, { decision: "allow" });
+    const d = await evaluate(BASE_CONFIG);
+    expect(d.risk_class).toBeUndefined();
+    expect(d.authority_basis).toBeUndefined();
+    expect(d.escalation_id).toBeUndefined();
+  });
 });

--- a/packages/enforce/src/index.ts
+++ b/packages/enforce/src/index.ts
@@ -21,6 +21,19 @@ export interface EnforceConfig {
   actor: string;
   environment?: string;
   targetId?: string;
+  resource?: {
+    type: string;
+    id?: string;
+    attributes?: Record<string, unknown>;
+  };
+  current_state?: { description: string; attributes?: Record<string, unknown> };
+  proposed_state?: { description: string; attributes?: Record<string, unknown> };
+  execution_binding?: {
+    kind: string;
+    adapter_version?: string;
+    resource_id?: string;
+    enforcement_point?: string;
+  };
   context?: Record<string, unknown>;
 }
 
@@ -32,6 +45,15 @@ export interface Decision {
   riskScore?: number;
   denyReason?: string;
   holdReason?: string;
+  /** Resolved risk class from the evaluation (critical / high / medium / low). */
+  risk_class?: string;
+  /** WHY this was allowed — kind + reference ID (policy, quorum, emergency, etc.). */
+  authority_basis?: { kind: string; reference?: string; granted_by?: string; rationale?: string };
+  /**
+   * Present iff decision === "hold". ID of the HITL escalation auto-created by
+   * the control plane. Poll GET /v1/hitl/{id} for resolution.
+   */
+  escalation_id?: string;
   /** v1.1 audit chain fields — present when the API returns them. */
   chainEntry?: Record<string, unknown> | null;
   snapshot?: Record<string, unknown> | null;
@@ -68,12 +90,19 @@ export async function evaluate(config: EnforceConfig): Promise<Decision> {
     action_type: config.action,
     actor_id: config.actor,
     context: {
+      // Keep environment in context for backward compat with older control plane versions.
       ...(config.environment ? { environment: config.environment } : {}),
       ...(config.targetId ? { target_id: config.targetId } : {}),
       ...config.context,
     },
   };
-  if (config.targetId) payload["target_id"] = config.targetId;
+  // Top-level fields forwarded to the control plane's EvaluateRequest.
+  if (config.environment != null) payload["environment"] = config.environment;
+  if (config.resource != null) payload["resource"] = config.resource;
+  else if (config.targetId) payload["target_id"] = config.targetId;
+  if (config.current_state != null) payload["current_state"] = config.current_state;
+  if (config.proposed_state != null) payload["proposed_state"] = config.proposed_state;
+  if (config.execution_binding != null) payload["execution_binding"] = config.execution_binding;
 
   let status: number;
   let body: string;
@@ -250,6 +279,9 @@ function mapDecision(raw: Record<string, unknown>): Decision {
     riskScore: extractRiskScore(raw),
     denyReason: raw["deny_reason"] as string | undefined,
     holdReason: raw["hold_reason"] as string | undefined,
+    risk_class: raw["risk_class"] as string | undefined,
+    authority_basis: raw["authority_basis"] as Decision["authority_basis"],
+    escalation_id: raw["escalation_id"] as string | undefined,
     chainEntry: (raw["chain_entry"] as Record<string, unknown> | null | undefined) ?? null,
     snapshot: (raw["snapshot"] as Record<string, unknown> | null | undefined) ?? null,
     auditHash: raw["audit_hash"] as string | undefined,


### PR DESCRIPTION
## Summary

- `EnforceConfig` now accepts `resource`, `current_state`, `proposed_state`, `execution_binding`
- `evaluate()` forwards all four as top-level fields in the POST body to the control plane
- `Decision` surfaces `risk_class`, `authority_basis`, `escalation_id` from the response
- `mapDecision()` extracts the three new response fields

## The gap this closes

The Supabase connector (PR #73) builds a full `EnforceConfig` with `resource`, `current_state`, `proposed_state`, and `execution_binding` — the full state transition context that Phases 3–5 depend on. But `EnforceConfig` didn't declare those fields, and `evaluate()` never included them in the HTTP body. They were silently dropped. The evaluator saw only `action_type`, `actor_id`, and `context`.

**Before**: evaluator received `{ action_type, actor_id, context }`  
**After**: evaluator receives `{ action_type, actor_id, context, environment, resource, current_state, proposed_state, execution_binding }`

## What callers can now read from `Decision`

```ts
const decision = await evaluate(enforceConfig);
// decision.risk_class       — "critical" | "high" | "medium" | "low"
// decision.authority_basis  — { kind: "policy" | "quorum" | "emergency", reference }
// decision.escalation_id    — set when decision=hold and CP auto-created a HITL escalation
```

## Backward compatibility

- `targetId` behavior preserved — still sent as `target_id` when `resource` is absent
- `environment` still included in context for older control plane versions
- All new `EnforceConfig` fields are optional — no breaking change for existing callers

## Pairs with

- `atlasent-action` PR #73 — Supabase migration guard (uses the new fields)
- `atlasent-control-plane` PR #82 (merged) — Phase 4 state-aware evaluation
- `atlasent-control-plane` PR #83 (merged) — Phase 5 authority graph

## Test plan

- [ ] `evaluate()` with `current_state` + `proposed_state` → POST body contains them (unit test with fetch mock)
- [ ] `evaluate()` with `resource` → body contains `resource` object, not `target_id`
- [ ] `evaluate()` with only `targetId` → body still contains `target_id` (backward compat)
- [ ] `evaluate()` response with `risk_class` + `authority_basis` → surfaced in `Decision`
- [ ] `evaluate()` response with `escalation_id` on hold → surfaced in `Decision.escalation_id`
- [ ] All new `EnforceConfig` fields optional — existing callers compile without changes

https://claude.ai/code/session_01ST41Z1gcc8oXQ2hGwsfro3

---
_Generated by [Claude Code](https://claude.ai/code/session_01ST41Z1gcc8oXQ2hGwsfro3)_