### PR TITLE
fix(release): add commit_sha input to create-v1-tag workflow

### DIFF
--- a/.github/workflows/create-v1-tag.yml
+++ b/.github/workflows/create-v1-tag.yml
@@ -12,6 +12,10 @@ on:
         description: 'Tag v1 should point at (e.g. v1.3.0). Leave blank to use the latest v1.*.* tag.'
         required: false
         default: ''
+      commit_sha:
+        description: 'Commit SHA to point v1 at directly (bypasses versioned tag requirement — use for hotfixes before a versioned release is cut).'
+        required: false
+        default: ''
 
 permissions:
   contents: write
@@ -27,20 +31,31 @@ jobs:
 
       - name: Resolve and move v1
         run: |
+          commit_sha='${{ github.event.inputs.commit_sha }}'
           target='${{ github.event.inputs.target_tag }}'
-          if [ -z "$target" ]; then
-            target="$(git tag -l 'v1.*.*' --sort=-v:refname | head -n1)"
-          fi
-          if [ -z "$target" ]; then
-            echo "::error::No v1.*.* tag found and no target_tag provided. Cut a v1.x release first."
-            exit 1
-          fi
-          if ! git rev-parse -q --verify "refs/tags/$target" >/dev/null; then
-            echo "::error::Tag '$target' does not exist."
-            exit 1
-          fi
-          echo "Moving v1 -> $target"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag -f v1 "$target"
+          if [ -n "$commit_sha" ]; then
+            # Direct SHA mode — validate it exists in the repo then point v1 at it.
+            if ! git rev-parse -q --verify "$commit_sha^{commit}" >/dev/null; then
+              echo "::error::Commit SHA '$commit_sha' not found."
+              exit 1
+            fi
+            echo "Moving v1 -> $commit_sha (direct SHA)"
+            git tag -f v1 "$commit_sha"
+          else
+            if [ -z "$target" ]; then
+              target="$(git tag -l 'v1.*.*' --sort=-v:refname | head -n1)"
+            fi
+            if [ -z "$target" ]; then
+              echo "::error::No v1.*.* tag found and no target_tag/commit_sha provided. Cut a v1.x release first."
+              exit 1
+            fi
+            if ! git rev-parse -q --verify "refs/tags/$target" >/dev/null; then
+              echo "::error::Tag '$target' does not exist."
+              exit 1
+            fi
+            echo "Moving v1 -> $target"
+            git tag -f v1 "$target"
+          fi
           git push origin refs/tags/v1 --force

--- a/action.yml
+++ b/action.yml
@@ -36,7 +36,7 @@ inputs:
           review is APPROVED, derived from the GitHub API, and inject as
           context.approvals + context.approving_reviewers. Lets the
           `allow-2-approvals-change-window` policy template work out of the box.
-          Requires GITHUB_TOKEN (pass `env: GITHUB_TOKEN: ${{ github.token }}`).
+          Requires GITHUB_TOKEN (set `env: GITHUB_TOKEN` to your token secret).
         - "none": do not derive approvals; supply them via the `context` input.
       Best-effort and fail-open-to-zero: any API failure yields 0 approvals,
       which denies a count-gated deploy (the fail-closed direction).


### PR DESCRIPTION
## Summary

Adds a `commit_sha` input to the `create-v1-tag` workflow so the `v1` floating tag can be pointed at a specific commit SHA without needing a versioned `v1.x.y` tag to already exist.

Needed right now to move `v1` to `734cd99` (the fix from PR #90) before a full versioned release is cut.

## Usage after merge

Run `Move v1 floating tag` workflow with:
- `commit_sha`: `734cd99567ece1358db74fdbde61963685875eff`
- `target_tag`: *(leave blank)*

## Test plan

- [ ] Merge to main
- [ ] Trigger `Move v1 floating tag` with `commit_sha=734cd99567ece1358db74fdbde61963685875eff`
- [ ] Verify `v1` tag points to `734cd99`
- [ ] Trigger `deploy-production.yml` with `skip_gate=true`, `FUNCTIONS_ONLY`, `v1-evaluate` — gate step should load cleanly

https://claude.ai/code/session_018ekMik8GxT9zRus8sw99d8

---
_Generated by [Claude Code](https://claude.ai/code/session_018ekMik8GxT9zRus8sw99d8)_