### PR TITLE
fix(action): add /functions/v1 suffix to default API URL and emit warning when absent

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -388,7 +388,7 @@ function assertValidActionType(raw) {
 // src/inputs.ts
 function parseInputs(env) {
   const apiKey = required(env, "ATLASENT_API_KEY");
-  const apiUrl = env["INPUT_API-URL"] || env["ATLASENT_BASE_URL"] || "https://api.atlasent.io";
+  const apiUrl = env["INPUT_API-URL"] || env["ATLASENT_BASE_URL"] || "https://api.atlasent.io/functions/v1";
   const failOnDeny = (env["INPUT_FAIL-ON-DENY"] || "true") === "true";
   const policySyncEnabled = (env["INPUT_POLICY-SYNC"] ?? "").toLowerCase() === "true";
   if (policySyncEnabled) {
@@ -2263,7 +2263,12 @@ async function run() {
   }
   const apiKey = getApiKey();
   maskValue(apiKey);
-  const apiUrl = getInput("api-url") || (process.env["ATLASENT_BASE_URL"] ?? "").trim() || "https://api.atlasent.io";
+  const apiUrl = getInput("api-url") || (process.env["ATLASENT_BASE_URL"] ?? "").trim() || "https://api.atlasent.io/functions/v1";
+  if (!apiUrl.includes("/functions/v1")) {
+    warning(
+      "ATLASENT_BASE_URL does not contain '/functions/v1'. For Supabase-hosted AtlaSent instances set ATLASENT_BASE_URL to your project URL ending in /functions/v1 (e.g. https://<project-ref>.supabase.co/functions/v1). Without this suffix every API call will 404."
+    );
+  }
   const failOnDeny = getInput("fail-on-deny") !== "false";
   if (!failOnDeny) {
     warning(

--- a/src/__tests__/v21.test.ts
+++ b/src/__tests__/v21.test.ts
@@ -64,7 +64,7 @@ it("wraps single action/actor into a 1-item batch", async () => {
     FLAGS,
   );
   expect(mockEvaluateMany).toHaveBeenCalledWith(
-    "https://api.atlasent.io",
+    "https://api.atlasent.io/functions/v1",
     "ask_test_key",
     [expect.objectContaining({ action: "production.deploy", actor: "bob" })],
     false,

--- a/src/index.ts
+++ b/src/index.ts
@@ -976,7 +976,15 @@ export async function run(): Promise<void> {
   const apiUrl =
     getInput("api-url") ||
     (process.env["ATLASENT_BASE_URL"] ?? "").trim() ||
-    "https://api.atlasent.io";
+    "https://api.atlasent.io/functions/v1";
+  if (!apiUrl.includes("/functions/v1")) {
+    warning(
+      "ATLASENT_BASE_URL does not contain '/functions/v1'. " +
+        "For Supabase-hosted AtlaSent instances set ATLASENT_BASE_URL to your project URL " +
+        "ending in /functions/v1 (e.g. https://<project-ref>.supabase.co/functions/v1). " +
+        "Without this suffix every API call will 404.",
+    );
+  }
   const failOnDeny = getInput("fail-on-deny") !== "false";
   if (!failOnDeny) {
     warning(

--- a/src/inputs.ts
+++ b/src/inputs.ts
@@ -44,7 +44,7 @@ export function parseInputs(env: Record<string, string | undefined>): ActionInpu
   const apiUrl =
     env["INPUT_API-URL"] ||
     env["ATLASENT_BASE_URL"] ||
-    "https://api.atlasent.io";
+    "https://api.atlasent.io/functions/v1";
   const failOnDeny = (env["INPUT_FAIL-ON-DENY"] || "true") === "true";
 
   // ── Policy sync mode (checked first) ────────────────────────────────────────


### PR DESCRIPTION
## Summary

- `src/inputs.ts`: default API URL changed from `https://api.atlasent.io` to `https://api.atlasent.io/functions/v1` — the bare apex 404s on every Supabase-hosted call
- `src/index.ts`: same default fix, plus a `warning()` call (surfaced in the GitHub Actions log) when the resolved `apiUrl` lacks `/functions/v1`, catching misconfigured `ATLASENT_BASE_URL` values set without the suffix

Mirrors the same fix applied to `@atlasent/mcp-server` `engine.ts` (PR #89).

The README already documents the requirement ("set this to your project URL ending in `/functions/v1`") but the default and the fallback path silently ignored it.

## Test plan

- [ ] Verify `parseInputs` test: when neither `INPUT_API-URL` nor `ATLASENT_BASE_URL` is set, the resolved `apiUrl` is `https://api.atlasent.io/functions/v1`
- [ ] Verify `warning()` is called in the Actions log when `ATLASENT_BASE_URL=https://myproject.supabase.co` (no suffix)
- [ ] Verify no `warning()` is emitted when `ATLASENT_BASE_URL=https://myproject.supabase.co/functions/v1`
- [ ] End-to-end: existing CI evaluate/verify round-trip still passes

https://claude.ai/code/session_014huKKV7vjytvDDb5jVe5p3

---
_Generated by [Claude Code](https://claude.ai/code/session_014huKKV7vjytvDDb5jVe5p3)_