### PR TITLE
docs: document required state_snapshot context field

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,38 @@ Push to main → AtlaSent evaluates → permit issued → deploy
     target-id: api-service
     environment: live
     fail-on-deny: 'true'
-    context: '{"team": "platform", "service": "api"}'
+    context: |
+      {
+        "team": "platform",
+        "service": "api",
+        "state_snapshot": {
+          "source": "github-actions",
+          "complete": true,
+          "run_id": "${{ github.run_id }}"
+        }
+      }
 ```
+
+## Required context: `state_snapshot`
+
+All `production.deploy` evaluations (and all action classes in the AtlaSent system) **require a `state_snapshot` field** in the context. Omitting it results in an immediate `SNAPSHOT_REQUIRED` deny regardless of policy.
+
+Include it in the `context` JSON:
+
+```yaml
+context: |
+  {
+    "state_snapshot": {
+      "source": "github-actions",
+      "complete": true,
+      "run_id": "${{ github.run_id }}"
+    }
+  }
+```
+
+The `source` field identifies where the snapshot was captured (`github-actions`, `buildkite`, `jenkins`, etc.). The `complete: true` flag signals that the pre-deploy state was captured successfully. The action will pass it through to the AtlaSent evaluator exactly as provided.
+
+> **Why is this required?** AtlaSent enforces that every protected action is evaluated against a known, captured state — this closes the TOCTOU (time-of-check, time-of-use) window by proving the workflow observed the environment before the gate ran.
 
 ## Using Outputs
 


### PR DESCRIPTION
## Summary

- Add a dedicated **"Required context: `state_snapshot`"** section to the README explaining that all evaluate calls need `state_snapshot` in the context JSON
- Update the **Full Configuration** YAML example to include the field with `source`, `complete`, and `run_id` populated from GitHub Actions context variables
- Explain the TOCTOU rationale: AtlaSent requires proof that the workflow observed the environment before the gate ran

Without `state_snapshot`, every evaluate call to a current AtlaSent runtime returns `SNAPSHOT_REQUIRED` deny before policy evaluation — this is a silent first-use failure that would block every new customer during onboarding.

## Test plan

- [ ] Review README renders correctly on GitHub
- [ ] Verify the YAML example in Full Configuration is syntactically valid
- [ ] Confirm no existing functionality changed (docs-only PR)

https://claude.ai/code/session_01LswzwnoNPuYqy1kMb4qBG5

---
_Generated by [Claude Code](https://claude.ai/code/session_01LswzwnoNPuYqy1kMb4qBG5)_