### PR TITLE
feat(gate): render a trust panel in the GitHub job summary for every outcome

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1503,6 +1503,96 @@ async function resolveApprovals(options) {
   return { approvals, approving_reviewers, pr_number: prNumber, source: "pr-reviews" };
 }
 
+// src/stepSummary.ts
+var DEFAULT_CONSOLE = "https://console.atlasent.io";
+function truncHash(h) {
+  if (!h)
+    return void 0;
+  return h.length > 24 ? `${h.slice(0, 24)}\u2026` : h;
+}
+function buildGateStepSummary(input) {
+  const consoleBase = (input.consoleBaseUrl ?? DEFAULT_CONSOLE).replace(/\/$/, "");
+  const isAllow = input.outcome === "allow";
+  const icon = input.outcome === "allow" ? "\u2705" : input.outcome === "deny" ? "\u{1F534}" : input.outcome === "hold" ? "\u{1F7E1}" : input.outcome === "escalate" ? "\u{1F6A8}" : "\u26D4";
+  const label = input.outcome === "allow" ? "AUTHORIZED" : input.outcome === "deny" ? "DENIED" : input.outcome === "hold" ? "ON HOLD" : input.outcome === "escalate" ? "ESCALATED" : "BLOCKED (fail-closed)";
+  const lines = [];
+  lines.push("", "---", `## ${icon} AtlaSent Deploy Gate \u2014 ${label}`, "");
+  if (isAllow) {
+    lines.push(
+      `Authorization **granted** for \`${input.action}\` by **${input.actor}** in **${input.environment}**. The deploy is permitted to proceed.`
+    );
+  } else if (input.outcome === "error") {
+    lines.push(
+      `The gate **could not confirm authorization** for \`${input.action}\`, so the deploy did **not** run. This is fail-closed behavior by design \u2014 a gate that cannot verify a decision blocks rather than waves the action through.`
+    );
+  } else {
+    lines.push(
+      `The gate **blocked** \`${input.action}\` by **${input.actor}** in **${input.environment}**. The deploy did not run.`
+    );
+  }
+  lines.push("");
+  lines.push(`| Field | Value |`, `|---|---|`);
+  lines.push(`| Decision | \`${input.outcome}\` |`);
+  if (!isAllow && input.reason)
+    lines.push(`| Reason | ${input.reason} |`);
+  if (!isAllow && input.denyCode)
+    lines.push(`| Deny code | \`${input.denyCode}\` |`);
+  lines.push(`| Action | \`${input.action}\` |`);
+  lines.push(`| Actor | \`${input.actor}\` |`);
+  lines.push(`| Environment | \`${input.environment}\` |`);
+  if (input.targetId)
+    lines.push(`| Target | \`${input.targetId}\` |`);
+  if (typeof input.riskScore === "number") {
+    const cls = input.riskClass ? ` (${input.riskClass})` : "";
+    lines.push(`| Risk score | ${input.riskScore}${cls} |`);
+  } else if (input.riskClass) {
+    lines.push(`| Risk class | \`${input.riskClass}\` |`);
+  }
+  lines.push("");
+  const evalId = input.evaluationId;
+  const audit = truncHash(input.auditHash);
+  const hasEvidence = !!(evalId || audit || isAllow && input.permitIssued);
+  if (hasEvidence) {
+    lines.push("### Evidence", "");
+    if (evalId)
+      lines.push(`- **Evaluation ID:** \`${evalId}\``);
+    if (audit)
+      lines.push(`- **Audit chain hash:** \`${audit}\``);
+    if (isAllow && input.permitIssued) {
+      const verifiedNote = input.verified ? `issued and **verified**${input.verifyOutcome ? ` (${input.verifyOutcome})` : ""}` : "issued";
+      lines.push(`- **Permit:** ${verifiedNote} \u2713`);
+    }
+    if (isAllow && input.evidenceReceiptId) {
+      lines.push(`- **Evidence receipt:** \`${input.evidenceReceiptId}\``);
+    }
+    lines.push("");
+  }
+  if (evalId) {
+    lines.push(
+      `[View the full decision & replay the evidence](${consoleBase}/decisions/${evalId}/replay)`
+    );
+  }
+  lines.push(`[View workflow run](${input.runUrl})`);
+  if (input.outcome === "hold" || input.outcome === "escalate") {
+    lines.push(
+      "",
+      `> **Next step:** an authorized reviewer must approve this deployment in the [AtlaSent console](${consoleBase}/approvals) or via the Slack Approval Bot, then re-run this job.`
+    );
+  } else if (input.outcome === "deny") {
+    lines.push(
+      "",
+      `> **Why blocked?** The decision above is recorded as an immutable, hash-linked audit entry. Open the decision link to see exactly which policy rule fired.`
+    );
+  } else if (isAllow) {
+    lines.push(
+      "",
+      `> This decision is recorded as a tamper-evident, hash-linked audit entry and can be verified offline against the signed audit chain.`
+    );
+  }
+  lines.push("");
+  return lines.join("\n");
+}
+
 // src/index.ts
 function getApiKey() {
   const apiKey = (process.env["ATLASENT_API_KEY"] ?? "").trim();
@@ -2412,6 +2502,26 @@ async function run() {
           });
         }
       }
