### PR TITLE
docs(action): warn that the api.atlasent.io apex 404s — set api-url to project URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ The action sets several outputs you can reference in subsequent steps.
 | `actor`        | No       | `${{ github.actor }}`  | Actor identity                                          |
 | `target-id`    | No       | —                      | Target resource being acted on (service, artifact, etc) |
 | `environment`  | No       | Auto-detected          | `live` for `main`/`master`, `test` otherwise            |
-| `api-url`      | No       | `ATLASENT_BASE_URL` or `https://api.atlasent.io` | AtlaSent API base URL override. |
+| `api-url`      | No       | `ATLASENT_BASE_URL` or `https://api.atlasent.io` | AtlaSent API base URL override. **Self-hosted / pilot: set this to your project URL ending in `/functions/v1`. The `api.atlasent.io` apex 404s unless a custom domain is verified — which looks like a broken gate.** |
 | `fail-on-deny` | No       | `true`                 | Deprecated for pilot mode; deny/hold/escalate still fail closed. |
 | `context`      | No       | `{}`                   | Additional JSON context for evaluation. Overrides auto-derived values (e.g. an explicit `approvals` here wins over PR-review-derived approvals). |
 | `approvals-from` | No     | `pr-reviews`           | Source of `context.approvals`. `pr-reviews` (default) counts distinct reviewers whose latest PR review is `APPROVED` and injects `context.approvals` + `context.approving_reviewers`; `none` disables it. Requires `GITHUB_TOKEN`. Fail-open-to-zero. |

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
     description: 'Environment (defaults to live for main branch, test otherwise)'
     required: false
   api-url:
-    description: 'AtlaSent API URL base. Defaults to ATLASENT_BASE_URL when set, otherwise https://api.atlasent.io. The action only calls /v1-evaluate and /v1-verify-permit runtime routes.'
+    description: 'AtlaSent API URL base. Defaults to ATLASENT_BASE_URL when set, otherwise https://api.atlasent.io. IMPORTANT: the api.atlasent.io apex 404s unless a custom domain is verified — for a self-hosted or pilot deployment set this to your project URL ending in /functions/v1, or the gate will appear broken. The action only calls /v1-evaluate and /v1-verify-permit runtime routes.'
     required: false
     default: 'https://api.atlasent.io'
   fail-on-deny:


### PR DESCRIPTION
## Summary

The action defaults `api-url` to `https://api.atlasent.io`, which **404s unless a custom domain is verified**. A pilot/self-hosted customer using the defaults gets a gate that *looks broken* — exactly the kind of first-impression failure to avoid.

Adds a prominent warning to:
- `action.yml` — the `api-url` input description.
- `README.md` — the inputs table row.

Both say: **set `api-url` to your project URL ending in `/functions/v1`** for a self-hosted or pilot deployment.

The **default is unchanged** (to avoid breaking setups that already have the apex wired) — this is a docs/clarity change only.

Companion to atlasent-console (hides the half-built GitHub webhook card from the pilot nav; the deploy-gate guidance lives here, its proper home).

https://claude.ai/code/session_0156C8Mw8szXMbT3FGPu8X7t

---
_Generated by [Claude Code](https://claude.ai/code/session_0156C8Mw8szXMbT3FGPu8X7t)_