### PR TITLE
fix(packages): add repository field for npm provenance (unblock publish)

### DIFF
--- a/packages/action/package.json
+++ b/packages/action/package.json
@@ -2,6 +2,12 @@
   "name": "@atlasent/action",
   "version": "2.0.0",
   "description": "AtlaSent execution-authority connectors (agent / webhook / Supabase-migration guards) — authorize-before-execute for any Node runtime",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/AtlaSent-Systems-Inc/atlasent-action.git",
+    "directory": "packages/action"
+  },
+  "homepage": "https://github.com/AtlaSent-Systems-Inc/atlasent-action/tree/main/packages/action#readme",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/packages/enforce/package.json
+++ b/packages/enforce/package.json
@@ -2,6 +2,12 @@
   "name": "@atlasent/enforce",
   "version": "2.0.0",
   "description": "Fail-closed execution wrapper enforcing the AtlaSent evaluate → verify → execute contract",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/AtlaSent-Systems-Inc/atlasent-action.git",
+    "directory": "packages/enforce"
+  },
+  "homepage": "https://github.com/AtlaSent-Systems-Inc/atlasent-action/tree/main/packages/enforce#readme",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [


### PR DESCRIPTION
## Summary

The first real publish run failed with **E422** from npm:

```
Error verifying sigstore provenance bundle: Failed to validate repository information:
package.json: "repository.url" is "", expected to match
"https://github.com/AtlaSent-Systems-Inc/atlasent-action" from provenance
```

npm `--provenance` cross-checks each package's `repository.url` against the signed source repo, and I'd omitted the field. This adds `repository` (with the monorepo `directory`) + `homepage` to both `@atlasent/enforce` and `@atlasent/action`.

- **`NPM_TOKEN` is confirmed working** — the failed run authenticated and signed the provenance statement; it only tripped on this metadata check.
- **Nothing was published** — `@atlasent/enforce` is published first and failed, so `2.0.0` is not burned on either package. A clean re-run will publish both.

No code or version change.

## Next step
Once merged, re-run `publish-packages.yml` (workflow_dispatch, `publish: true`) on `main` to publish `2.0.0` of both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AaRgWezyFYJv1wEDZVN9fQ)_