### PR TITLE
feat(approvals): derive context.approvals from GitHub PR reviews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to `atlasent-action` are documented here.
 
 ## [Unreleased]
 
+### Approvals from PR reviews (P0 — deploy pilot)
+
+The single-eval path now derives `context.approvals` from the pull request's
+reviews, so the canonical `allow-2-approvals-change-window` policy template
+works out of the box without a second integration.
+
+- New `approvals-from` input (`pr-reviews` default | `none`). When
+  `pr-reviews`, the action counts distinct reviewers whose latest review state
+  is `APPROVED` (GitHub's own latest-review-per-user semantics:
+  `COMMENTED`/`PENDING` don't change approval; a later `CHANGES_REQUESTED` or
+  `DISMISSED` supersedes an earlier `APPROVED`) and injects
+  `context.approvals` + `context.approving_reviewers`.
+- Resolves the PR from the `pull_request` event ref, or — on a `push`/merge to
+  the default branch — from the head commit's associated PR
+  (`GET /repos/{repo}/commits/{sha}/pulls`).
+- Requires `GITHUB_TOKEN` (`env: GITHUB_TOKEN: ${{ github.token }}`).
+- **Best-effort, fail-open-to-zero:** any API error (including a non-JSON
+  body) yields `0` approvals, which denies a count-gated deploy — the
+  fail-closed direction. Never throws.
+- The operator's `context` input still wins (an explicit `approvals` overrides
+  the derived value). `change_window` remains an operator-supplied signal.
+- New module `src/approvals.ts` with 16 unit tests; `dist/index.js` rebuilt.
+
 ### V1 convergence — SDK realignment verification (P0)
 
 V1 pilot SDK alignment audit. `@atlasent/sdk` remains pinned at the latest

--- a/README.md
+++ b/README.md
@@ -119,7 +119,35 @@ The action sets several outputs you can reference in subsequent steps.
 | `environment`  | No       | Auto-detected          | `live` for `main`/`master`, `test` otherwise            |
 | `api-url`      | No       | `ATLASENT_BASE_URL` or `https://api.atlasent.io` | AtlaSent API base URL override. |
 | `fail-on-deny` | No       | `true`                 | Deprecated for pilot mode; deny/hold/escalate still fail closed. |
-| `context`      | No       | `{}`                   | Additional JSON context for evaluation                  |
+| `context`      | No       | `{}`                   | Additional JSON context for evaluation. Overrides auto-derived values (e.g. an explicit `approvals` here wins over PR-review-derived approvals). |
+| `approvals-from` | No     | `pr-reviews`           | Source of `context.approvals`. `pr-reviews` (default) counts distinct reviewers whose latest PR review is `APPROVED` and injects `context.approvals` + `context.approving_reviewers`; `none` disables it. Requires `GITHUB_TOKEN`. Fail-open-to-zero. |
+
+### Approvals from PR reviews
+
+The canonical `production.deploy` policy template `allow-2-approvals-change-window` allows only when `context.approvals >= 2`. By default the action derives that count from the pull request's reviews — no second integration required — so a deploy with two approving reviews is permitted and one without is blocked.
+
+Pass the token so the action can read reviews, and ensure the deploy is associated with a PR (a `pull_request` event, or a `push`/merge to `main` whose commit has an associated PR):
+
+```yaml
+- name: Authorization Gate
+  id: gate
+  uses: AtlaSent-Systems-Inc/atlasent-action@v1
+  env:
+    ATLASENT_API_KEY: ${{ secrets.ATLASENT_API_KEY }}
+    ATLASENT_BASE_URL: ${{ secrets.ATLASENT_BASE_URL }}
+    GITHUB_TOKEN: ${{ github.token }}      # lets the gate read PR reviews
+  with:
+    action: production.deploy
+    environment: live
+    # change_window is an operator signal — supply it explicitly:
+    context: '{"change_window": true}'
+
+- name: Deploy
+  if: steps.gate.outputs.verified == 'true'
+  run: ./deploy.sh
+```
+
+`change_window` is a deliberate operator signal and is **not** auto-derived — set it in `context` (or use a template that does not require it). The approval lookup is best-effort and **fails open to zero**: if the GitHub API can't be reached, `approvals` is `0`, which denies a count-gated deploy (the fail-closed direction).
 
 ### Batch inputs (v2.1)
 

