### PR TITLE
chore: add workflow to create v1 floating tag (points at v1.3.0)

### DIFF
--- a/.github/workflows/create-v1-tag.yml
+++ b/.github/workflows/create-v1-tag.yml
@@ -1,0 +1,22 @@
+name: Create v1 floating tag
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  create-tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create v1 floating tag pointing at v1.3.0
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git push origin dbc729d1c5bb88d15f67e19e0a67dc4d22f94606:refs/tags/v1 --force


### PR DESCRIPTION
## Summary\n\n- Adds `.github/workflows/create-v1-tag.yml` — a `workflow_dispatch` workflow that force-creates the `v1` floating tag pointing at commit `dbc729d` (the `v1.3.0` release)\n- Fixes broken `uses: atlasent/action@v1` in the value prop: without a `v1` ref, the snippet fails with \"couldn't find remote ref v1\"\n\n## How to ship\n\n1. Merge this PR\n2. Go to Actions → \"Create v1 floating tag\" → Run workflow (from `main`)\n3. Confirm `git ls-remote origin refs/tags/v1` resolves to `dbc729d`\n\n## Test plan\n\n- [ ] Merge to main\n- [ ] Trigger `create-v1-tag.yml` via Actions UI or API\n- [ ] Verify `atlasent/action@v1` resolves in a test workflow\n\nhttps://claude.ai/code/session_01Me7bscu1ffn7smjTnL5oKK

---
_Generated by [Claude Code](https://claude.ai/code/session_01Me7bscu1ffn7smjTnL5oKK)_