### PR TITLE
docs(readme): frame deploy gate as one source of authority → permit

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ GitHub Action for the **CI/CD deployment authorization** domain of [AtlaSent](ht
 
 Require execution-time authorization before critical CI/CD actions run. Drop AtlaSent into any GitHub Actions workflow with a single step.
 
+The deploy gate is one source of authority — a CI/CD check that confirms a change is safe to ship. A human approval, a policy rule, or a risk-engine decision are others. Whatever authorizes the deploy, the result is the same: a single-use permit, verified before the deploy step runs and recorded as audit evidence.
+
 ```
 Push to main → AtlaSent evaluates → permit issued → deploy
                                   → denied       → fail with reason


### PR DESCRIPTION
## Summary

README positioning pass, part of a cross-repo framing rollout (atlasent-console #897/#899, atlasent-docs #315).

Adds a paragraph framing the deploy gate as one source of authority (a CI/CD safe-to-ship check) — alongside human approval, policy rules, and risk-engine decisions. Whatever authorizes the deploy, the result is the same: a single-use permit verified before the deploy step runs and recorded as audit evidence.

## Test plan
- [x] Additive prose only; no code change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DUFk8QjPSo2LeByUZmddUZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01DUFk8QjPSo2LeByUZmddUZ)_