--- a/action.yml
+++ b/action.yml
@@ -26,9 +26,22 @@ inputs:
     required: false
     default: 'true'
   context:
-    description: 'JSON context to include in the evaluation (optional). Used for single-eval path.'
+    description: 'JSON context to include in the evaluation (optional). Used for single-eval path. Values here override anything the action derives automatically (e.g. an explicit `approvals` count wins over PR-review-derived approvals).'
     required: false
     default: '{}'
+  approvals-from:
+    description: |
+      Where the `context.approvals` count comes from on the single-eval path.
+        - "pr-reviews" (default): count distinct reviewers whose latest PR
+          review is APPROVED, derived from the GitHub API, and inject as
+          context.approvals + context.approving_reviewers. Lets the
+          `allow-2-approvals-change-window` policy template work out of the box.
+          Requires GITHUB_TOKEN (pass `env: GITHUB_TOKEN: ${{ github.token }}`).
+        - "none": do not derive approvals; supply them via the `context` input.
+      Best-effort and fail-open-to-zero: any API failure yields 0 approvals,
+      which denies a count-gated deploy (the fail-closed direction).
+    required: false
+    default: 'pr-reviews'
   evaluations:
     description: 'JSON array of evaluation requests for batch mode, e.g. [{"action":"production.deploy","actor":"alice"}]. When set, single-eval inputs (action, actor, context) are ignored.'
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -1365,6 +1365,139 @@ async function runVqpVerify(inputs, fetchFn = globalThis.fetch) {
   };
 }
 
