### PR TITLE
feat: accept package.release as a permitted gate action

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -358,7 +358,12 @@ async function loopEvaluate(apiUrl, headers, items) {
 
 // src/canonicalAction.ts
 var PRODUCTION_DEPLOY_ACTION = "production.deploy";
+var PACKAGE_RELEASE_ACTION = "package.release";
 var LEGACY_PRODUCTION_DEPLOY_ALIAS = "deployment.production";
+var GATE_PERMITTED_ACTIONS = /* @__PURE__ */ new Set([
+  PRODUCTION_DEPLOY_ACTION,
+  PACKAGE_RELEASE_ACTION
+]);
 function normalizeProtectedAction(raw) {
   if (raw === LEGACY_PRODUCTION_DEPLOY_ALIAS) {
     return { canonical: PRODUCTION_DEPLOY_ACTION, wasLegacyAlias: true };
@@ -1508,11 +1513,11 @@ function getApiKey() {
 }
 function normalizeAndValidateProtectedAction(actionType) {
   const { canonical } = normalizeProtectedAction(actionType);
-  if (canonical !== PRODUCTION_DEPLOY_ACTION) {
+  if (!GATE_PERMITTED_ACTIONS.has(canonical)) {
     setOutput("decision", "error");
     setOutput("verified", "false");
     setFailed(
-      `AtlaSent Gate: unsupported protected action "${actionType}". Deploy Gate V1 only permits "${PRODUCTION_DEPLOY_ACTION}" (legacy alias "${LEGACY_PRODUCTION_DEPLOY_ALIAS}" is accepted during the V1 alias window).`
+      `AtlaSent Gate: unsupported protected action "${actionType}". Permitted actions: ${[...GATE_PERMITTED_ACTIONS].map((a) => `"${a}"`).join(", ")} (legacy alias "${LEGACY_PRODUCTION_DEPLOY_ALIAS}" is accepted and normalized to "${PRODUCTION_DEPLOY_ACTION}").`
     );
   }
   return canonical;

--- a/src/__tests__/canonicalAction.test.ts
+++ b/src/__tests__/canonicalAction.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
+  GATE_PERMITTED_ACTIONS,
   LEGACY_PRODUCTION_DEPLOY_ALIAS,
+  PACKAGE_RELEASE_ACTION,
   PRODUCTION_DEPLOY_ACTION,
   PROTECTED_ACTIONS_CATALOG,
   assertProtectedAction,
@@ -69,6 +71,26 @@ describe("canonicalAction", () => {
 
     it("PROTECTED_ACTIONS_CATALOG contains exactly 19 entries", () => {
       expect(PROTECTED_ACTIONS_CATALOG.size).toBe(19);
+    });
+  });
+
+  describe("GATE_PERMITTED_ACTIONS", () => {
+    it("permits production.deploy and package.release", () => {
+      expect(GATE_PERMITTED_ACTIONS.has(PRODUCTION_DEPLOY_ACTION)).toBe(true);
+      expect(GATE_PERMITTED_ACTIONS.has(PACKAGE_RELEASE_ACTION)).toBe(true);
+    });
+
+    it("is a conservative two-entry allow-list (not open to arbitrary types)", () => {
+      expect(GATE_PERMITTED_ACTIONS.size).toBe(2);
+      // A well-formed but unlisted action is NOT gate-permitted, even though
+      // its format is valid — the runtime policy is the authority, but the
+      // gate's client-side guard stays explicit.
+      expect(GATE_PERMITTED_ACTIONS.has("database.migration.apply")).toBe(false);
+    });
+
+    it("package.release is distinct from production.deploy", () => {
+      expect(PACKAGE_RELEASE_ACTION).toBe("package.release");
+      expect(PACKAGE_RELEASE_ACTION).not.toBe(PRODUCTION_DEPLOY_ACTION);
     });
   });
 });

--- a/src/canonicalAction.ts
+++ b/src/canonicalAction.ts
@@ -17,6 +17,14 @@
 // ---------------------------------------------------------------------------
 
 export const PRODUCTION_DEPLOY_ACTION = "production.deploy";
+/**
+ * Package/artifact publishing to a public registry (PyPI, npm, crates, …).
+ * Distinct from production.deploy: governed by a release policy that does NOT
+ * require interactive PR approvals, since publishes run on workflow_dispatch /
+ * tag pushes where no PR review evidence exists. production.deploy keeps its
+ * human-approval requirement — the two must never share a policy.
+ */
+export const PACKAGE_RELEASE_ACTION = "package.release";
 export const DATABASE_MIGRATION_ACTION = "database.migration.apply";
 export const DATABASE_SCHEMA_DROP_ACTION = "database.schema.drop";
 export const DATA_EXPORT_BULK_ACTION = "data.export.bulk";
@@ -26,6 +34,19 @@ export const SECRET_ROTATION_PRODUCTION_ACTION = "secret.rotation.production";
 
 /** Legacy alias — accepted during the V1 alias window, normalized on input. */
 export const LEGACY_PRODUCTION_DEPLOY_ALIAS = "deployment.production";
+
+/**
+ * Action types the gate accepts on its single-eval path. This is a
+ * conservative client-side allow-list, NOT the authority — the runtime
+ * policy is. Deny-by-default still applies: an accepted action type with
+ * no published policy bundle resolves to deny at the runtime. We keep the
+ * set explicit (rather than accepting any well-formed type) so a typo in a
+ * workflow surfaces as a clear gate error instead of a silent deny.
+ */
+export const GATE_PERMITTED_ACTIONS: ReadonlySet<string> = new Set([
+  PRODUCTION_DEPLOY_ACTION,
+  PACKAGE_RELEASE_ACTION,
+]);
 
 // ---------------------------------------------------------------------------
 // Phase 1–6 catalog (informational — not an enforcement whitelist)

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,7 @@ import {
   type EvidenceBundleRegime,
 } from "./postDeployEvidenceBundle";
 import {
+  GATE_PERMITTED_ACTIONS,
   LEGACY_PRODUCTION_DEPLOY_ALIAS,
   PRODUCTION_DEPLOY_ACTION,
   normalizeProtectedAction,
@@ -53,24 +54,31 @@ function getApiKey(): string {
 }
 
 /**
- * Normalize the workflow-supplied `action` input to the canonical
- * Deploy Gate V1 string. Legacy alias `deployment.production` is
- * accepted and rewritten to `production.deploy`. Anything else
- * fails closed with `decision=error`.
+ * Normalize the workflow-supplied `action` input to a canonical gate action
+ * string. Legacy alias `deployment.production` is accepted and rewritten to
+ * `production.deploy`. The canonical value must be in GATE_PERMITTED_ACTIONS
+ * (currently `production.deploy` and `package.release`); anything else fails
+ * closed with `decision=error`.
  *
- * Returns the canonical string for downstream use. Callers should
- * use the returned value, NOT the raw input, so every downstream
- * surface (evaluate body, GH outputs, audit) carries the canonical.
+ * The permitted set is a conservative client-side guard, not the authority —
+ * the runtime policy decides allow/deny, and deny-by-default still applies to
+ * an accepted action type that has no published bundle. Keeping the set
+ * explicit means a workflow typo surfaces as a clear gate error here rather
+ * than a confusing silent deny at the runtime.
+ *
+ * Returns the canonical string for downstream use. Callers should use the
+ * returned value, NOT the raw input, so every downstream surface (evaluate
+ * body, GH outputs, audit) carries the canonical.
  */
 function normalizeAndValidateProtectedAction(actionType: string): string {
   const { canonical } = normalizeProtectedAction(actionType);
-  if (canonical !== PRODUCTION_DEPLOY_ACTION) {
+  if (!GATE_PERMITTED_ACTIONS.has(canonical)) {
     setOutput("decision", "error");
     setOutput("verified", "false");
     setFailed(
       `AtlaSent Gate: unsupported protected action "${actionType}". ` +
-        `Deploy Gate V1 only permits "${PRODUCTION_DEPLOY_ACTION}" ` +
-        `(legacy alias "${LEGACY_PRODUCTION_DEPLOY_ALIAS}" is accepted during the V1 alias window).`,
+        `Permitted actions: ${[...GATE_PERMITTED_ACTIONS].map((a) => `"${a}"`).join(", ")} ` +
+        `(legacy alias "${LEGACY_PRODUCTION_DEPLOY_ALIAS}" is accepted and normalized to "${PRODUCTION_DEPLOY_ACTION}").`,
     );
   }
   return canonical;


### PR DESCRIPTION
## Summary

PR 1 of 3 enabling a dedicated `package.release` protected action for package publishing (PyPI/npm/…), so releases stop being forced through the `production.deploy` human-approval policy. **`production.deploy` is not weakened by this PR.**

This PR makes the gate *accept* the new action type. It does **not** move `@v1` — that's a gated step pending your review + green CI.

### Files changed
- `src/canonicalAction.ts` — add `PACKAGE_RELEASE_ACTION = "package.release"` and a conservative `GATE_PERMITTED_ACTIONS = { production.deploy, package.release }` set.
- `src/index.ts` — `normalizeAndValidateProtectedAction()` now checks membership in `GATE_PERMITTED_ACTIONS` (was: equality with `production.deploy`). Error message lists permitted actions.
- `src/__tests__/canonicalAction.test.ts` — +3 tests pinning the permitted set (size = 2, both members present, unlisted well-formed types excluded).
- `dist/index.js` — rebuilt via esbuild (the action runs from `dist`).

### Behavior (client-side guard only — runtime policy is the authority)
- `production.deploy` → accepted (unchanged)
- `deployment.production` → normalized → `production.deploy` (unchanged)
- `package.release` → **accepted (new)**
- any other type (e.g. `database.migration.apply`) → rejected client-side with `decision=error` (deny-direction). Deny-by-default still applies at the runtime for an accepted type with no published bundle.

### Test plan
- `npm run build` → `dist/index.js` rebuilt (88.1kb), contains `package.release`.
- `npm run typecheck` → clean.
- `npm test` → **314 passed** (was 311; +3 new).

### Rollback plan
- Pre-merge: close PR. No consumer impact — `@v1` is unchanged until the tag is deliberately moved.
- Post-merge, pre-tag-move: still no consumer impact (consumers pin `@v1`).
- Post-tag-move: revert `@v1` to the previous commit (`a60e112`). The change is purely additive to the allow-list, so reverting only removes `package.release` acceptance; `production.deploy` consumers are unaffected throughout.

### ⚠️ Gated next step (your approval required)
Move `atlasent-action@v1` to this commit **only after** review + CI pass. Until then, the atlasent-sdk workflow (PR 3) must not switch to `package.release`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YXtoRUrdoUesaSN2Zeqt4V)_