### PR TITLE
feat(gate): surface runtime deny remediation ("how to fix") in the job summary

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -218,6 +218,8 @@ var require_dist = __commonJS({
         proofHash: raw["proof_hash"],
         riskScore: extractRiskScore(raw),
         denyReason: raw["deny_reason"],
+        denyCode: raw["deny_code"],
+        remediation: raw["remediation"],
         holdReason: raw["hold_reason"],
         risk_class: raw["risk_class"],
         authority_basis: raw["authority_basis"],
@@ -1567,6 +1569,20 @@ function buildGateStepSummary(input) {
     }
     lines.push("");
   }
+  if (!isAllow && input.remediation) {
+    const r = input.remediation;
+    const steps = (r.how_to ?? []).filter((s) => typeof s === "string" && s.length > 0);
+    if (r.summary || steps.length > 0) {
+      lines.push("### How to fix", "");
+      if (r.summary)
+        lines.push(r.summary, "");
+      for (const step of steps)
+        lines.push(`- ${step}`);
+      if (r.docs)
+        lines.push("", `See [deny-code reference](${r.docs}).`);
+      lines.push("");
+    }
+  }
   if (evalId) {
     lines.push(
       `[View the full decision & replay the evidence](${consoleBase}/decisions/${evalId}/replay)`
@@ -2515,6 +2531,8 @@ async function run() {
             targetId,
             runUrl: `${gh.server_url}/${gh.repository}/actions/runs/${gh.run_id}`,
             reason: summaryReason,
+            denyCode: err.decision?.denyCode,
+            remediation: err.decision?.remediation,
             evaluationId: err.decision?.evaluationId,
             auditHash: err.decision?.auditHash,
             riskScore: err.decision?.riskScore,

--- a/packages/enforce/dist/index.d.ts
+++ b/packages/enforce/dist/index.d.ts
@@ -42,6 +42,18 @@ export interface Decision {
     proofHash?: string;
     riskScore?: number;
     denyReason?: string;
+    /** Machine deny code (e.g. INSUFFICIENT_APPROVALS), present on deny. */
+    denyCode?: string;
+    /**
+     * Additive remediation hint the runtime attaches to common, safe-to-disclose
+     * denies — tells the caller how to fix it. Surfaced verbatim; never used for
+     * a decision.
+     */
+    remediation?: {
+        summary?: string;
+        how_to?: string[];
+        docs?: string;
+    };
     holdReason?: string;
     /** Resolved risk class from the evaluation (critical / high / medium / low). */
     risk_class?: string;

--- a/packages/enforce/dist/index.js
+++ b/packages/enforce/dist/index.js
@@ -173,6 +173,8 @@ function mapDecision(raw) {
         proofHash: raw["proof_hash"],
         riskScore: extractRiskScore(raw),
         denyReason: raw["deny_reason"],
+        denyCode: raw["deny_code"],
+        remediation: raw["remediation"],
         holdReason: raw["hold_reason"],
         risk_class: raw["risk_class"],
         authority_basis: raw["authority_basis"],

--- a/packages/enforce/src/__tests__/evaluate.test.ts
+++ b/packages/enforce/src/__tests__/evaluate.test.ts
@@ -49,6 +49,24 @@ describe("evaluate", () => {
     expect(d.riskScore).toBeUndefined();
   });
 
+  it("maps deny_code and remediation from the evaluate response", async () => {
+    mockResponse(200, {
+      decision: "deny",
+      deny_reason: "environment_mismatch",
+      deny_code: "ENVIRONMENT_MISMATCH",
+      remediation: {
+        summary: "Use a matching key.",
+        how_to: ["step one", "step two"],
+        docs: "https://example.com/deny-codes.md",
+      },
+    });
+    const d = await evaluate(BASE_CONFIG);
+    expect(d.denyCode).toBe("ENVIRONMENT_MISMATCH");
+    expect(d.remediation?.summary).toBe("Use a matching key.");
+    expect(d.remediation?.how_to).toEqual(["step one", "step two"]);
+    expect(d.remediation?.docs).toBe("https://example.com/deny-codes.md");
+  });
+
   it("threads target_id into both top-level and context", async () => {
     mockResponse(200, { decision: "allow" });
     await evaluate({ ...BASE_CONFIG, targetId: "svc-prod" });

--- a/packages/enforce/src/index.ts
+++ b/packages/enforce/src/index.ts
@@ -53,6 +53,14 @@ export interface Decision {
   proofHash?: string;
   riskScore?: number;
   denyReason?: string;
+  /** Machine deny code (e.g. INSUFFICIENT_APPROVALS), present on deny. */
+  denyCode?: string;
+  /**
+   * Additive remediation hint the runtime attaches to common, safe-to-disclose
+   * denies — tells the caller how to fix it. Surfaced verbatim; never used for
+   * a decision.
+   */
+  remediation?: { summary?: string; how_to?: string[]; docs?: string };
   holdReason?: string;
   /** Resolved risk class from the evaluation (critical / high / medium / low). */
   risk_class?: string;
@@ -295,6 +303,8 @@ function mapDecision(raw: Record<string, unknown>): Decision {
     proofHash: raw["proof_hash"] as string | undefined,
     riskScore: extractRiskScore(raw),
     denyReason: raw["deny_reason"] as string | undefined,
+    denyCode: raw["deny_code"] as string | undefined,
+    remediation: raw["remediation"] as Decision["remediation"] | undefined,
     holdReason: raw["hold_reason"] as string | undefined,
     risk_class: raw["risk_class"] as string | undefined,
     authority_basis: raw["authority_basis"] as Decision["authority_basis"],

--- a/src/__tests__/stepSummary.test.ts
+++ b/src/__tests__/stepSummary.test.ts
@@ -75,6 +75,50 @@ describe("buildGateStepSummary", () => {
     expect(md).toContain("Deny code | `INSUFFICIENT_APPROVALS`");
   });
 
+  it("renders a How-to-fix section from runtime remediation on deny", () => {
+    const md = buildGateStepSummary({
+      ...base,
+      outcome: "deny",
+      reason: "environment_mismatch",
+      denyCode: "ENVIRONMENT_MISMATCH",
+      remediation: {
+        summary: "Use an API key whose environment matches context.environment.",
+        how_to: [
+          "A live key must evaluate against a production context.",
+          "Use a test key for non-production environments.",
+        ],
+        docs: "https://example.com/deny-codes.md",
+      },
+    });
+    expect(md).toContain("### How to fix");
+    expect(md).toContain(
+      "Use an API key whose environment matches context.environment.",
+    );
+    expect(md).toContain("- A live key must evaluate against a production context.");
+    expect(md).toContain("[deny-code reference](https://example.com/deny-codes.md)");
+  });
+
+  it("never renders a How-to-fix section on allow", () => {
+    const md = buildGateStepSummary({
+      ...base,
+      outcome: "allow",
+      permitIssued: true,
+      remediation: { summary: "should not appear", how_to: ["nope"] },
+    });
+    expect(md).not.toContain("How to fix");
+    expect(md).not.toContain("should not appear");
+  });
+
+  it("omits How-to-fix when remediation has no usable content", () => {
+    const md = buildGateStepSummary({
+      ...base,
+      outcome: "deny",
+      reason: "policy",
+      remediation: { how_to: [] },
+    });
+    expect(md).not.toContain("### How to fix");
+  });
+
   it("renders a HOLD panel with the approve-and-rerun next step", () => {
     const md = buildGateStepSummary({
       ...base,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1326,6 +1326,8 @@ export async function run(): Promise<void> {
             targetId,
             runUrl: `${gh.server_url}/${gh.repository}/actions/runs/${gh.run_id}`,
             reason: summaryReason,
+            denyCode: err.decision?.denyCode,
+            remediation: err.decision?.remediation,
             evaluationId: err.decision?.evaluationId,
             auditHash: err.decision?.auditHash,
             riskScore: err.decision?.riskScore,

--- a/src/stepSummary.ts
+++ b/src/stepSummary.ts
@@ -40,6 +40,11 @@ export interface GateSummaryInput {
   reason?: string;
   /** Machine deny code (e.g. INSUFFICIENT_APPROVALS), when surfaced. */
   denyCode?: string;
+  /**
+   * Additive remediation hint from the runtime for common, safe-to-disclose
+   * denies — { summary, how_to[], docs }. Rendered verbatim as "How to fix".
+   */
+  remediation?: { summary?: string; how_to?: string[]; docs?: string };
   /** allow path: whether the issued permit was verified. */
   verified?: boolean;
   /** allow path: verify outcome string from /v1-verify-permit. */
@@ -149,6 +154,19 @@ export function buildGateStepSummary(input: GateSummaryInput): string {
       lines.push(`- **Evidence receipt:** \`${input.evidenceReceiptId}\``);
     }
     lines.push("");
+  }
+
+  // ── How to fix (remediation hint from the runtime, deny path only) ────────
+  if (!isAllow && input.remediation) {
+    const r = input.remediation;
+    const steps = (r.how_to ?? []).filter((s) => typeof s === "string" && s.length > 0);
+    if (r.summary || steps.length > 0) {
+      lines.push("### How to fix", "");
+      if (r.summary) lines.push(r.summary, "");
+      for (const step of steps) lines.push(`- ${step}`);
+      if (r.docs) lines.push("", `See [deny-code reference](${r.docs}).`);
+      lines.push("");
+    }
   }
 
   // ── How to verify / next step ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary

The runtime already attaches an additive remediation hint to common, safe-to-disclose denies — `{ summary, how_to[], docs }` (the `DENY_REMEDIATION` map in `v1-evaluate`). But the GitHub Action was **dropping it**: `@atlasent/enforce` parsed `deny_reason` only, so a blocked pilot saw *why* they were denied but not the concrete steps to **unblock**.

This threads it end-to-end so the job-summary deny panel (added in #100) now answers "how do I fix this?", not just "what happened":

- **`@atlasent/enforce`** — `Decision` now carries `denyCode` + `remediation`; `mapDecision` reads `deny_code` and `remediation` from the evaluate response. Additive; never used for a decision. `dist/` rebuilt.
- **`stepSummary`** — the deny/hold/escalate panel renders a **"How to fix"** section from `remediation.summary` + `how_to[]` steps + a deny-code reference link. Allow never shows it; empty remediation → section omitted.
- **`index.ts`** — passes `err.decision.denyCode` + `remediation` into the deny summary call.

Net effect: when a pilot's deploy is blocked, the GitHub run page shows not just WHY (reason + deny code) but exactly HOW to fix it — the strongest self-serve/trust outcome at the pilot's critical moment.

## Test plan
- [x] `@atlasent/enforce` evaluate mapper test: `deny_code` + `remediation` captured from the response.
- [x] `stepSummary` tests: "How to fix" renders from remediation; never on allow; omitted when remediation has no usable content.
- [x] `vitest run` → **326 passed** (full suite, +4).
- [x] `tsc --noEmit` clean; `npm run build` → `dist/index.js` rebuilt; `packages/enforce` `dist/` rebuilt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AC6LhgDu8zf7ynDcrcdqtB)_