### PR TITLE
chore(deps): bump @atlasent/sdk 2.10.0 → 2.16.0 (pilot alignment)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to `atlasent-action` are documented here.
 
 ## [Unreleased]
 
+### SDK bump: `@atlasent/sdk` → `2.16.0` (pilot client-surface alignment)
+
+Bumps the bundled `@atlasent/sdk` from `2.10.0` to `2.16.0` — the current
+latest **published** npm version. `2.10.0` predates `2.14.0`, the release that
+added the top-level `state_snapshot` field; with the pilot's action classes
+defaulting to `requires_state_snapshot = true`, the stale pin was a
+client-surface drift (the Action injects `state_snapshot` at the HTTP layer, so
+the deploy gate kept working, but the bundled SDK was behind). `2.16.0` is the
+known-good pinned version for the pilot path. No publish was required — this is
+a dependency/lockfile bump only.
+
+> The SDK repo source is at `2.17.0`, but that version is not published to npm
+> yet. The Action tracks the latest *published* version; it moves to `2.17.0`
+> when (and if) `2.17.0` is released. The Action does not import `@atlasent/sdk`
+> at runtime (the contract goes over HTTP), so this bump carries no behavioral
+> change to the gate.
+
+
 ### Approvals from PR reviews (P0 — deploy pilot)
 
 The single-eval path now derives `context.approvals` from the pull request's

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       ],
       "dependencies": {
         "@atlasent/enforce": "^2.0.0",
-        "@atlasent/sdk": "2.10.0"
+        "@atlasent/sdk": "2.16.0"
       },
       "devDependencies": {
         "@types/node": "^20.0.0",
@@ -27,8 +27,9 @@
       "link": true
     },
     "node_modules/@atlasent/sdk": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@atlasent/sdk/-/sdk-2.10.0.tgz",
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/@atlasent/sdk/-/sdk-2.16.0.tgz",
+      "integrity": "sha512-3wTzcCnhlJG2Kk/U5IheaeUPSTo/TCb2VsjniaFyEo32da/WQDJy6kmDLERVv0pS+DE/IJPqB4FASTlxU3XI9Q==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@atlasent/enforce": "^2.0.0",
-    "@atlasent/sdk": "2.10.0"
+    "@atlasent/sdk": "2.16.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",


### PR DESCRIPTION
## Summary

Closes the pilot client-surface drift flagged in the next-layer / B7 prereq work: `atlasent-action` bundled `@atlasent/sdk@2.10.0`, which **predates `2.14.0`** — the release that added the top-level `state_snapshot` field. The pilot's action classes default to `requires_state_snapshot = true`, so the pin was stale.

Bumps to **`2.16.0`**, the current **latest published** npm version (verified: `npm view @atlasent/sdk version` → `2.16.0`) and the known-good pin for the pilot path. `2.16.0 ≥ 2.14.0`, so it supports `state_snapshot`.

**No publish was required** — this is a `package.json` + `package-lock.json` bump only, with a clean integrity-hashed lockfile resolution (no transitive churn).

> The SDK repo *source* is at `2.17.0`, but `2.17.0` is **not published to npm**. The Action tracks the latest *published* version; it moves to `2.17.0` if/when that's released. The Action does **not import `@atlasent/sdk` at runtime** (the contract goes over HTTP), so this carries no behavioral change to the gate — the deploy gate worked throughout because the Action injects `state_snapshot` at the HTTP layer.

## Test plan

- `npm ci` resolves `@atlasent/sdk@2.16.0` (published, integrity-pinned) — CI green expected.
- No `src/` change → prebuilt `dist/` stays valid (SDK not imported at runtime).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VMM1YLR83woi5Eh2b6A5Em)_