+      {
+        const blockedDecision = err.decision?.decision;
+        const summaryOutcome = blockedDecision === "deny" || blockedDecision === "hold" || blockedDecision === "escalate" ? blockedDecision : "error";
+        const summaryReason = summaryOutcome === "deny" ? err.decision?.denyReason ?? err.message : summaryOutcome === "hold" ? err.decision?.holdReason ?? "awaiting approval" : summaryOutcome === "escalate" ? "manual review required" : err.message;
+        appendToStepSummary(
+          buildGateStepSummary({
+            outcome: summaryOutcome,
+            action: actionType,
+            actor: `github:${actor}`,
+            environment,
+            targetId,
+            runUrl: `${gh.server_url}/${gh.repository}/actions/runs/${gh.run_id}`,
+            reason: summaryReason,
+            evaluationId: err.decision?.evaluationId,
+            auditHash: err.decision?.auditHash,
+            riskScore: err.decision?.riskScore,
+            riskClass: err.decision?.risk_class
+          })
+        );
+      }
       switch (err.phase) {
         case "evaluate":
           setFailed(
@@ -2466,6 +2576,17 @@ async function run() {
       targetUrl: `${gh.server_url}/${gh.repository}/actions/runs/${gh.run_id}`
     });
     emitFinancialGovernanceAdvisory(actionType, actor, orgId);
+    appendToStepSummary(
+      buildGateStepSummary({
+        outcome: "error",
+        action: actionType,
+        actor: `github:${actor}`,
+        environment,
+        targetId,
+        runUrl: `${gh.server_url}/${gh.repository}/actions/runs/${gh.run_id}`,
+        reason: err instanceof Error ? err.message : String(err)
+      })
+    );
     setFailed(
       `AtlaSent Gate: Unexpected error: ${err instanceof Error ? err.message : String(err)}`
     );
@@ -2488,6 +2609,7 @@ async function run() {
   if (d.riskScore !== void 0)
     info(`  Risk score:   ${d.riskScore}`);
   info(`  Verify:       ${verifyOutcome ?? "verified"}`);
+  let evidenceReceiptId;
   try {
     const receiptSigningSecret = process.env["ATLASENT_RECEIPT_SIGNING_SECRET"];
     const receiptSigningKeyId = getInput("receipt-signing-key-id");
@@ -2508,6 +2630,7 @@ async function run() {
     });
     setOutput("evidence-receipt", JSON.stringify(bundle.receipt));
     setOutput("evidence-bundle", JSON.stringify(bundle));
+    evidenceReceiptId = bundle.receipt.receipt_id;
     info(
       `  Evidence:     receipt=${bundle.receipt.receipt_id} algorithm=${bundle.receipt.algorithm}`
     );
@@ -2518,6 +2641,24 @@ async function run() {
     setOutput("evidence-receipt", JSON.stringify(null));
     setOutput("evidence-bundle", JSON.stringify(null));
   }
+  appendToStepSummary(
+    buildGateStepSummary({
+      outcome: "allow",
+      action: actionType,
+      actor: `github:${actor}`,
+      environment,
+      targetId,
+      runUrl: `${gh.server_url}/${gh.repository}/actions/runs/${gh.run_id}`,
+      verified: true,
+      verifyOutcome,
+      evaluationId: d.evaluationId,
+      auditHash: d.auditHash,
+      riskScore: d.riskScore,
+      riskClass: d.risk_class,
+      permitIssued: !!d.permitToken,
+      evidenceReceiptId
+    })
+  );
   if (d.permitToken && d.evaluationId) {
     await emitEvidenceEvent(
       { apiKey, apiUrl },

--- a/src/__tests__/stepSummary.test.ts
+++ b/src/__tests__/stepSummary.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from "vitest";
+import { buildGateStepSummary } from "../stepSummary";
+
+const base = {
+  action: "production.deploy",
+  actor: "github:alice",
+  environment: "live",
+  runUrl: "https://github.com/org/repo/actions/runs/123",
+};
+
+describe("buildGateStepSummary", () => {
+  it("renders an AUTHORIZED panel with the evidence anchors on allow", () => {
+    const md = buildGateStepSummary({
+      ...base,
+      outcome: "allow",
+      targetId: "org/repo",
+      verified: true,
+      verifyOutcome: "verified",
+      evaluationId: "eval_abc123",
+      auditHash: "a".repeat(40),
+      riskScore: 12,
+      riskClass: "low",
+      permitIssued: true,
+      evidenceReceiptId: "rcpt_1",
+    });
+    expect(md).toContain("✅ AtlaSent Deploy Gate — AUTHORIZED");
+    expect(md).toContain("Authorization **granted**");
+    expect(md).toContain("**Evaluation ID:** `eval_abc123`");
+    // permit is acknowledged as verified, but the token is never printed.
+    expect(md).toContain("**Permit:** issued and **verified** (verified) ✓");
+    expect(md).toContain("**Evidence receipt:** `rcpt_1`");
+    expect(md).toContain("Risk score | 12 (low)");
+    // deep link to the decision replay/evidence view.
+    expect(md).toContain(
+      "https://console.atlasent.io/decisions/eval_abc123/replay",
+    );
+    expect(md).toContain("verified offline against the signed audit chain");
+  });
+
+  it("never prints the permit token or proof hash", () => {
+    const md = buildGateStepSummary({
+      ...base,
+      outcome: "allow",
+      permitIssued: true,
+      evaluationId: "eval_x",
+    });
+    expect(md).not.toMatch(/permit[_-]?token/i);
+    expect(md).not.toContain("proofHash");
+  });
+
+  it("renders a DENIED panel with the reason and audit anchor", () => {
+    const md = buildGateStepSummary({
+      ...base,
+      outcome: "deny",
+      reason: "requires 2 approvals; found 0",
+      evaluationId: "eval_deny1",
+      auditHash: "b".repeat(64),
+    });
+    expect(md).toContain("🔴 AtlaSent Deploy Gate — DENIED");
+    expect(md).toContain("Reason | requires 2 approvals; found 0");
+    expect(md).toContain("**Evaluation ID:** `eval_deny1`");
+    // audit hash is truncated to 24 chars + ellipsis, never the full value.
+    expect(md).toContain(`\`${"b".repeat(24)}…\``);
+    expect(md).not.toContain("b".repeat(25));
+    expect(md).toContain("which policy rule fired");
+  });
+
+  it("includes a deny code when one is supplied", () => {
+    const md = buildGateStepSummary({
+      ...base,
+      outcome: "deny",
+      reason: "human approval required",
+      denyCode: "INSUFFICIENT_APPROVALS",
+    });
+    expect(md).toContain("Deny code | `INSUFFICIENT_APPROVALS`");
+  });
+
+  it("renders a HOLD panel with the approve-and-rerun next step", () => {
+    const md = buildGateStepSummary({
+      ...base,
+      outcome: "hold",
+      reason: "awaiting approval",
+      evaluationId: "eval_hold1",
+    });
+    expect(md).toContain("🟡 AtlaSent Deploy Gate — ON HOLD");
+    expect(md).toContain("authorized reviewer must approve");
+    expect(md).toContain("https://console.atlasent.io/approvals");
+    expect(md).toContain("re-run this job");
+  });
+
+  it("renders a fail-closed panel on infra error and explains the default", () => {
+    const md = buildGateStepSummary({
+      ...base,
+      outcome: "error",
+      reason: "evaluate request timed out",
+    });
+    expect(md).toContain("⛔ AtlaSent Deploy Gate — BLOCKED (fail-closed)");
+    expect(md).toContain("could not confirm authorization");
+    expect(md).toContain("fail-closed behavior by design");
+    expect(md).toContain("Reason | evaluate request timed out");
+  });
+
+  it("omits the decision deep link when there is no evaluation id", () => {
+    const md = buildGateStepSummary({ ...base, outcome: "error", reason: "boom" });
+    expect(md).not.toContain("/decisions/");
+    expect(md).toContain("[View workflow run]");
+  });
+
+  it("honors a custom console base url", () => {
+    const md = buildGateStepSummary({
+      ...base,
+      outcome: "deny",
+      reason: "nope",
+      evaluationId: "e1",
+      consoleBaseUrl: "https://acme.example.com/",
+    });
+    expect(md).toContain("https://acme.example.com/decisions/e1/replay");
+    expect(md).not.toContain("example.com//decisions");
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,6 +44,7 @@ import {
 } from "./canonicalAction";
 import { runVqpVerify } from "./vqpVerify";
 import { resolveApprovals, type ApprovalEvidence } from "./approvals";
+import { buildGateStepSummary, type GateOutcome } from "./stepSummary";
 
 function getApiKey(): string {
   const apiKey = (process.env["ATLASENT_API_KEY"] ?? "").trim();
@@ -1297,6 +1298,42 @@ export async function run(): Promise<void> {
         }
       }
 
+      // ── Job summary — written BEFORE setFailed (which exits the process) ──
+      // so the customer always gets the rich "why was I blocked" panel on the
+      // run page, never a bare one-line ::error::. Best-effort.
+      {
+        const blockedDecision = err.decision?.decision;
+        const summaryOutcome: GateOutcome =
+          blockedDecision === "deny" ||
+          blockedDecision === "hold" ||
+          blockedDecision === "escalate"
+            ? blockedDecision
+            : "error";
+        const summaryReason =
+          summaryOutcome === "deny"
+            ? (err.decision?.denyReason ?? err.message)
+            : summaryOutcome === "hold"
+              ? (err.decision?.holdReason ?? "awaiting approval")
+              : summaryOutcome === "escalate"
+                ? "manual review required"
+                : err.message;
+        appendToStepSummary(
+          buildGateStepSummary({
+            outcome: summaryOutcome,
+            action: actionType,
+            actor: `github:${actor}`,
+            environment,
+            targetId,
+            runUrl: `${gh.server_url}/${gh.repository}/actions/runs/${gh.run_id}`,
+            reason: summaryReason,
+            evaluationId: err.decision?.evaluationId,
+            auditHash: err.decision?.auditHash,
+            riskScore: err.decision?.riskScore,
+            riskClass: err.decision?.risk_class,
+          }),
+        );
+      }
+
       switch (err.phase) {
         case "evaluate":
           setFailed(
@@ -1358,6 +1395,18 @@ export async function run(): Promise<void> {
 
     emitFinancialGovernanceAdvisory(actionType, actor, orgId);
 
+    appendToStepSummary(
+      buildGateStepSummary({
+        outcome: "error",
+        action: actionType,
+        actor: `github:${actor}`,
+        environment,
+        targetId,
+        runUrl: `${gh.server_url}/${gh.repository}/actions/runs/${gh.run_id}`,
+        reason: err instanceof Error ? err.message : String(err),
+      }),
+    );
+
     setFailed(
       `AtlaSent Gate: Unexpected error: ${err instanceof Error ? err.message : String(err)}`,
     );
@@ -1387,6 +1436,7 @@ export async function run(): Promise<void> {
 
   // ── Build evidence bundle ─────────────────────────────────────────────────
   // Best-effort: evidence output failures must never block the gate decision.
+  let evidenceReceiptId: string | undefined;
   try {
     const receiptSigningSecret = process.env["ATLASENT_RECEIPT_SIGNING_SECRET"];
     const receiptSigningKeyId = getInput("receipt-signing-key-id");
@@ -1409,6 +1459,7 @@ export async function run(): Promise<void> {
 
     setOutput("evidence-receipt", JSON.stringify(bundle.receipt));
     setOutput("evidence-bundle", JSON.stringify(bundle));
+    evidenceReceiptId = bundle.receipt.receipt_id;
     info(
       `  Evidence:     receipt=${bundle.receipt.receipt_id} algorithm=${bundle.receipt.algorithm}`,
     );
@@ -1421,6 +1472,27 @@ export async function run(): Promise<void> {
     setOutput("evidence-receipt", JSON.stringify(null));
     setOutput("evidence-bundle", JSON.stringify(null));
   }
+
+  // ── Job summary — the rich panel a customer reads on the run page ─────────
+  // Best-effort: a summary failure must never affect the (already-granted) gate.
+  appendToStepSummary(
+    buildGateStepSummary({
+      outcome: "allow",
+      action: actionType,
+      actor: `github:${actor}`,
+      environment,
+      targetId,
+      runUrl: `${gh.server_url}/${gh.repository}/actions/runs/${gh.run_id}`,
+      verified: true,
+      verifyOutcome,
+      evaluationId: d.evaluationId,
+      auditHash: d.auditHash,
+      riskScore: d.riskScore,
+      riskClass: d.risk_class,
+      permitIssued: !!d.permitToken,
+      evidenceReceiptId,
+    }),
+  );
 
   // ── B7: emit execution_started evidence event ────────────────────────────
   // Best-effort, fire-and-forget. Build outcome is already determined above.

--- a/src/stepSummary.ts
+++ b/src/stepSummary.ts
@@ -1,0 +1,185 @@
+// AtlaSent Gate — GitHub Actions job-summary renderer.
+//
+// WHY THIS EXISTS
+// ---------------
+// The job summary (GITHUB_STEP_SUMMARY) is the single most prominent surface on
+// a GitHub Actions run page — it renders as a rich Markdown panel above the
+// logs. Until now the core deploy-gate decision wrote NOTHING there (only the
+// optional financial-governance advisory did), so a pilot whose deploy was
+// gated had to scroll raw logs to learn what happened, and a denied deploy
+// could surface as a bare "Authorization DENIED: no reason provided" with no
+// evaluation ID, no audit anchor, and no way to verify the evidence.
+//
+// This module renders one self-explanatory panel for every terminal gate
+// outcome (allow / deny / hold / escalate / fail-closed error) so the customer
+// can answer, right on the run page: what was decided, why, and how to trust /
+// verify the evidence. It is PURE (returns a string) so it is unit-testable;
+// index.ts writes the result to the step summary before failing the step.
+//
+// Evidence-surfacing rule (matches buildGateDenyComment): show the open
+// identifiers — evaluation ID + audit hash (truncated) — and state that the
+// permit was issued & verified, but NEVER print the single-use permit token or
+// the raw proof hash. The trust signal without leaking the bearer secret.
+
+export type GateOutcome = "allow" | "deny" | "hold" | "escalate" | "error";
+
+export interface GateSummaryInput {
+  /** Terminal outcome of the gate. */
+  outcome: GateOutcome;
+  /** Canonical action type (e.g. production.deploy). */
+  action: string;
+  /** Display actor (e.g. github:alice). */
+  actor: string;
+  /** Resolved environment (e.g. live / test). */
+  environment: string;
+  /** Target resource id, when supplied. */
+  targetId?: string;
+  /** Link back to this workflow run. */
+  runUrl: string;
+  /** Human-readable reason for a non-allow outcome, or the error message. */
+  reason?: string;
+  /** Machine deny code (e.g. INSUFFICIENT_APPROVALS), when surfaced. */
+  denyCode?: string;
+  /** allow path: whether the issued permit was verified. */
+  verified?: boolean;
+  /** allow path: verify outcome string from /v1-verify-permit. */
+  verifyOutcome?: string;
+  /** Evaluation / decision id — the audit anchor. */
+  evaluationId?: string;
+  /** Truncated audit chain entry hash. */
+  auditHash?: string;
+  /** Risk score 0..100, when present. */
+  riskScore?: number;
+  /** Resolved risk class (critical / high / medium / low), when present. */
+  riskClass?: string;
+  /** allow path: whether a permit token was issued. */
+  permitIssued?: boolean;
+  /** allow path: evidence receipt id, when the bundle was built. */
+  evidenceReceiptId?: string;
+  /** Console base URL for deep links (default https://console.atlasent.io). */
+  consoleBaseUrl?: string;
+}
+
+const DEFAULT_CONSOLE = "https://console.atlasent.io";
+
+function truncHash(h: string | undefined): string | undefined {
+  if (!h) return undefined;
+  return h.length > 24 ? `${h.slice(0, 24)}…` : h;
+}
+
+/** Build the Markdown job-summary panel for a terminal gate outcome. */
+export function buildGateStepSummary(input: GateSummaryInput): string {
+  const consoleBase = (input.consoleBaseUrl ?? DEFAULT_CONSOLE).replace(/\/$/, "");
+  const isAllow = input.outcome === "allow";
+
+  const icon =
+    input.outcome === "allow"
+      ? "✅"
+      : input.outcome === "deny"
+        ? "🔴"
+        : input.outcome === "hold"
+          ? "🟡"
+          : input.outcome === "escalate"
+            ? "🚨"
+            : "⛔";
+  const label =
+    input.outcome === "allow"
+      ? "AUTHORIZED"
+      : input.outcome === "deny"
+        ? "DENIED"
+        : input.outcome === "hold"
+          ? "ON HOLD"
+          : input.outcome === "escalate"
+            ? "ESCALATED"
+            : "BLOCKED (fail-closed)";
+
+  const lines: string[] = [];
+  lines.push("", "---", `## ${icon} AtlaSent Deploy Gate — ${label}`, "");
+
+  if (isAllow) {
+    lines.push(
+      `Authorization **granted** for \`${input.action}\` by **${input.actor}** in **${input.environment}**. ` +
+        `The deploy is permitted to proceed.`,
+    );
+  } else if (input.outcome === "error") {
+    lines.push(
+      `The gate **could not confirm authorization** for \`${input.action}\`, so the deploy did **not** run. ` +
+        `This is fail-closed behavior by design — a gate that cannot verify a decision blocks rather than waves the action through.`,
+    );
+  } else {
+    lines.push(
+      `The gate **blocked** \`${input.action}\` by **${input.actor}** in **${input.environment}**. ` +
+        `The deploy did not run.`,
+    );
+  }
+  lines.push("");
+
+  // ── Decision table ────────────────────────────────────────────────────────
+  lines.push(`| Field | Value |`, `|---|---|`);
+  lines.push(`| Decision | \`${input.outcome}\` |`);
+  if (!isAllow && input.reason) lines.push(`| Reason | ${input.reason} |`);
+  if (!isAllow && input.denyCode) lines.push(`| Deny code | \`${input.denyCode}\` |`);
+  lines.push(`| Action | \`${input.action}\` |`);
+  lines.push(`| Actor | \`${input.actor}\` |`);
+  lines.push(`| Environment | \`${input.environment}\` |`);
+  if (input.targetId) lines.push(`| Target | \`${input.targetId}\` |`);
+  if (typeof input.riskScore === "number") {
+    const cls = input.riskClass ? ` (${input.riskClass})` : "";
+    lines.push(`| Risk score | ${input.riskScore}${cls} |`);
+  } else if (input.riskClass) {
+    lines.push(`| Risk class | \`${input.riskClass}\` |`);
+  }
+  lines.push("");
+
+  // ── Evidence ──────────────────────────────────────────────────────────────
+  const evalId = input.evaluationId;
+  const audit = truncHash(input.auditHash);
+  const hasEvidence = !!(evalId || audit || (isAllow && input.permitIssued));
+  if (hasEvidence) {
+    lines.push("### Evidence", "");
+    if (evalId) lines.push(`- **Evaluation ID:** \`${evalId}\``);
+    if (audit) lines.push(`- **Audit chain hash:** \`${audit}\``);
+    if (isAllow && input.permitIssued) {
+      const verifiedNote = input.verified
+        ? `issued and **verified**${input.verifyOutcome ? ` (${input.verifyOutcome})` : ""}`
+        : "issued";
+      lines.push(`- **Permit:** ${verifiedNote} ✓`);
+    }
+    if (isAllow && input.evidenceReceiptId) {
+      lines.push(`- **Evidence receipt:** \`${input.evidenceReceiptId}\``);
+    }
+    lines.push("");
+  }
+
+  // ── How to verify / next step ─────────────────────────────────────────────
+  if (evalId) {
+    lines.push(
+      `[View the full decision & replay the evidence](${consoleBase}/decisions/${evalId}/replay)`,
+    );
+  }
+  lines.push(`[View workflow run](${input.runUrl})`);
+
+  if (input.outcome === "hold" || input.outcome === "escalate") {
+    lines.push(
+      "",
+      `> **Next step:** an authorized reviewer must approve this deployment in the ` +
+        `[AtlaSent console](${consoleBase}/approvals) or via the Slack Approval Bot, ` +
+        `then re-run this job.`,
+    );
+  } else if (input.outcome === "deny") {
+    lines.push(
+      "",
+      `> **Why blocked?** The decision above is recorded as an immutable, hash-linked ` +
+        `audit entry. Open the decision link to see exactly which policy rule fired.`,
+    );
+  } else if (isAllow) {
+    lines.push(
+      "",
+      `> This decision is recorded as a tamper-evident, hash-linked audit entry and ` +
+        `can be verified offline against the signed audit chain.`,
+    );
+  }
+  lines.push("");
+
+  return lines.join("\n");
+}


### PR DESCRIPTION
## Summary

When a pilot's deploy is gated, the GitHub Actions run is where they must answer **"what happened, and can I trust the evidence?"** — half the pilot success metric. But the core gate wrote **nothing** to the job summary (`GITHUB_STEP_SUMMARY`), the most prominent panel on a run page. Only the optional financial-governance advisory rendered there. A denied deploy could surface as a bare `Authorization DENIED: no reason provided` in the logs — no evaluation ID, no audit anchor, no path to verify.

This adds a self-explanatory Markdown panel for **every terminal outcome** — allow / deny / hold / escalate / fail-closed error — so the customer never has to scroll raw logs to understand a gate decision.

### What's in the panel
- **Decision** + reason (+ deny code when surfaced), action, actor, environment, target, risk score/class.
- **Evidence:** evaluation ID and truncated audit-chain hash; on allow, that the permit was *issued & verified*. The single-use permit token and raw proof hash are **never** printed — same evidence rule as the existing `buildGateDenyComment`.
- **How to verify / next step:** a deep link to the console decision replay view (`/decisions/<id>/replay`) and the workflow run, plus the right call to action — approve-and-rerun for hold/escalate, "which policy rule fired" for deny, and an offline-verification note for allow.

### How it's wired
- New `src/stepSummary.ts` — a **pure** `buildGateStepSummary()` (returns a string), so it's fully unit-testable.
- Called at all three terminal points in the single-eval path: allow (after verify + evidence bundle), the `EnforceError` deny/hold/escalate/infra block (written **before** `setFailed` exits the process), and the unexpected-error catch.
- **Best-effort throughout** — a summary failure never affects the (fail-closed) gate decision, consistent with the existing evidence-bundle/advisory handling.
- `dist/index.js` rebuilt (the committed, deployed entry).

## Test plan
- [x] New `src/__tests__/stepSummary.test.ts` (8 tests): AUTHORIZED panel with evidence anchors; token/proof-hash never printed; DENIED with reason + truncated audit hash; deny code; HOLD approve-and-rerun next step; fail-closed error panel; deep-link omitted when no evaluation id; custom console base URL.
- [x] `vitest run` → **322 passed** (full suite).
- [x] `tsc --noEmit` clean.
- [x] `npm run build` → `dist/index.js` rebuilt; verified the new strings + `/decisions/${evalId}/replay` deep link are bundled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AC6LhgDu8zf7ynDcrcdqtB)_