### PR TITLE
fix(enforce): rebuild dist with state_snapshot; fix tsconfig for TS 5.9

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -99,17 +99,34 @@ var require_dist = __commonJS({
     exports2.EnforceError = EnforceError2;
     async function evaluate(config) {
       const apiUrl = (config.apiUrl ?? DEFAULT_API_URL).replace(/\/$/, "");
+      const rawContext = { ...config.context };
+      const contextSnapshot = rawContext["state_snapshot"];
+      delete rawContext["state_snapshot"];
       const payload = {
         action_type: config.action,
         actor_id: config.actor,
         context: {
+          // Keep environment in context for backward compat with older control plane versions.
           ...config.environment ? { environment: config.environment } : {},
           ...config.targetId ? { target_id: config.targetId } : {},
-          ...config.context
+          ...rawContext
         }
       };
-      if (config.targetId)
+      if (config.environment != null)
+        payload["environment"] = config.environment;
+      if (config.resource != null)
+        payload["resource"] = config.resource;
+      else if (config.targetId)
         payload["target_id"] = config.targetId;
+      if (config.current_state != null)
+        payload["current_state"] = config.current_state;
+      if (config.proposed_state != null)
+        payload["proposed_state"] = config.proposed_state;
+      if (config.execution_binding != null)
+        payload["execution_binding"] = config.execution_binding;
+      const snap = config.state_snapshot ?? contextSnapshot;
+      if (snap != null)
+        payload["state_snapshot"] = snap;
       let status;
       let body;
       try {
@@ -202,6 +219,9 @@ var require_dist = __commonJS({
         riskScore: extractRiskScore(raw),
         denyReason: raw["deny_reason"],
         holdReason: raw["hold_reason"],
+        risk_class: raw["risk_class"],
+        authority_basis: raw["authority_basis"],
+        escalation_id: raw["escalation_id"],
         chainEntry: raw["chain_entry"] ?? null,
         snapshot: raw["snapshot"] ?? null,
         auditHash: raw["audit_hash"]

--- a/packages/enforce/dist/index.d.ts
+++ b/packages/enforce/dist/index.d.ts
@@ -5,7 +5,35 @@ export interface EnforceConfig {
     actor: string;
     environment?: string;
     targetId?: string;
+    resource?: {
+        type: string;
+        id?: string;
+        attributes?: Record<string, unknown>;
+    };
+    current_state?: {
+        description: string;
+        attributes?: Record<string, unknown>;
+    };
+    proposed_state?: {
+        description: string;
+        attributes?: Record<string, unknown>;
+    };
+    execution_binding?: {
+        kind: string;
+        adapter_version?: string;
+        resource_id?: string;
+        enforcement_point?: string;
+    };
     context?: Record<string, unknown>;
+    /** Top-level body field required when the action class has requires_state_snapshot=true.
+     *  Must be sent alongside context, not nested inside it. */
+    state_snapshot?: {
+        source?: string;
+        source_kind?: string;
+        complete?: boolean;
+        run_id?: string;
+        payload?: unknown;
+    };
 }
 export interface Decision {
     decision: "allow" | "deny" | "hold" | "escalate";
@@ -15,6 +43,20 @@ export interface Decision {
     riskScore?: number;
     denyReason?: string;
     holdReason?: string;
+    /** Resolved risk class from the evaluation (critical / high / medium / low). */
+    risk_class?: string;
+    /** WHY this was allowed — kind + reference ID (policy, quorum, emergency, etc.). */
+    authority_basis?: {
+        kind: string;
+        reference?: string;
+        granted_by?: string;
+        rationale?: string;
+    };
+    /**
+     * Present iff decision === "hold". ID of the HITL escalation auto-created by
+     * the control plane. Poll GET /v1/hitl/{id} for resolution.
+     */
+    escalation_id?: string;
     /** v1.1 audit chain fields — present when the API returns them. */
     chainEntry?: Record<string, unknown> | null;
     snapshot?: Record<string, unknown> | null;

--- a/packages/enforce/dist/index.js
+++ b/packages/enforce/dist/index.js
@@ -30,17 +30,37 @@ exports.EnforceError = EnforceError;
 // ---------------------------------------------------------------------------
 async function evaluate(config) {
     const apiUrl = (config.apiUrl ?? DEFAULT_API_URL).replace(/\/$/, "");
+    // Separate state_snapshot out of context if the caller mistakenly nested it there.
+    const rawContext = { ...config.context };
+    const contextSnapshot = rawContext["state_snapshot"];
+    delete rawContext["state_snapshot"];
     const payload = {
         action_type: config.action,
         actor_id: config.actor,
         context: {
+            // Keep environment in context for backward compat with older control plane versions.
             ...(config.environment ? { environment: config.environment } : {}),
             ...(config.targetId ? { target_id: config.targetId } : {}),
-            ...config.context,
+            ...rawContext,
         },
     };
-    if (config.targetId)
+    // Top-level fields forwarded to the control plane's EvaluateRequest.
+    if (config.environment != null)
+        payload["environment"] = config.environment;
+    if (config.resource != null)
+        payload["resource"] = config.resource;
+    else if (config.targetId)
         payload["target_id"] = config.targetId;
+    if (config.current_state != null)
+        payload["current_state"] = config.current_state;
+    if (config.proposed_state != null)
+        payload["proposed_state"] = config.proposed_state;
+    if (config.execution_binding != null)
+        payload["execution_binding"] = config.execution_binding;
+    // state_snapshot is a top-level body field (EvaluateBody.state_snapshot), not inside context.
+    const snap = config.state_snapshot ?? contextSnapshot;
+    if (snap != null)
+        payload["state_snapshot"] = snap;
     let status;
     let body;
     try {
@@ -154,6 +174,9 @@ function mapDecision(raw) {
         riskScore: extractRiskScore(raw),
         denyReason: raw["deny_reason"],
         holdReason: raw["hold_reason"],
+        risk_class: raw["risk_class"],
+        authority_basis: raw["authority_basis"],
+        escalation_id: raw["escalation_id"],
         chainEntry: raw["chain_entry"] ?? null,
         snapshot: raw["snapshot"] ?? null,
         auditHash: raw["audit_hash"],

--- a/packages/enforce/tsconfig.json
+++ b/packages/enforce/tsconfig.json
@@ -3,12 +3,14 @@
     "target": "ES2022",
     "module": "commonjs",
     "moduleResolution": "node",
+    "ignoreDeprecations": "5.0",
     "strict": true,
     "esModuleInterop": true,
     "outDir": "dist",
     "rootDir": "src",
     "declaration": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "types": ["node"]
   },
   "include": ["src"],
   "exclude": ["src/__tests__"]


### PR DESCRIPTION
## Summary

- Rebuilds `packages/enforce/dist/index.d.ts` and `dist/index.js` to include the `state_snapshot` field added to `EnforceConfig` in the previous PR
- Fixes `packages/enforce/tsconfig.json` to add `"ignoreDeprecations": "5.0"` and `"types": ["node"]` so the package builds under TypeScript 5.9

## Why this is needed

PR #81 merged the `state_snapshot` source change in `packages/enforce/src/index.ts` but the `dist/` output was not rebuilt. The root `src/index.ts` references `EnforceConfig` from the workspace package, which resolves types from `dist/index.d.ts` (as declared in `package.json`). Without the rebuilt dist the `test-action-syntax` CI check fails with `TS2353: 'state_snapshot' does not exist in type 'EnforceConfig'`.

## Test plan

- [ ] `test-action-syntax` CI check passes (typecheck succeeds with rebuilt dist)
- [ ] `packages/enforce/dist/index.d.ts` contains the `state_snapshot` field

https://claude.ai/code/session_01LswzwnoNPuYqy1kMb4qBG5

---
_Generated by [Claude Code](https://claude.ai/code/session_01LswzwnoNPuYqy1kMb4qBG5)_