### PR TITLE
fix(action): remove expression from description text (blocks action load)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -36,7 +36,7 @@ inputs:
           review is APPROVED, derived from the GitHub API, and inject as
           context.approvals + context.approving_reviewers. Lets the
           `allow-2-approvals-change-window` policy template work out of the box.
-          Requires GITHUB_TOKEN (pass `env: GITHUB_TOKEN: ${{ github.token }}`).
+          Requires GITHUB_TOKEN (set `env: GITHUB_TOKEN` to your token secret).
         - "none": do not derive approvals; supply them via the `context` input.
       Best-effort and fail-open-to-zero: any API failure yields 0 approvals,
       which denies a count-gated deploy (the fail-closed direction).


### PR DESCRIPTION
## Summary

GitHub Actions evaluates `${{ }}` expressions even inside YAML block scalar `description` fields. The `approvals-from` input description contained `` `env: GITHUB_TOKEN: ${{ github.token }}` `` as a documentation example, which GitHub tried to parse as a live expression — causing:

```
atlasent-systems-inc/atlasent-action/v1/action.yml (Line: 33, Col: 18):
Unrecognized named-value: 'github'. Located at position 1 within expression: github.token
Failed to load atlasent-systems-inc/atlasent-action/v1/action.yml
```

This blocked every `atlasent-action@v1` invocation from loading at all.

**Fix:** Replace the `${{ github.token }}` example in the description with plain text.

After merging, the `v1` tag must be moved to this commit so the fix takes effect for all callers using `@v1`.

## Test plan

- [ ] Merge to main
- [ ] Move `v1` tag to new commit (trigger `create-v1-tag` workflow or push tag manually)
- [ ] Verify `deploy-production.yml` gate step loads without error

https://claude.ai/code/session_018ekMik8GxT9zRus8sw99d8

---
_Generated by [Claude Code](https://claude.ai/code/session_018ekMik8GxT9zRus8sw99d8)_