+// src/approvals.ts
+var EMPTY = {
+  approvals: 0,
+  approving_reviewers: [],
+  pr_number: null,
+  source: "none"
+};
+var MAX_REVIEW_PAGES = 10;
+var PER_PAGE = 100;
+function ghHeaders(token) {
+  return {
+    Authorization: `Bearer ${token}`,
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28"
+  };
+}
+async function resolvePrNumber(opts) {
+  const explicit = typeof opts.prNumber === "number" ? opts.prNumber : typeof opts.prNumber === "string" && /^\d+$/.test(opts.prNumber.trim()) ? parseInt(opts.prNumber.trim(), 10) : null;
+  if (explicit && explicit > 0)
+    return explicit;
+  if (!opts.sha)
+    return null;
+  const url = `${opts.apiBase}/repos/${opts.repository}/commits/${opts.sha}/pulls`;
+  try {
+    const res = await opts.fetchImpl(url, { headers: ghHeaders(opts.token) });
+    if (!res.ok) {
+      opts.warn(
+        `AtlaSent: could not resolve PR for commit ${opts.sha.slice(0, 8)} (${res.status}); treating as 0 approvals`
+      );
+      return null;
+    }
+    const pulls = await res.json();
+    if (!Array.isArray(pulls) || pulls.length === 0)
+      return null;
+    const merged = pulls.find((p) => p.state === "closed") ?? pulls[0];
+    return typeof merged.number === "number" ? merged.number : null;
+  } catch (err) {
+    opts.warn(
+      `AtlaSent: PR resolution error (advisory, non-blocking): ${err instanceof Error ? err.message : String(err)}`
+    );
+    return null;
+  }
+}
+async function fetchAllReviews(opts) {
+  const reviews = [];
+  for (let page = 1; page <= MAX_REVIEW_PAGES; page++) {
+    const url = `${opts.apiBase}/repos/${opts.repository}/pulls/${opts.prNumber}/reviews?per_page=${PER_PAGE}&page=${page}`;
+    let batch;
+    try {
+      const res = await opts.fetchImpl(url, { headers: ghHeaders(opts.token) });
+      if (!res.ok) {
+        opts.warn(
+          `AtlaSent: could not read reviews for PR #${opts.prNumber} (${res.status}); treating as 0 approvals`
+        );
+        return null;
+      }
+      batch = await res.json();
+    } catch (err) {
+      opts.warn(
+        `AtlaSent: review fetch error (advisory, non-blocking): ${err instanceof Error ? err.message : String(err)}`
+      );
+      return null;
+    }
+    if (!Array.isArray(batch) || batch.length === 0)
+      break;
+    reviews.push(...batch);
+    if (batch.length < PER_PAGE)
+      break;
+  }
+  return reviews;
+}
+function countApprovals(reviews) {
+  const STATEFUL = /* @__PURE__ */ new Set(["APPROVED", "CHANGES_REQUESTED", "DISMISSED"]);
+  const latestByUser = /* @__PURE__ */ new Map();
+  for (const r of reviews) {
+    const login = r.user?.login;
+    const state = (r.state ?? "").toUpperCase();
+    if (!login || !STATEFUL.has(state))
+      continue;
+    latestByUser.set(login, state);
+  }
+  const approving = [...latestByUser.entries()].filter(([, state]) => state === "APPROVED").map(([login]) => login).sort();
+  return { approvals: approving.length, approving_reviewers: approving };
+}
+async function resolveApprovals(options) {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const warn = options.warn ?? (() => {
+  });
+  const log = options.log ?? (() => {
+  });
+  const apiBase = (options.apiBase ?? "https://api.github.com").replace(/\/+$/, "");
+  const token = options.token?.trim();
+  if (!token) {
+    warn(
+      "AtlaSent: GITHUB_TOKEN not available \u2014 cannot read PR reviews for approval evidence. Pass `env: GITHUB_TOKEN: ${{ github.token }}` or supply `approvals` via the `context` input. Treating as 0 approvals."
+    );
+    return { ...EMPTY };
+  }
+  if (!options.repository) {
+    warn("AtlaSent: GITHUB_REPOSITORY not set \u2014 cannot read PR reviews. Treating as 0 approvals.");
+    return { ...EMPTY };
+  }
+  const prNumber = await resolvePrNumber({
+    repository: options.repository,
+    sha: options.sha,
+    token,
+    apiBase,
+    prNumber: options.prNumber,
+    fetchImpl,
+    warn
+  });
+  if (!prNumber) {
+    log("AtlaSent: no associated pull request found \u2014 0 approvals from PR reviews.");
+    return { ...EMPTY };
+  }
+  const reviews = await fetchAllReviews({
+    repository: options.repository,
+    token,
+    apiBase,
+    prNumber,
+    fetchImpl,
+    warn
+  });
+  if (reviews === null) {
+    return { approvals: 0, approving_reviewers: [], pr_number: prNumber, source: "none" };
+  }
+  const { approvals, approving_reviewers } = countApprovals(reviews);
+  log(
+    `AtlaSent: PR #${prNumber} has ${approvals} approving review${approvals === 1 ? "" : "s"}` + (approving_reviewers.length ? ` (${approving_reviewers.join(", ")})` : "")
+  );
+  return { approvals, approving_reviewers, pr_number: prNumber, source: "pr-reviews" };
+}
+
 // src/index.ts
 function getApiKey() {
   const apiKey = (process.env["ATLASENT_API_KEY"] ?? "").trim();
@@ -2148,6 +2281,19 @@ async function run() {
   info(
     `AtlaSent Gate: evaluating "${actionType}" for actor "github:${actor}" in ${environment} environment` + (targetId ? ` (target=${targetId})` : "")
   );
+  const approvalsFrom = (getInput("approvals-from") || "pr-reviews").toLowerCase();
+  let approvalEvidence = null;
+  if (approvalsFrom === "pr-reviews") {
+    approvalEvidence = await resolveApprovals({
+      repository: gh.repository,
+      sha: gh.sha,
+      prNumber: gh.pr_number ?? null,
+      token: process.env["GITHUB_TOKEN"],
+      apiBase: process.env["GITHUB_API_URL"],
+      log: info,
+      warn: warning
+    });
+  }
   const config = {
     apiKey,
     apiUrl,
@@ -2171,8 +2317,13 @@ async function run() {
       run_id: gh.run_id,
       run_number: gh.run_number,
       event_name: gh.event_name,
-      pr_number: gh.pr_number ?? null,
+      pr_number: approvalEvidence?.pr_number ?? gh.pr_number ?? null,
       run_url: `${gh.server_url}/${gh.repository}/actions/runs/${gh.run_id}`,
+      // Verified approval evidence from PR reviews (operator context can override).
+      ...approvalEvidence && approvalEvidence.source === "pr-reviews" ? {
+        approvals: approvalEvidence.approvals,
+        approving_reviewers: approvalEvidence.approving_reviewers
+      } : {},
       ...extraContext
     }
   };

--- a/src/__tests__/approvals.test.ts
+++ b/src/__tests__/approvals.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it, vi } from "vitest";
+import { countApprovals, resolveApprovals } from "../approvals";
+
+// A minimal fetch double: maps URL substrings to {status, json}.
+function makeFetch(
+  routes: Array<{ match: string; status?: number; body: unknown }>,
+): { fn: typeof fetch; calls: string[] } {
+  const calls: string[] = [];
+  const fn = (async (url: string) => {
+    calls.push(url);
+    const route = routes.find((r) => url.includes(r.match));
+    if (!route) {
+      return { ok: false, status: 404, json: async () => ({}) } as unknown as Response;
+    }
+    const status = route.status ?? 200;
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      json: async () => route.body,
+    } as unknown as Response;
+  }) as unknown as typeof fetch;
+  return { fn, calls };
+}
+
+const review = (login: string, state: string) => ({ user: { login }, state });
+
+describe("countApprovals", () => {
+  it("counts one approval per distinct reviewer", () => {
+    const out = countApprovals([review("alice", "APPROVED"), review("bob", "APPROVED")]);
+    expect(out.approvals).toBe(2);
+    expect(out.approving_reviewers).toEqual(["alice", "bob"]);
+  });
+
+  it("uses the latest stateful review per reviewer (re-approval)", () => {
+    const out = countApprovals([
+      review("alice", "CHANGES_REQUESTED"),
+      review("alice", "APPROVED"),
+    ]);
+    expect(out.approvals).toBe(1);
+    expect(out.approving_reviewers).toEqual(["alice"]);
+  });
+
+  it("a later CHANGES_REQUESTED supersedes an earlier APPROVED", () => {
+    const out = countApprovals([
+      review("alice", "APPROVED"),
+      review("alice", "CHANGES_REQUESTED"),
+    ]);
+    expect(out.approvals).toBe(0);
+  });
+
+  it("a later DISMISSED removes the approval", () => {
+    const out = countApprovals([review("alice", "APPROVED"), review("alice", "DISMISSED")]);
+    expect(out.approvals).toBe(0);
+  });
+
+  it("ignores COMMENTED / PENDING (they do not change approval state)", () => {
+    const out = countApprovals([
+      review("alice", "APPROVED"),
+      review("alice", "COMMENTED"),
+      review("bob", "PENDING"),
+    ]);
+    expect(out.approvals).toBe(1);
+    expect(out.approving_reviewers).toEqual(["alice"]);
+  });
+
+  it("ignores reviews with no user login", () => {
+    const out = countApprovals([{ state: "APPROVED" }, review("bob", "APPROVED")]);
+    expect(out.approvals).toBe(1);
+    expect(out.approving_reviewers).toEqual(["bob"]);
+  });
+
+  it("returns zero for an empty review list", () => {
+    expect(countApprovals([]).approvals).toBe(0);
+  });
+});
+
+describe("resolveApprovals", () => {
+  const base = {
+    repository: "acme/web",
+    sha: "abc123def456",
+    apiBase: "https://api.github.com",
+    token: "ghs_token",
+  };
+
+  it("fail-opens to zero when no token is available", async () => {
+    const warn = vi.fn();
+    const out = await resolveApprovals({ ...base, token: undefined, warn });
+    expect(out).toEqual({ approvals: 0, approving_reviewers: [], pr_number: null, source: "none" });
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it("reads reviews for an explicit PR number (pull_request event)", async () => {
+    const { fn, calls } = makeFetch([
+      { match: "/pulls/42/reviews", body: [review("alice", "APPROVED"), review("bob", "APPROVED")] },
+    ]);
+    const out = await resolveApprovals({ ...base, prNumber: 42, fetchImpl: fn });
+    expect(out.approvals).toBe(2);
+    expect(out.pr_number).toBe(42);
+    expect(out.source).toBe("pr-reviews");
+    // Did not need the commit→pulls resolution call.
+    expect(calls.some((c) => c.includes("/commits/"))).toBe(false);
+  });
+
+  it("resolves the PR from the head commit on a push/merge event", async () => {
+    const { fn } = makeFetch([
+      { match: `/commits/${base.sha}/pulls`, body: [{ number: 7, state: "closed" }] },
+      { match: "/pulls/7/reviews", body: [review("alice", "APPROVED")] },
+    ]);
+    const out = await resolveApprovals({ ...base, prNumber: null, fetchImpl: fn });
+    expect(out.pr_number).toBe(7);
+    expect(out.approvals).toBe(1);
+    expect(out.source).toBe("pr-reviews");
+  });
+
+  it("prefers a closed/merged PR over an open one when several match a commit", async () => {
+    const { fn } = makeFetch([
+      {
+        match: `/commits/${base.sha}/pulls`,
+        body: [
+          { number: 9, state: "open" },
+          { number: 8, state: "closed" },
+        ],
+      },
+      { match: "/pulls/8/reviews", body: [review("alice", "APPROVED")] },
+    ]);
+    const out = await resolveApprovals({ ...base, fetchImpl: fn });
+    expect(out.pr_number).toBe(8);
+  });
+
+  it("returns zero approvals (source none) when no PR is associated", async () => {
+    const { fn } = makeFetch([{ match: `/commits/${base.sha}/pulls`, body: [] }]);
+    const out = await resolveApprovals({ ...base, fetchImpl: fn });
+    expect(out).toEqual({ approvals: 0, approving_reviewers: [], pr_number: null, source: "none" });
+  });
+
+  it("fail-opens to zero when the reviews API errors", async () => {
+    const warn = vi.fn();
+    const { fn } = makeFetch([{ match: "/pulls/42/reviews", status: 403, body: {} }]);
+    const out = await resolveApprovals({ ...base, prNumber: 42, fetchImpl: fn, warn });
+    expect(out.approvals).toBe(0);
+    expect(out.pr_number).toBe(42);
+    expect(out.source).toBe("none");
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it("fail-opens to zero when the reviews body is not JSON (never throws)", async () => {
+    // Reproduces the real GH-Actions mock returning a plain "ok" body: res.json()
+    // throws a SyntaxError, which must be swallowed rather than crashing the gate.
+    const fn = (async () =>
+      ({
+        ok: true,
+        status: 200,
+        json: async () => {
+          throw new SyntaxError(`Unexpected token 'o', "ok" is not valid JSON`);
+        },
+      }) as unknown as Response) as unknown as typeof fetch;
+    const out = await resolveApprovals({ ...base, prNumber: 42, fetchImpl: fn });
+    expect(out.approvals).toBe(0);
+    expect(out.source).toBe("none");
+  });
+
+  it("fail-opens to zero when fetch throws", async () => {
+    const throwing = (async () => {
+      throw new Error("network down");
+    }) as unknown as typeof fetch;
+    const out = await resolveApprovals({ ...base, prNumber: 42, fetchImpl: throwing });
+    expect(out.approvals).toBe(0);
+  });
+
+  it("sends the GitHub bearer token and API version header", async () => {
+    const seen: Array<Record<string, string>> = [];
+    const fn = (async (_url: string, init?: { headers?: Record<string, string> }) => {
+      seen.push(init?.headers ?? {});
+      return { ok: true, status: 200, json: async () => [review("alice", "APPROVED")] } as unknown as Response;
+    }) as unknown as typeof fetch;
+    await resolveApprovals({ ...base, prNumber: 1, fetchImpl: fn });
+    expect(seen[0]?.Authorization).toBe("Bearer ghs_token");
+    expect(seen[0]?.["X-GitHub-Api-Version"]).toBe("2022-11-28");
+  });
+});

--- a/src/approvals.ts
+++ b/src/approvals.ts
@@ -1,0 +1,246 @@
+// PR-reviews-as-approval reader.
+//
+// Derives verified approval evidence for a deploy from GitHub pull-request
+// reviews, so the canonical `allow-2-approvals-change-window` policy template
+// (which reads `context.approvals >= 2`) can be satisfied without the customer
+// wiring a second integration. The approving reviewers are real GitHub
+// identities, not a self-asserted count.
+//
+// Design contract:
+//   - Best-effort and FAIL-OPEN-TO-ZERO. A metadata fetch failure must never
+//     *grant* authorization. Returning zero approvals causes the count gate to
+//     deny — i.e. failure collapses to the fail-closed direction, consistent
+//     with the rest of the action.
+//   - "Approvals" = the number of DISTINCT reviewers whose LATEST review state
+//     is APPROVED (mirrors GitHub's own latest-review-per-user semantics:
+//     COMMENTED / PENDING reviews do not change a user's approval state; a later
+//     CHANGES_REQUESTED or DISMISSED supersedes an earlier APPROVED).
+//   - Pure and injectable: `fetchImpl` + loggers are passed in so the module is
+//     unit-testable with no GitHub Actions environment.
+
+export interface ApprovalEvidence {
+  /** Count of distinct reviewers whose latest review is APPROVED. */
+  approvals: number;
+  /** Logins of those reviewers, captured for audit evidence. */
+  approving_reviewers: string[];
+  /** The PR the reviews were read from, if one was resolved. */
+  pr_number: number | null;
+  /** "pr-reviews" when the GitHub API was actually consulted; "none" otherwise. */
+  source: "pr-reviews" | "none";
+}
+
+export interface ResolveApprovalsOptions {
+  /** "owner/repo". */
+  repository: string;
+  /** Head commit SHA (used to resolve the PR on push/merge events). */
+  sha: string;
+  /** PR number from the event ref, if this is a pull_request event. */
+  prNumber?: string | number | null;
+  /** GitHub token (GITHUB_TOKEN). Without it the API cannot be read. */
+  token?: string;
+  /** GitHub API base (GITHUB_API_URL). Defaults to public github.com. */
+  apiBase?: string;
+  /** Injectable fetch for tests. Defaults to global fetch. */
+  fetchImpl?: typeof fetch;
+  log?: (message: string) => void;
+  warn?: (message: string) => void;
+}
+
+interface GitHubReview {
+  state?: string;
+  user?: { login?: string } | null;
+}
+
+interface AssociatedPull {
+  number?: number;
+  state?: string;
+}
+
+const EMPTY: ApprovalEvidence = {
+  approvals: 0,
+  approving_reviewers: [],
+  pr_number: null,
+  source: "none",
+};
+
+const MAX_REVIEW_PAGES = 10;
+const PER_PAGE = 100;
+
+function ghHeaders(token: string): Record<string, string> {
+  return {
+    Authorization: `Bearer ${token}`,
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+}
+
+/**
+ * Resolve the PR number to read reviews from. Prefers the explicit
+ * pull_request-event number; otherwise asks GitHub which PRs are
+ * associated with the head commit (covers deploy-on-merge `push` events).
+ */
+async function resolvePrNumber(
+  opts: Required<Pick<ResolveApprovalsOptions, "repository" | "sha" | "token" | "apiBase">> & {
+    prNumber?: string | number | null;
+    fetchImpl: typeof fetch;
+    warn: (m: string) => void;
+  },
+): Promise<number | null> {
+  const explicit =
+    typeof opts.prNumber === "number"
+      ? opts.prNumber
+      : typeof opts.prNumber === "string" && /^\d+$/.test(opts.prNumber.trim())
+        ? parseInt(opts.prNumber.trim(), 10)
+        : null;
+  if (explicit && explicit > 0) return explicit;
+
+  if (!opts.sha) return null;
+  const url = `${opts.apiBase}/repos/${opts.repository}/commits/${opts.sha}/pulls`;
+  try {
+    const res = await opts.fetchImpl(url, { headers: ghHeaders(opts.token) });
+    if (!res.ok) {
+      opts.warn(
+        `AtlaSent: could not resolve PR for commit ${opts.sha.slice(0, 8)} (${res.status}); ` +
+          `treating as 0 approvals`,
+      );
+      return null;
+    }
+    const pulls = (await res.json()) as AssociatedPull[];
+    if (!Array.isArray(pulls) || pulls.length === 0) return null;
+    // Prefer a merged/closed PR (the one this deploy came from), else the first.
+    const merged = pulls.find((p) => p.state === "closed") ?? pulls[0];
+    return typeof merged.number === "number" ? merged.number : null;
+  } catch (err) {
+    opts.warn(
+      `AtlaSent: PR resolution error (advisory, non-blocking): ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+    return null;
+  }
+}
+
+/** Fetch every review for a PR, following pagination up to a sane cap. */
+async function fetchAllReviews(
+  opts: Required<Pick<ResolveApprovalsOptions, "repository" | "token" | "apiBase">> & {
+    prNumber: number;
+    fetchImpl: typeof fetch;
+    warn: (m: string) => void;
+  },
+): Promise<GitHubReview[] | null> {
+  const reviews: GitHubReview[] = [];
+  for (let page = 1; page <= MAX_REVIEW_PAGES; page++) {
+    const url =
+      `${opts.apiBase}/repos/${opts.repository}/pulls/${opts.prNumber}/reviews` +
+      `?per_page=${PER_PAGE}&page=${page}`;
+    let batch: GitHubReview[];
+    try {
+      const res = await opts.fetchImpl(url, { headers: ghHeaders(opts.token) });
+      if (!res.ok) {
+        opts.warn(
+          `AtlaSent: could not read reviews for PR #${opts.prNumber} (${res.status}); ` +
+            `treating as 0 approvals`,
+        );
+        return null;
+      }
+      batch = (await res.json()) as GitHubReview[];
+    } catch (err) {
+      opts.warn(
+        `AtlaSent: review fetch error (advisory, non-blocking): ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+      return null;
+    }
+    if (!Array.isArray(batch) || batch.length === 0) break;
+    reviews.push(...batch);
+    if (batch.length < PER_PAGE) break;
+  }
+  return reviews;
+}
+
+/**
+ * Reduce a chronological review list to the count of distinct reviewers whose
+ * latest *state-bearing* review is APPROVED. COMMENTED / PENDING reviews are
+ * ignored for state (they don't change approval), matching GitHub semantics.
+ */
+export function countApprovals(reviews: GitHubReview[]): {
+  approvals: number;
+  approving_reviewers: string[];
+} {
+  const STATEFUL = new Set(["APPROVED", "CHANGES_REQUESTED", "DISMISSED"]);
+  const latestByUser = new Map<string, string>();
+  for (const r of reviews) {
+    const login = r.user?.login;
+    const state = (r.state ?? "").toUpperCase();
+    if (!login || !STATEFUL.has(state)) continue;
+    latestByUser.set(login, state); // chronological order → last wins
+  }
+  const approving = [...latestByUser.entries()]
+    .filter(([, state]) => state === "APPROVED")
+    .map(([login]) => login)
+    .sort();
+  return { approvals: approving.length, approving_reviewers: approving };
+}
+
+/**
+ * Resolve verified approval evidence for the current deploy. Never throws;
+ * any failure returns zero approvals (the fail-closed direction for a
+ * count-based gate).
+ */
+export async function resolveApprovals(
+  options: ResolveApprovalsOptions,
+): Promise<ApprovalEvidence> {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const warn = options.warn ?? (() => {});
+  const log = options.log ?? (() => {});
+  const apiBase = (options.apiBase ?? "https://api.github.com").replace(/\/+$/, "");
+  const token = options.token?.trim();
+
+  if (!token) {
+    warn(
+      "AtlaSent: GITHUB_TOKEN not available — cannot read PR reviews for approval " +
+        "evidence. Pass `env: GITHUB_TOKEN: ${{ github.token }}` or supply `approvals` " +
+        "via the `context` input. Treating as 0 approvals.",
+    );
+    return { ...EMPTY };
+  }
+  if (!options.repository) {
+    warn("AtlaSent: GITHUB_REPOSITORY not set — cannot read PR reviews. Treating as 0 approvals.");
+    return { ...EMPTY };
+  }
+
+  const prNumber = await resolvePrNumber({
+    repository: options.repository,
+    sha: options.sha,
+    token,
+    apiBase,
+    prNumber: options.prNumber,
+    fetchImpl,
+    warn,
+  });
+  if (!prNumber) {
+    log("AtlaSent: no associated pull request found — 0 approvals from PR reviews.");
+    return { ...EMPTY };
+  }
+
+  const reviews = await fetchAllReviews({
+    repository: options.repository,
+    token,
+    apiBase,
+    prNumber,
+    fetchImpl,
+    warn,
+  });
+  if (reviews === null) {
+    return { approvals: 0, approving_reviewers: [], pr_number: prNumber, source: "none" };
+  }
+
+  const { approvals, approving_reviewers } = countApprovals(reviews);
+  log(
+    `AtlaSent: PR #${prNumber} has ${approvals} approving ` +
+      `review${approvals === 1 ? "" : "s"}` +
+      (approving_reviewers.length ? ` (${approving_reviewers.join(", ")})` : ""),
+  );
+  return { approvals, approving_reviewers, pr_number: prNumber, source: "pr-reviews" };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,7 @@ import {
   normalizeProtectedAction,
 } from "./canonicalAction";
 import { runVqpVerify } from "./vqpVerify";
+import { resolveApprovals, type ApprovalEvidence } from "./approvals";
 
 function getApiKey(): string {
   const apiKey = (process.env["ATLASENT_API_KEY"] ?? "").trim();
@@ -1134,6 +1135,27 @@ export async function run(): Promise<void> {
       (targetId ? ` (target=${targetId})` : ""),
   );
 
+  // Derive verified approval evidence from PR reviews so the
+  // `allow-2-approvals-change-window` policy template can read a trustworthy
+  // `context.approvals` count without a second integration. Best-effort and
+  // fail-open-to-zero: any failure leaves approvals at 0, which denies a
+  // count-gated deploy (the fail-closed direction). `approvals-from: none`
+  // skips the lookup entirely. The operator's `context` input always wins,
+  // so an explicit `approvals` there overrides what we derive.
+  const approvalsFrom = (getInput("approvals-from") || "pr-reviews").toLowerCase();
+  let approvalEvidence: ApprovalEvidence | null = null;
+  if (approvalsFrom === "pr-reviews") {
+    approvalEvidence = await resolveApprovals({
+      repository: gh.repository,
+      sha: gh.sha,
+      prNumber: gh.pr_number ?? null,
+      token: process.env["GITHUB_TOKEN"],
+      apiBase: process.env["GITHUB_API_URL"],
+      log: info,
+      warn: warning,
+    });
+  }
+
   const config: EnforceConfig = {
     apiKey,
     apiUrl,
@@ -1157,8 +1179,15 @@ export async function run(): Promise<void> {
       run_id: gh.run_id,
       run_number: gh.run_number,
       event_name: gh.event_name,
-      pr_number: gh.pr_number ?? null,
+      pr_number: approvalEvidence?.pr_number ?? gh.pr_number ?? null,
       run_url: `${gh.server_url}/${gh.repository}/actions/runs/${gh.run_id}`,
+      // Verified approval evidence from PR reviews (operator context can override).
+      ...(approvalEvidence && approvalEvidence.source === "pr-reviews"
+        ? {
+            approvals: approvalEvidence.approvals,
+            approving_reviewers: approvalEvidence.approving_reviewers,
+          }
+        : {}),
       ...extraContext,
     },
   };


### PR DESCRIPTION
## Summary

P0 from the deploy-governance pilot plan ([atlasent-docs#310](https://github.com/AtlaSent-Systems-Inc/atlasent-docs/pull/310)). Makes the headline "require 2 approvals" gate real **without a second integration**.

The single-eval path now derives `context.approvals` from the pull request's reviews and injects it (plus `context.approving_reviewers`) into the evaluate context. The canonical `production.deploy` policy template `allow-2-approvals-change-window` reads `context.approvals >= 2`, so a deploy with two approving reviews is permitted and one without is blocked — out of the box.

## What changed

- **New `src/approvals.ts`** — resolves the PR (from the `pull_request` ref, or on a `push`/merge from the head commit's associated PR via `GET /repos/{repo}/commits/{sha}/pulls`), fetches reviews (paginated), and counts distinct reviewers whose **latest** review state is `APPROVED`. Mirrors GitHub's latest-review-per-user semantics: `COMMENTED`/`PENDING` don't change approval; a later `CHANGES_REQUESTED`/`DISMISSED` supersedes an earlier `APPROVED`.
- **New `approvals-from` input** (`pr-reviews` default | `none`). Documented in `action.yml` + README.
- **Wired into `src/index.ts`** single-eval path — injected before the operator `context` spread, so an explicit `approvals` in `context` still wins. `pr_number` evidence is backfilled from the resolved PR.
- **`dist/index.js` rebuilt** (esbuild bundle, committed).

## Fail-closed posture

Best-effort and **fail-open-to-zero**: any API failure — unreachable, non-2xx, or a non-JSON body — yields `0` approvals, which *denies* a count-gated deploy. Failure collapses to the fail-closed direction. The module never throws into the gate. `change_window` stays an operator-supplied signal (not auto-derived).

Requires `GITHUB_TOKEN` (`env: GITHUB_TOKEN: ${{ github.token }}`), consistent with the existing commit-status / PR-comment helpers.

## Test plan

- `npm run typecheck` — clean.
- `npm test` — **311 passed (21 files)**, including **16 new** `src/__tests__/approvals.test.ts` cases: count semantics (re-approval, supersession, dismissal, commented/pending ignored, missing login), PR resolution (explicit / commit-derived / prefers merged / none), and fail-open paths (no token, API error, **non-JSON body**, fetch throws, header assertions).
- Regression test pins the exact non-JSON-body case that an earlier draft let escape.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01H2qoEv6DJd9E9Uuc5FMrAK

---
_Generated by [Claude Code](https://claude.ai/code/session_01H2qoEv6DJd9E9Uuc5FMrAK)_