### PR TITLE
feat: vqp-verify mode — re-derivation hash check and drift detection

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -207,6 +207,48 @@ inputs:
       The window is [now - days, now].
     required: false
     default: '90'
+  # ── VQP Re-Derivation Verify ──────────────────────────────────────────────
+  vqp-snapshot-id:
+    description: |
+      UUID of the VQP snapshot to re-derive and audit. When set, the action
+      runs in vqp-verify mode: re-derives the VQP prompt from DB rules,
+      computes a SHA-256 hash, and compares it to the stored prompt_hash.
+      Fails the job when hash_match=false (integrity violation) or
+      verdict_changed=true (AI score drift with verdict flip).
+      Mutually exclusive with evaluate, policy-sync, release-mode, and
+      governance-agents paths. Does NOT require ATLASENT_API_KEY.
+    required: false
+    default: ''
+  vqp-supabase-url:
+    description: |
+      Supabase project URL for the VQP edge functions
+      (e.g. https://xxxxxxxxxxx.supabase.co). Required when vqp-snapshot-id
+      is set. Falls back to the ATLASENT_SUPABASE_URL env var.
+    required: false
+    default: ''
+  vqp-service-role-key:
+    description: |
+      Supabase service role key — server-side only, must be stored as an
+      Actions secret (never expose in workflow YAML). Required when
+      vqp-snapshot-id is set. Falls back to the
+      ATLASENT_SUPABASE_SERVICE_ROLE_KEY env var.
+    required: false
+    default: ''
+  vqp-rerun:
+    description: |
+      When "true", re-run the AI engine on the re-derived prompt to detect
+      score drift (emits score_delta and verdict_changed outputs).
+      Default: "false" (hash integrity check only).
+    required: false
+    default: 'false'
+  vqp-fail-on-drift:
+    description: |
+      When "true" (default), fail the job if hash_match=false (integrity
+      violation) or verdict_changed=true (score drift with verdict flip).
+      Set to "false" to surface outputs without failing — useful for
+      advisory monitoring workflows.
+    required: false
+    default: 'true'
 outputs:
   decision:
     description: 'The evaluation decision (allow/deny/hold/escalate). Set for single-eval path only.'
@@ -298,6 +340,15 @@ outputs:
     description: |
       Evidence export record ID returned by POST /v1/orgs/{orgId}/evidence-exports.
       Empty string when evidence-bundle is 'false' or the call was skipped / failed.
+  # ── VQP Re-Derivation outputs ─────────────────────────────────────────────
+  vqp-hash-match:
+    description: '"true" when the re-derived SHA-256 hash matches the stored prompt_hash; "false" on integrity violation (vqp-verify mode only).'
+  vqp-score-delta:
+    description: 'Numeric score delta between the rerun score and the original snapshot score. Empty string when vqp-rerun is "false" (vqp-verify mode only).'
+  vqp-verdict-changed:
+    description: '"true" when the verdict flipped between the original snapshot and the AI rerun (vqp-verify mode only).'
+  vqp-audit-id:
+    description: 'Audit log entry ID written by v1-verify-vqp for this re-derivation run (vqp-verify mode only).'
 runs:
   using: 'node24'
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -1311,6 +1311,40 @@ async function callPostDeployEvidenceBundle(args, log, timeoutMs = 3e4) {
   }
 }
 
