### PR TITLE
feat(deploy-gate): Slack notifications and PR comments on deny

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -173,6 +173,28 @@ inputs:
     description: 'Shortcut for governance-fail-on-severity: blocker.'
     required: false
     default: 'false'
+  # ── Outbound notifications ───────────────────────────────────────────────────────────
+  slack-webhook:
+    description: |
+      Slack Incoming Webhook URL. When set, the action posts an informational
+      Block Kit message to this URL whenever the deploy gate returns deny,
+      hold, or escalate. This is outbound notification only — no interactive
+      approval buttons. For in-flow approvals, use the AtlaSent Slack Approval
+      Bot instead (configured in the AtlaSent console).
+      Best-effort: webhook failures are logged as warnings and never block or
+      alter the gate decision.
+    required: false
+    default: ''
+  pr-comment-on-deny:
+    description: |
+      When "true" (default), post a comment to the pull request when the gate
+      returns deny, hold, or escalate and a PR number is detected in the
+      workflow context. Requires: permissions: pull-requests: write in the
+      workflow, and GITHUB_TOKEN must be available.
+      Best-effort: comment failures are logged as warnings and never block or
+      alter the gate decision. Set to "false" to suppress PR comments.
+    required: false
+    default: 'true'
   # ── Post-deploy compliance evidence bundle ────────────────────────────────────────────
   evidence-bundle:
     description: |

--- a/dist/index.js
+++ b/dist/index.js
@@ -2059,6 +2059,43 @@ async function run() {
     setOutput("decisions", decisionsJson);
     setOutput("verified", allVerified ? "true" : "false");
     if (result.failed) {
+      {
+        const gh2 = getGitHubContext();
+        const runUrl = `${gh2.server_url}/${gh2.repository}/actions/runs/${gh2.run_id}`;
+        const slackWebhook = getInput("slack-webhook");
+        const prCommentEnabled = getInput("pr-comment-on-deny").toLowerCase() !== "false";
+        const blockedDecisions = result.decisions.filter(
+          (d2) => d2.decision === "deny" || d2.decision === "hold" || d2.decision === "escalate"
+        );
+        const worstDecision = blockedDecisions.some((d2) => d2.decision === "deny") ? "deny" : blockedDecisions.some((d2) => d2.decision === "escalate") ? "escalate" : "hold";
+        const batchActor = getInput("actor") || "unknown";
+        const batchEnv = resolveEnvironment(getInput("environment"), gh2.ref, apiKey);
+        const reasonSummary = `${blockedDecisions.length} of ${result.decisions.length} evaluation(s) blocked (${worstDecision})`;
+        if (slackWebhook) {
+          await notifySlack(slackWebhook, {
+            decision: worstDecision,
+            action: "batch evaluation",
+            actor: batchActor,
+            environment: batchEnv,
+            reason: reasonSummary,
+            runUrl
+          });
+        }
+        if (prCommentEnabled && gh2.pr_number) {
+          await postPRComment({
+            repository: gh2.repository,
+            prNumber: gh2.pr_number,
+            body: buildGateDenyComment({
+              decision: worstDecision,
+              reason: reasonSummary,
+              action: "batch evaluation",
+              actor: batchActor,
+              environment: batchEnv,
+              runUrl
+            })
+          });
+        }
+      }
       setFailed(
         `AtlaSent Gate: one or more evaluations were not allowed (deny/hold/escalate). See 'decisions' output for details.`
       );

--- a/dist/index.js
+++ b/dist/index.js
@@ -1428,6 +1428,124 @@ async function postCommitStatus(args) {
     );
   }
 }
