### PR TITLE
fix(action): getInput reads INPUT_API-KEY not INPUT_API_KEY

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1385,7 +1385,7 @@ function normalizeAndValidateProtectedAction(actionType) {
   return canonical;
 }
 function getInput(name, required2 = false) {
-  const envKey = `INPUT_${name.replace(/-/g, "_").toUpperCase()}`;
+  const envKey = `INPUT_${name.replace(/ /g, "_").toUpperCase()}`;
   const val = (process.env[envKey] ?? "").trim();
   if (required2 && !val) {
     setFailed(`Input required and not supplied: ${name}`);

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -117,7 +117,7 @@ afterEach(() => {
 });
 
 function setInput(name: string, value: string) {
-  process.env[`INPUT_${name.replace(/-/g, "_").toUpperCase()}`] = value;
+  process.env[`INPUT_${name.replace(/ /g, "_").toUpperCase()}`] = value;
 }
 
 function setApiKey(value = "ask_test_key") {

--- a/src/__tests__/notifications.test.ts
+++ b/src/__tests__/notifications.test.ts
@@ -110,7 +110,7 @@ afterEach(() => {
 // ── Convenience helpers ─────────────────────────────────────────────────────
 
 function setInput(name: string, value: string) {
-  process.env[`INPUT_${name.replace(/-/g, "_").toUpperCase()}`] = value;
+  process.env[`INPUT_${name.replace(/ /g, "_").toUpperCase()}`] = value;
 }
 
 function setApiKey(value = "ask_test_key") {

--- a/src/index.ts
+++ b/src/index.ts
@@ -80,7 +80,7 @@ function normalizeAndValidateProtectedAction(actionType: string): string {
 // ---------------------------------------------------------------------------
 
 function getInput(name: string, required = false): string {
-  const envKey = `INPUT_${name.replace(/-/g, "_").toUpperCase()}`;
+  const envKey = `INPUT_${name.replace(/ /g, "_").toUpperCase()}`;
   const val = (process.env[envKey] ?? "").trim();
   if (required && !val) {
     setFailed(`Input required and not supplied: ${name}`);


### PR DESCRIPTION
## Summary

- Fixes a bug in the custom `getInput()` helper in `src/index.ts` (and its compiled output in `dist/index.js`) where dashes in input names were converted to underscores when looking up the environment variable.
- GitHub Actions sets `INPUT_API-KEY` (dash preserved) but `getInput` was reading `INPUT_API_KEY` (underscore) — a different, always-empty variable — causing every gate invocation to fail with `Input required and not supplied: api-key`.
- Fix: `replace(/-/g, "_")` → `replace(/ /g, "_")` — matching `@actions/core` convention (only spaces become underscores).

## Root cause

GitHub sets `INPUT_<name>` with the input name uppercased and spaces converted to underscores, but dashes are preserved (`api-key` → `INPUT_API-KEY`). The custom `getInput` was incorrectly also converting dashes, producing `INPUT_API_KEY` which never matched.

## After merge

Move the `v1` tag to this commit so consumers using `@v1` get the fix:

```bash
git tag -f v1 <merged-sha>
git push --force origin v1
```

## Test plan

- [ ] Trigger `deploy-production.yml` after merging and moving the v1 tag — gate step should proceed past the api-key check
- [ ] All `api-key` input lookups are now correct; other dashed inputs (`api-url`, `fail-on-deny`, etc.) also benefit from the fix

https://claude.ai/code/session_01Me7bscu1ffn7smjTnL5oKK

---
_Generated by [Claude Code](https://claude.ai/code/session_01Me7bscu1ffn7smjTnL5oKK)_