+// src/vqpVerify.ts
+async function runVqpVerify(inputs, fetchFn = globalThis.fetch) {
+  const base = inputs.supabaseUrl.replace(/\/$/, "");
+  const url = `${base}/functions/v1/v1-verify-vqp`;
+  const res = await fetchFn(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${inputs.serviceRoleKey}`
+    },
+    body: JSON.stringify({
+      snapshot_id: inputs.snapshotId,
+      rerun: inputs.rerun
+    })
+  });
+  const text = await res.text();
+  if (!res.ok) {
+    throw new Error(`v1-verify-vqp failed (${res.status}): ${text.slice(0, 400)}`);
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    throw new Error(`v1-verify-vqp returned non-JSON: ${text.slice(0, 200)}`);
+  }
+  const body = parsed.success && parsed.data ? parsed.data : parsed;
+  return {
+    hashMatch: body.hash_match === true,
+    scoreDelta: body.score_delta !== void 0 ? body.score_delta : null,
+    verdictChanged: body.verdict_changed === true,
+    auditId: body.audit_id ?? ""
+  };
+}
+
 // src/index.ts
 function getApiKey() {
   const apiKey = (process.env["ATLASENT_API_KEY"] ?? "").trim();
@@ -1746,9 +1780,103 @@ async function runReleaseModeStep() {
     return;
   }
 }
+async function runVqpVerifyStep() {
+  const snapshotId = getInput("vqp-snapshot-id", true);
+  const supabaseUrl = getInput("vqp-supabase-url") || (process.env["ATLASENT_SUPABASE_URL"] ?? "").trim();
+  if (!supabaseUrl) {
+    setFailed(
+      "vqp-verify: vqp-supabase-url input or ATLASENT_SUPABASE_URL env var is required"
+    );
+    return;
+  }
+  const serviceRoleKey = getInput("vqp-service-role-key") || (process.env["ATLASENT_SUPABASE_SERVICE_ROLE_KEY"] ?? "").trim();
+  if (!serviceRoleKey) {
+    setFailed(
+      "vqp-verify: vqp-service-role-key input or ATLASENT_SUPABASE_SERVICE_ROLE_KEY env var is required"
+    );
+    return;
+  }
+  maskValue(serviceRoleKey);
+  const rerun = getInput("vqp-rerun").toLowerCase() === "true";
+  const failOnDrift = getInput("vqp-fail-on-drift").toLowerCase() !== "false";
+  info(
+    `AtlaSent VQP verify: re-deriving snapshot ${snapshotId}` + (rerun ? " (with AI rerun)" : " (hash check only)")
+  );
+  const setEmptyVqpOutputs = () => {
+    setOutput("vqp-hash-match", "false");
+    setOutput("vqp-score-delta", "");
+    setOutput("vqp-verdict-changed", "false");
+    setOutput("vqp-audit-id", "");
+  };
+  let result;
+  try {
+    result = await runVqpVerify({ supabaseUrl, serviceRoleKey, snapshotId, rerun });
+  } catch (err) {
+    setEmptyVqpOutputs();
+    setFailed(
+      `AtlaSent VQP verify: ${err instanceof Error ? err.message : String(err)}`
+    );
+    return;
+  }
+  setOutput("vqp-hash-match", result.hashMatch ? "true" : "false");
+  setOutput(
+    "vqp-score-delta",
+    result.scoreDelta !== null ? String(result.scoreDelta) : ""
+  );
+  setOutput("vqp-verdict-changed", result.verdictChanged ? "true" : "false");
+  setOutput("vqp-audit-id", result.auditId);
+  info(`  Hash match:      ${result.hashMatch}`);
+  if (result.scoreDelta !== null) {
+    info(`  Score delta:     ${result.scoreDelta}`);
+    info(`  Verdict changed: ${result.verdictChanged}`);
+  }
+  info(`  Audit ID:        ${result.auditId}`);
+  appendToStepSummary(
+    [
+      "",
+      "## \u{1F9EC} AtlaSent VQP Re-Derivation Audit",
+      "",
+      `| Field | Value |`,
+      `|---|---|`,
+      `| Snapshot ID | \`${snapshotId}\` |`,
+      `| Hash Match | ${result.hashMatch ? "\u2705 `true`" : "\u274C `false`"} |`,
+      result.scoreDelta !== null ? `| Score Delta | \`${result.scoreDelta}\` |` : "| Score Delta | N/A (rerun not requested) |",
+      result.scoreDelta !== null ? `| Verdict Changed | ${result.verdictChanged ? "\u26A0\uFE0F `true`" : "\u2705 `false`"} |` : "| Verdict Changed | N/A |",
+      `| Audit ID | \`${result.auditId || "\u2014"}\` |`,
+      ""
+    ].join("\n")
+  );
+  if (!failOnDrift) {
+    if (!result.hashMatch) {
+      warning(
+        `VQP hash mismatch for snapshot ${snapshotId} (advisory; vqp-fail-on-drift=false)`
+      );
+    }
+    return;
+  }
+  if (!result.hashMatch) {
+    setFailed(
+      `AtlaSent VQP verify: hash mismatch for snapshot ${snapshotId} \u2014 prompt was mutated after snapshot creation (integrity violation). Investigate vqp_snapshots and vqp_audit_log for root cause.`
+    );
+    return;
+  }
+  if (result.verdictChanged) {
+    setFailed(
+      `AtlaSent VQP verify: verdict changed for snapshot ${snapshotId} \u2014 score drift detected (rerun verdict differs from original). Review score_delta in vqp_audit_log.`
+    );
+    return;
+  }
+  info(
+    `AtlaSent VQP verify: integrity confirmed for snapshot ${snapshotId}` + (rerun ? " \u2014 no score drift" : "")
+  );
+}
 async function run() {
   if (getInput("release-mode") === "register-and-verify") {
     await runReleaseModeStep();
+    return;
+  }
+  if (getInput("vqp-snapshot-id")) {
+    await runVqpVerifyStep();
     return;
   }
   const apiKey = getApiKey();

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,8 @@
 // Routing (in priority order):
 //   release-mode set      → POST-deploy candidate registration + verify
 //                           against atlasent-control-plane /v1/release/*
+//   vqp-snapshot-id set   → VQP re-derivation audit (hash check + optional
+//                           AI rerun drift detection) via v1-verify-vqp
 //   policy-sync=true      → v1-policy-sync (post bundle, fail CI on rejection)
 //   evaluations input set → v2.1 batch path via runV21()
 //   single action input   → @atlasent/enforce (canonical enforcement wrapper)
@@ -39,6 +41,7 @@ import {
   PRODUCTION_DEPLOY_ACTION,
   normalizeProtectedAction,
 } from "./canonicalAction";
+import { runVqpVerify } from "./vqpVerify";
 
 function getApiKey(): string {
   const apiKey = (process.env["ATLASENT_API_KEY"] ?? "").trim();
@@ -627,6 +630,126 @@ async function runReleaseModeStep(): Promise<void> {
 }
 
 // ---------------------------------------------------------------------------
+// VQP re-derivation audit step
+// ---------------------------------------------------------------------------
+
+async function runVqpVerifyStep(): Promise<void> {
+  const snapshotId = getInput("vqp-snapshot-id", true);
+  const supabaseUrl =
+    getInput("vqp-supabase-url") ||
+    (process.env["ATLASENT_SUPABASE_URL"] ?? "").trim();
+  if (!supabaseUrl) {
+    setFailed(
+      "vqp-verify: vqp-supabase-url input or ATLASENT_SUPABASE_URL env var is required",
+    );
+    return;
+  }
+  const serviceRoleKey =
+    getInput("vqp-service-role-key") ||
+    (process.env["ATLASENT_SUPABASE_SERVICE_ROLE_KEY"] ?? "").trim();
+  if (!serviceRoleKey) {
+    setFailed(
+      "vqp-verify: vqp-service-role-key input or ATLASENT_SUPABASE_SERVICE_ROLE_KEY env var is required",
+    );
+    return;
+  }
+  maskValue(serviceRoleKey);
+
+  const rerun = getInput("vqp-rerun").toLowerCase() === "true";
+  const failOnDrift = getInput("vqp-fail-on-drift").toLowerCase() !== "false";
+
+  info(
+    `AtlaSent VQP verify: re-deriving snapshot ${snapshotId}` +
+      (rerun ? " (with AI rerun)" : " (hash check only)"),
+  );
+
+  const setEmptyVqpOutputs = (): void => {
+    setOutput("vqp-hash-match", "false");
+    setOutput("vqp-score-delta", "");
+    setOutput("vqp-verdict-changed", "false");
+    setOutput("vqp-audit-id", "");
+  };
+
+  let result;
+  try {
+    result = await runVqpVerify({ supabaseUrl, serviceRoleKey, snapshotId, rerun });
+  } catch (err) {
+    setEmptyVqpOutputs();
+    setFailed(
+      `AtlaSent VQP verify: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return;
+  }
+
+  setOutput("vqp-hash-match", result.hashMatch ? "true" : "false");
+  setOutput(
+    "vqp-score-delta",
+    result.scoreDelta !== null ? String(result.scoreDelta) : "",
+  );
+  setOutput("vqp-verdict-changed", result.verdictChanged ? "true" : "false");
+  setOutput("vqp-audit-id", result.auditId);
+
+  info(`  Hash match:      ${result.hashMatch}`);
+  if (result.scoreDelta !== null) {
+    info(`  Score delta:     ${result.scoreDelta}`);
+    info(`  Verdict changed: ${result.verdictChanged}`);
+  }
+  info(`  Audit ID:        ${result.auditId}`);
+
+  appendToStepSummary(
+    [
+      "",
+      "## 🧬 AtlaSent VQP Re-Derivation Audit",
+      "",
+      `| Field | Value |`,
+      `|---|---|`,
+      `| Snapshot ID | \`${snapshotId}\` |`,
+      `| Hash Match | ${result.hashMatch ? "✅ \`true\`" : "❌ \`false\`"} |`,
+      result.scoreDelta !== null
+        ? `| Score Delta | \`${result.scoreDelta}\` |`
+        : "| Score Delta | N/A (rerun not requested) |",
+      result.scoreDelta !== null
+        ? `| Verdict Changed | ${result.verdictChanged ? "⚠️ \`true\`" : "✅ \`false\`"} |`
+        : "| Verdict Changed | N/A |",
+      `| Audit ID | \`${result.auditId || "—"}\` |`,
+      "",
+    ].join("\n"),
+  );
+
+  if (!failOnDrift) {
+    if (!result.hashMatch) {
+      warning(
+        `VQP hash mismatch for snapshot ${snapshotId} (advisory; vqp-fail-on-drift=false)`,
+      );
+    }
+    return;
+  }
+
+  if (!result.hashMatch) {
+    setFailed(
+      `AtlaSent VQP verify: hash mismatch for snapshot ${snapshotId} — ` +
+        `prompt was mutated after snapshot creation (integrity violation). ` +
+        `Investigate vqp_snapshots and vqp_audit_log for root cause.`,
+    );
+    return;
+  }
+
+  if (result.verdictChanged) {
+    setFailed(
+      `AtlaSent VQP verify: verdict changed for snapshot ${snapshotId} — ` +
+        `score drift detected (rerun verdict differs from original). ` +
+        `Review score_delta in vqp_audit_log.`,
+    );
+    return;
+  }
+
+  info(
+    `AtlaSent VQP verify: integrity confirmed for snapshot ${snapshotId}` +
+      (rerun ? " — no score drift" : ""),
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
 
@@ -637,6 +760,14 @@ export async function run(): Promise<void> {
   // paths' input requirements.
   if (getInput("release-mode") === "register-and-verify") {
     await runReleaseModeStep();
+    return;
+  }
+
+  // ── VQP re-derivation audit path ────────────────────────────────────────────
+  // Runs directly against the Supabase edge functions via service role key.
+  // Does NOT require ATLASENT_API_KEY.
+  if (getInput("vqp-snapshot-id")) {
+    await runVqpVerifyStep();
     return;
   }
 

--- a/src/vqpVerify.ts
+++ b/src/vqpVerify.ts
@@ -1,0 +1,83 @@
+// VQP re-derivation audit — CI enforcement step.
+//
+// Calls v1-verify-vqp to re-derive the VQP prompt from DB rules, compute
+// its SHA-256 hash, compare to the stored prompt_hash, and optionally
+// re-run the AI to detect score drift.
+//
+// Fails the job when:
+//   - hash_match = false  → prompt was mutated (integrity violation)
+//   - verdict_changed = true AND vqp-fail-on-drift = true (default)
+//
+// API:
+//   POST /functions/v1/v1-verify-vqp
+//   Authorization: Bearer <service-role-key>
+//   Body: { snapshot_id: string, rerun?: boolean }
+//
+//   Response (Supabase ok() envelope or bare):
+//   { hash_match: boolean, rerun_score?: number, score_delta?: number,
+//     verdict_changed?: boolean, audit_id?: string }
+
+export interface VqpVerifyInputs {
+  supabaseUrl: string;
+  serviceRoleKey: string;
+  snapshotId: string;
+  rerun: boolean;
+}
+
+export interface VqpVerifyResult {
+  hashMatch: boolean;
+  scoreDelta: number | null;
+  verdictChanged: boolean;
+  auditId: string;
+}
+
+interface VqpVerifyBody {
+  hash_match?: boolean;
+  rerun_score?: number;
+  score_delta?: number;
+  verdict_changed?: boolean;
+  audit_id?: string;
+}
+
+export async function runVqpVerify(
+  inputs: VqpVerifyInputs,
+  fetchFn: typeof fetch = globalThis.fetch,
+): Promise<VqpVerifyResult> {
+  const base = inputs.supabaseUrl.replace(/\/$/, '');
+  const url = `${base}/functions/v1/v1-verify-vqp`;
+
+  const res = await fetchFn(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${inputs.serviceRoleKey}`,
+    },
+    body: JSON.stringify({
+      snapshot_id: inputs.snapshotId,
+      rerun: inputs.rerun,
+    }),
+  });
+
+  const text = await res.text();
+  if (!res.ok) {
+    throw new Error(`v1-verify-vqp failed (${res.status}): ${text.slice(0, 400)}`);
+  }
+
+  let parsed: VqpVerifyBody & { data?: VqpVerifyBody; success?: boolean };
+  try {
+    parsed = JSON.parse(text) as typeof parsed;
+  } catch {
+    throw new Error(`v1-verify-vqp returned non-JSON: ${text.slice(0, 200)}`);
+  }
+
+  // Unwrap Supabase ok() envelope when present.
+  const body: VqpVerifyBody =
+    parsed.success && parsed.data ? parsed.data : parsed;
+
+  return {
+    hashMatch: body.hash_match === true,
+    scoreDelta: body.score_delta !== undefined ? body.score_delta : null,
+    verdictChanged: body.verdict_changed === true,
+    auditId: body.audit_id ?? '',
+  };
+}


### PR DESCRIPTION
## Summary

Implements Delta VQP Phase 3 re-derivation audit as a new action mode.

- **`src/vqpVerify.ts`** — pure `runVqpVerify()` function that POSTs `{ snapshot_id, rerun }` to `POST ${supabaseUrl}/functions/v1/v1-verify-vqp` and returns `{ hashMatch, scoreDelta, verdictChanged, auditId }`
- **`src/index.ts`** — `runVqpVerifyStep()` wired into `run()` before the `getApiKey()` call; triggered when `vqp-snapshot-id` input is present
- **`action.yml`** — 5 new inputs (`vqp-snapshot-id`, `vqp-supabase-url`, `vqp-service-role-key`, `vqp-rerun`, `vqp-fail-on-drift`) and 4 new outputs (`vqp-hash-match`, `vqp-score-delta`, `vqp-verdict-changed`, `vqp-audit-id`)

## Behaviour

| Condition | Job result |
|-----------|-----------|
| `hash_match = false` (integrity violation) | ❌ fail |
| `verdict_changed = true` AND `vqp-fail-on-drift: true` | ❌ fail |
| `score_delta != 0` only, no verdict flip | ✅ pass (delta surfaced in summary) |
| all clean | ✅ pass |

The step writes a job summary table with hash match / score delta / verdict changed / audit ID regardless of pass/fail.

## Example usage

```yaml
- uses: atlasent-systems-inc/atlasent-action@main
  with:
    vqp-snapshot-id: ${{ steps.snapshot.outputs.snapshot_id }}
    vqp-supabase-url: ${{ vars.ATLASENT_SUPABASE_URL }}
    vqp-service-role-key: ${{ secrets.ATLASENT_SUPABASE_SERVICE_ROLE_KEY }}
    vqp-rerun: 'true'
    vqp-fail-on-drift: 'true'
```

## Test plan

- [ ] `vqp-snapshot-id` not set → existing action modes unaffected
- [ ] Hash mismatch → job fails with integrity violation message
- [ ] Score drift + verdict flip + `vqp-fail-on-drift: true` → job fails
- [ ] Score drift + no verdict flip → job passes, delta in summary
- [ ] All clean → job passes

https://claude.ai/code/session_01Fd4bLYttWcp6TtWzqChVe2

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fd4bLYttWcp6TtWzqChVe2)_