+async function notifySlack(webhookUrl, opts) {
+  const emoji = opts.decision === "deny" ? ":no_entry:" : opts.decision === "hold" ? ":hourglass_flowing_sand:" : opts.decision === "escalate" ? ":rotating_light:" : ":warning:";
+  const label = opts.decision === "deny" ? "DENIED" : opts.decision === "hold" ? "ON HOLD" : opts.decision === "escalate" ? "ESCALATED" : "BLOCKED";
+  const fields = [
+    { type: "mrkdwn", text: `*Actor:*
+${opts.actor}` },
+    { type: "mrkdwn", text: `*Environment:*
+${opts.environment}` }
+  ];
+  if (opts.evaluationId) {
+    fields.push({ type: "mrkdwn", text: `*Evaluation ID:*
+${opts.evaluationId}` });
+  }
+  if (opts.auditHash) {
+    fields.push({
+      type: "mrkdwn",
+      text: `*Audit hash:*
+\`${opts.auditHash.slice(0, 16)}\u2026\``
+    });
+  }
+  const payload = {
+    text: `${emoji} AtlaSent Deploy Gate ${label}: ${opts.action} (${opts.environment})`,
+    blocks: [
+      {
+        type: "header",
+        text: { type: "plain_text", text: `${emoji} AtlaSent: Deploy ${label}`, emoji: true }
+      },
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: `*Action:* \`${opts.action}\`
+*Reason:* ${opts.reason}`
+        }
+      },
+      { type: "section", fields },
+      {
+        type: "actions",
+        elements: [
+          {
+            type: "button",
+            text: { type: "plain_text", text: "View Run", emoji: false },
+            url: opts.runUrl
+          }
+        ]
+      }
+    ]
+  };
+  try {
+    const res = await fetch(webhookUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload)
+    });
+    if (!res.ok) {
+      warning(`AtlaSent: Slack notification failed (${res.status}) \u2014 advisory, non-blocking`);
+    }
+  } catch (err) {
+    warning(
+      `AtlaSent: Slack notification error (advisory, non-blocking): ${err instanceof Error ? err.message : String(err)}`
+    );
+  }
+}
+function buildGateDenyComment(opts) {
+  const icon = opts.decision === "deny" ? "\u{1F534}" : opts.decision === "hold" ? "\u{1F7E1}" : opts.decision === "escalate" ? "\u{1F6A8}" : "\u274C";
+  const label = opts.decision === "deny" ? "DENIED" : opts.decision === "hold" ? "ON HOLD" : opts.decision === "escalate" ? "ESCALATED" : "BLOCKED";
+  const lines = [
+    `## ${icon} AtlaSent Deploy Gate \u2014 ${label}`,
+    "",
+    `The AtlaSent gate blocked \`${opts.action}\` for actor **${opts.actor}** in **${opts.environment}**.`,
+    "",
+    `**Decision:** \`${opts.decision}\``,
+    `**Reason:** ${opts.reason}`
+  ];
+  if (opts.evaluationId) {
+    lines.push(`**Evaluation ID:** \`${opts.evaluationId}\``);
+  }
+  if (opts.auditHash) {
+    lines.push(`**Audit hash:** \`${opts.auditHash.slice(0, 24)}\u2026\``);
+  }
+  lines.push("", `[View workflow run](${opts.runUrl})`);
+  if (opts.decision === "hold" || opts.decision === "escalate") {
+    lines.push(
+      "",
+      "> **Next step:** An authorized reviewer must approve this deployment in the [AtlaSent console](https://console.atlasent.io/approvals) or via the Slack Approval Bot."
+    );
+  }
+  return lines.join("\n");
+}
+async function postPRComment(args) {
+  const token = process.env["GITHUB_TOKEN"];
+  if (!token || !args.repository || !args.prNumber)
+    return;
+  const apiBase = process.env["GITHUB_API_URL"] ?? "https://api.github.com";
+  const url = `${apiBase}/repos/${args.repository}/issues/${args.prNumber}/comments`;
+  try {
+    const res = await fetch(url, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/vnd.github+json",
+        "Content-Type": "application/json",
+        "X-GitHub-Api-Version": "2022-11-28"
+      },
+      body: JSON.stringify({ body: args.body })
+    });
+    if (!res.ok) {
+      const text = await res.text().catch(() => "<unreadable>");
+      warning(
+        `AtlaSent: PR comment post failed (${res.status}): ${text.slice(0, 200)} \u2014 advisory, non-blocking`
+      );
+    }
+  } catch (err) {
+    warning(
+      `AtlaSent: PR comment post error (advisory, non-blocking): ${err instanceof Error ? err.message : String(err)}`
+    );
+  }
+}
 function getGitHubContext() {
   return {
     repository: process.env["GITHUB_REPOSITORY"] ?? "",
@@ -1437,7 +1555,7 @@ function getGitHubContext() {
     run_number: process.env["GITHUB_RUN_NUMBER"] ?? "",
     workflow: process.env["GITHUB_WORKFLOW"] ?? "",
     event_name: process.env["GITHUB_EVENT_NAME"] ?? "",
-    pr_number: process.env["GITHUB_REF"]?.match(/^\/refs\/pull\/(\d+)\//)?.[1],
+    pr_number: process.env["GITHUB_REF"]?.match(/^refs\/pull\/(\d+)\//)?.[1],
     server_url: process.env["GITHUB_SERVER_URL"] ?? "https://github.com"
   };
 }
@@ -2038,6 +2156,42 @@ async function run() {
         });
       }
       emitFinancialGovernanceAdvisory(actionType, actor, orgId);
+      {
+        const slackWebhook = getInput("slack-webhook");
+        const runUrl = `${gh.server_url}/${gh.repository}/actions/runs/${gh.run_id}`;
+        const decisionStr = err.decision?.decision ?? "error";
+        const isActionable = decisionStr === "deny" || decisionStr === "hold" || decisionStr === "escalate";
+        const reason = decisionStr === "deny" ? err.decision?.denyReason ?? "no reason provided" : decisionStr === "hold" ? err.decision?.holdReason ?? "awaiting approval" : decisionStr === "escalate" ? "escalated \u2014 manual review required" : err.message.slice(0, 200);
+        if (slackWebhook && isActionable) {
+          await notifySlack(slackWebhook, {
+            decision: decisionStr,
+            action: actionType,
+            actor,
+            environment,
+            reason,
+            runUrl,
+            evaluationId: err.decision?.evaluationId,
+            auditHash: err.decision?.auditHash
+          });
+        }
+        const prCommentEnabled = getInput("pr-comment-on-deny").toLowerCase() !== "false";
+        if (prCommentEnabled && gh.pr_number && isActionable) {
+          await postPRComment({
+            repository: gh.repository,
+            prNumber: gh.pr_number,
+            body: buildGateDenyComment({
+              decision: decisionStr,
+              reason,
+              action: actionType,
+              actor,
+              environment,
+              runUrl,
+              evaluationId: err.decision?.evaluationId,
+              auditHash: err.decision?.auditHash
+            })
+          });
+        }
+      }
       switch (err.phase) {
         case "evaluate":
           setFailed(

--- a/src/index.ts
+++ b/src/index.ts
@@ -173,6 +173,194 @@ async function postCommitStatus(args: {
 }
 
 // ---------------------------------------------------------------------------
+// Outbound Slack notification — informational, not interactive.
+// Fires on deny / hold / escalate when the slack-webhook input is set.
+// Best-effort: never blocks or alters the gate decision.
+// ---------------------------------------------------------------------------
+async function notifySlack(
+  webhookUrl: string,
+  opts: {
+    decision: string;
+    action: string;
+    actor: string;
+    environment: string;
+    reason: string;
+    runUrl: string;
+    evaluationId?: string;
+    auditHash?: string;
+  },
+): Promise<void> {
+  const emoji =
+    opts.decision === "deny"
+      ? ":no_entry:"
+      : opts.decision === "hold"
+        ? ":hourglass_flowing_sand:"
+        : opts.decision === "escalate"
+          ? ":rotating_light:"
+          : ":warning:";
+  const label =
+    opts.decision === "deny"
+      ? "DENIED"
+      : opts.decision === "hold"
+        ? "ON HOLD"
+        : opts.decision === "escalate"
+          ? "ESCALATED"
+          : "BLOCKED";
+
+  const fields: { type: "mrkdwn"; text: string }[] = [
+    { type: "mrkdwn", text: `*Actor:*\n${opts.actor}` },
+    { type: "mrkdwn", text: `*Environment:*\n${opts.environment}` },
+  ];
+  if (opts.evaluationId) {
+    fields.push({ type: "mrkdwn", text: `*Evaluation ID:*\n${opts.evaluationId}` });
+  }
+  if (opts.auditHash) {
+    fields.push({
+      type: "mrkdwn",
+      text: `*Audit hash:*\n\`${opts.auditHash.slice(0, 16)}…\``,
+    });
+  }
+
+  const payload = {
+    text: `${emoji} AtlaSent Deploy Gate ${label}: ${opts.action} (${opts.environment})`,
+    blocks: [
+      {
+        type: "header",
+        text: { type: "plain_text", text: `${emoji} AtlaSent: Deploy ${label}`, emoji: true },
+      },
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: `*Action:* \`${opts.action}\`\n*Reason:* ${opts.reason}`,
+        },
+      },
+      { type: "section", fields },
+      {
+        type: "actions",
+        elements: [
+          {
+            type: "button",
+            text: { type: "plain_text", text: "View Run", emoji: false },
+            url: opts.runUrl,
+          },
+        ],
+      },
+    ],
+  };
+
+  try {
+    const res = await fetch(webhookUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+    if (!res.ok) {
+      warning(`AtlaSent: Slack notification failed (${res.status}) — advisory, non-blocking`);
+    }
+  } catch (err) {
+    warning(
+      `AtlaSent: Slack notification error (advisory, non-blocking): ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// PR comment — posted on deny / hold / escalate when a PR number is detected
+// and pr-comment-on-deny is not "false".
+// Best-effort: never blocks or alters the gate decision.
+// ---------------------------------------------------------------------------
+function buildGateDenyComment(opts: {
+  decision: string;
+  reason: string;
+  action: string;
+  actor: string;
+  environment: string;
+  runUrl: string;
+  evaluationId?: string;
+  auditHash?: string;
+}): string {
+  const icon =
+    opts.decision === "deny"
+      ? "🔴"
+      : opts.decision === "hold"
+        ? "🟡"
+        : opts.decision === "escalate"
+          ? "🚨"
+          : "❌";
+  const label =
+    opts.decision === "deny"
+      ? "DENIED"
+      : opts.decision === "hold"
+        ? "ON HOLD"
+        : opts.decision === "escalate"
+          ? "ESCALATED"
+          : "BLOCKED";
+
+  const lines = [
+    `## ${icon} AtlaSent Deploy Gate — ${label}`,
+    "",
+    `The AtlaSent gate blocked \`${opts.action}\` for actor **${opts.actor}** in **${opts.environment}**.`,
+    "",
+    `**Decision:** \`${opts.decision}\``,
+    `**Reason:** ${opts.reason}`,
+  ];
+  if (opts.evaluationId) {
+    lines.push(`**Evaluation ID:** \`${opts.evaluationId}\``);
+  }
+  if (opts.auditHash) {
+    lines.push(`**Audit hash:** \`${opts.auditHash.slice(0, 24)}…\``);
+  }
+  lines.push("", `[View workflow run](${opts.runUrl})`);
+  if (opts.decision === "hold" || opts.decision === "escalate") {
+    lines.push(
+      "",
+      "> **Next step:** An authorized reviewer must approve this deployment in the [AtlaSent console](https://console.atlasent.io/approvals) or via the Slack Approval Bot.",
+    );
+  }
+  return lines.join("\n");
+}
+
+async function postPRComment(args: {
+  repository: string;
+  prNumber: string;
+  body: string;
+}): Promise<void> {
+  const token = process.env["GITHUB_TOKEN"];
+  if (!token || !args.repository || !args.prNumber) return;
+
+  const apiBase = process.env["GITHUB_API_URL"] ?? "https://api.github.com";
+  const url = `${apiBase}/repos/${args.repository}/issues/${args.prNumber}/comments`;
+
+  try {
+    const res = await fetch(url, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/vnd.github+json",
+        "Content-Type": "application/json",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+      body: JSON.stringify({ body: args.body }),
+    });
+    if (!res.ok) {
+      const text = await res.text().catch(() => "<unreadable>");
+      warning(
+        `AtlaSent: PR comment post failed (${res.status}): ${text.slice(0, 200)} — advisory, non-blocking`,
+      );
+    }
+  } catch (err) {
+    warning(
+      `AtlaSent: PR comment post error (advisory, non-blocking): ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
 // GitHub context
 // ---------------------------------------------------------------------------
 
@@ -197,7 +385,7 @@ function getGitHubContext(): GitHubContext {
     run_number: process.env["GITHUB_RUN_NUMBER"] ?? "",
     workflow: process.env["GITHUB_WORKFLOW"] ?? "",
     event_name: process.env["GITHUB_EVENT_NAME"] ?? "",
-    pr_number: process.env["GITHUB_REF"]?.match(/^\/refs\/pull\/(\d+)\//)?.[1],
+    pr_number: process.env["GITHUB_REF"]?.match(/^refs\/pull\/(\d+)\//)?.[1],
     server_url: process.env["GITHUB_SERVER_URL"] ?? "https://github.com",
   };
 }
@@ -968,6 +1156,56 @@ export async function run(): Promise<void> {
       }
 
       emitFinancialGovernanceAdvisory(actionType, actor, orgId);
+
+      // ── Outbound Slack notification + PR comment (best-effort, advisory) ──
+      {
+        const slackWebhook = getInput("slack-webhook");
+        const runUrl = `${gh.server_url}/${gh.repository}/actions/runs/${gh.run_id}`;
+        const decisionStr = err.decision?.decision ?? "error";
+        const isActionable =
+          decisionStr === "deny" || decisionStr === "hold" || decisionStr === "escalate";
+
+        const reason =
+          decisionStr === "deny"
+            ? (err.decision?.denyReason ?? "no reason provided")
+            : decisionStr === "hold"
+              ? (err.decision?.holdReason ?? "awaiting approval")
+              : decisionStr === "escalate"
+                ? "escalated — manual review required"
+                : err.message.slice(0, 200);
+
+        if (slackWebhook && isActionable) {
+          await notifySlack(slackWebhook, {
+            decision: decisionStr,
+            action: actionType,
+            actor,
+            environment,
+            reason,
+            runUrl,
+            evaluationId: err.decision?.evaluationId,
+            auditHash: err.decision?.auditHash,
+          });
+        }
+
+        const prCommentEnabled =
+          getInput("pr-comment-on-deny").toLowerCase() !== "false";
+        if (prCommentEnabled && gh.pr_number && isActionable) {
+          await postPRComment({
+            repository: gh.repository,
+            prNumber: gh.pr_number,
+            body: buildGateDenyComment({
+              decision: decisionStr,
+              reason,
+              action: actionType,
+              actor,
+              environment,
+              runUrl,
+              evaluationId: err.decision?.evaluationId,
+              auditHash: err.decision?.auditHash,
+            }),
+          });
+        }
+      }
 
       switch (err.phase) {
         case "evaluate":

--- a/src/index.ts
+++ b/src/index.ts
@@ -1045,6 +1045,52 @@ export async function run(): Promise<void> {
     setOutput("verified", allVerified ? "true" : "false");
 
     if (result.failed) {
+      // Fire Slack + PR-comment notifications for the batch deny path, mirroring
+      // the single-eval path. Aggregate across all blocked decisions.
+      {
+        const gh = getGitHubContext();
+        const runUrl = `${gh.server_url}/${gh.repository}/actions/runs/${gh.run_id}`;
+        const slackWebhook = getInput("slack-webhook");
+        const prCommentEnabled = getInput("pr-comment-on-deny").toLowerCase() !== "false";
+
+        const blockedDecisions = result.decisions.filter(
+          (d) => d.decision === "deny" || d.decision === "hold" || d.decision === "escalate",
+        );
+        const worstDecision: string = blockedDecisions.some((d) => d.decision === "deny")
+          ? "deny"
+          : blockedDecisions.some((d) => d.decision === "escalate")
+            ? "escalate"
+            : "hold";
+        const batchActor = getInput("actor") || "unknown";
+        const batchEnv = resolveEnvironment(getInput("environment"), gh.ref, apiKey);
+        const reasonSummary = `${blockedDecisions.length} of ${result.decisions.length} evaluation(s) blocked (${worstDecision})`;
+
+        if (slackWebhook) {
+          await notifySlack(slackWebhook, {
+            decision: worstDecision,
+            action: "batch evaluation",
+            actor: batchActor,
+            environment: batchEnv,
+            reason: reasonSummary,
+            runUrl,
+          });
+        }
+        if (prCommentEnabled && gh.pr_number) {
+          await postPRComment({
+            repository: gh.repository,
+            prNumber: gh.pr_number,
+            body: buildGateDenyComment({
+              decision: worstDecision,
+              reason: reasonSummary,
+              action: "batch evaluation",
+              actor: batchActor,
+              environment: batchEnv,
+              runUrl,
+            }),
+          });
+        }
+      }
+
       setFailed(
         `AtlaSent Gate: one or more evaluations were not allowed (deny/hold/escalate). See 'decisions' output for details.`,
       );


### PR DESCRIPTION
## Summary

- Add `slack-webhook` input: posts an informational Block Kit message to a Slack Incoming Webhook URL when the deploy gate returns `deny`, `hold`, or `escalate`. Best-effort — webhook failures are logged as warnings and never block the gate decision.
- Add `pr-comment-on-deny` input (default `true`): when a PR number is detected in the workflow context, posts a formatted comment to the PR with the decision, reason, evaluation ID, audit hash, and a link to the run. For `hold`/`escalate` outcomes, includes a direct link to the AtlaSent console approvals queue.
- Fix `pr_number` extraction regex — the previous pattern had a spurious leading `/` that prevented it from matching GitHub's `refs/pull/N/merge` format.

These notifications are **outbound only** (no interactive approval buttons). For in-flow approvals, the existing Slack Approval Bot continues to handle `hold`/`escalate` decisions.

## Test plan

- [ ] `slack-webhook` unset → no notification, gate behaves identically
- [ ] `slack-webhook` set + decision `allow` → no Slack message posted
- [ ] `slack-webhook` set + decision `deny` → Block Kit message with reason, evaluation ID, run link
- [ ] `slack-webhook` set + decision `hold` → Block Kit message with hold reason and console link
- [ ] `slack-webhook` set + decision `escalate` → Block Kit message with escalation reason
- [ ] Slack webhook URL is invalid / returns non-200 → warning emitted, gate not blocked
- [ ] `pr-comment-on-deny: 'false'` → no PR comment posted
- [ ] `pr-comment-on-deny: 'true'` + PR context + deny → comment posted to PR
- [ ] `pr-comment-on-deny: 'true'` + no PR context → no comment attempt, no warning

https://claude.ai/code/session_01Vi3xv7nGkgpgPkP5S8zBQE

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vi3xv7nGkgpgPkP5S8zBQE)_