### PR TITLE
ci(release): gate release on AtlaSent permit before build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,19 @@ jobs:
         with:
           node-version: '20'
 
+      # ── AtlaSent release gate ─────────────────────────────────────────────
+      # Gate closed: if the permit is not verified the job exits here and
+      # nothing builds, signs, or publishes.
+      - name: AtlaSent release gate
+        uses: atlasent/action@v1
+        env:
+          ATLASENT_API_KEY: ${{ secrets.ATLASENT_API_KEY }}
+        with:
+          action: production.release
+          actor: ${{ github.actor }}
+          environment: production
+          context: '{"ref": "${{ github.ref }}", "repo": "${{ github.repository }}"}'  
+
       - run: npm ci
 
       - run: npm run build


### PR DESCRIPTION
## Summary

- Adds `atlasent/action@v1` as the first real step in `release.yml`, before `npm ci`, build, cosign signing, and publish
- Action type: `production.release`, actor: `github.actor`, environment: `production`
- Job fails closed if the permit is not verified — nothing builds or ships without an authorized permit
- Dogfoods our own deploy-gate primitive on our own release pipeline

## Test plan

- [ ] Verify `ATLASENT_API_KEY` secret is set on this repo (needed for the gate to call the API)
- [ ] Trigger a test workflow_dispatch run to confirm the gate step evaluates and permits correctly
- [ ] Confirm the rest of the release steps (build, cosign, upload) still run after a successful gate

https://claude.ai/code/session_01Me7bscu1ffn7smjTnL5oKK

---
_Generated by [Claude Code](https://claude.ai/code/session_01Me7bscu1ffn7smjTnL5oKK)_