### PR TITLE
feat(canonical): add GxP clinical trial action types to gate allowlist

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -361,10 +361,16 @@ async function loopEvaluate(apiUrl, headers, items) {
 // src/canonicalAction.ts
 var PRODUCTION_DEPLOY_ACTION = "production.deploy";
 var PACKAGE_RELEASE_ACTION = "package.release";
+var TRIAL_BLINDING_SETUP_ACTION = "trial.blinding.setup";
+var TRIAL_UNBLINDING_EXECUTE_ACTION = "trial.unblinding.execute";
+var TRIAL_UNBLINDING_EMERGENCY_ACTION = "trial.unblinding.emergency";
 var LEGACY_PRODUCTION_DEPLOY_ALIAS = "deployment.production";
 var GATE_PERMITTED_ACTIONS = /* @__PURE__ */ new Set([
   PRODUCTION_DEPLOY_ACTION,
-  PACKAGE_RELEASE_ACTION
+  PACKAGE_RELEASE_ACTION,
+  TRIAL_BLINDING_SETUP_ACTION,
+  TRIAL_UNBLINDING_EXECUTE_ACTION,
+  TRIAL_UNBLINDING_EMERGENCY_ACTION
 ]);
 function normalizeProtectedAction(raw) {
   if (raw === LEGACY_PRODUCTION_DEPLOY_ALIAS) {

--- a/src/__tests__/canonicalAction.test.ts
+++ b/src/__tests__/canonicalAction.test.ts
@@ -5,6 +5,9 @@ import {
   PACKAGE_RELEASE_ACTION,
   PRODUCTION_DEPLOY_ACTION,
   PROTECTED_ACTIONS_CATALOG,
+  TRIAL_BLINDING_SETUP_ACTION,
+  TRIAL_UNBLINDING_EMERGENCY_ACTION,
+  TRIAL_UNBLINDING_EXECUTE_ACTION,
   assertProtectedAction,
   normalizeProtectedAction,
 } from "../canonicalAction";
@@ -69,8 +72,8 @@ describe("canonicalAction", () => {
       expect(() => assertProtectedAction("access.cert.revoke")).not.toThrow();
     });
 
-    it("PROTECTED_ACTIONS_CATALOG contains exactly 19 entries", () => {
-      expect(PROTECTED_ACTIONS_CATALOG.size).toBe(19);
+    it("PROTECTED_ACTIONS_CATALOG contains exactly 22 entries", () => {
+      expect(PROTECTED_ACTIONS_CATALOG.size).toBe(22);
     });
   });
 
@@ -80,8 +83,14 @@ describe("canonicalAction", () => {
       expect(GATE_PERMITTED_ACTIONS.has(PACKAGE_RELEASE_ACTION)).toBe(true);
     });
 
-    it("is a conservative two-entry allow-list (not open to arbitrary types)", () => {
-      expect(GATE_PERMITTED_ACTIONS.size).toBe(2);
+    it("permits the three GxP clinical trial action types", () => {
+      expect(GATE_PERMITTED_ACTIONS.has(TRIAL_BLINDING_SETUP_ACTION)).toBe(true);
+      expect(GATE_PERMITTED_ACTIONS.has(TRIAL_UNBLINDING_EXECUTE_ACTION)).toBe(true);
+      expect(GATE_PERMITTED_ACTIONS.has(TRIAL_UNBLINDING_EMERGENCY_ACTION)).toBe(true);
+    });
+
+    it("is a conservative explicit allow-list (not open to arbitrary types)", () => {
+      expect(GATE_PERMITTED_ACTIONS.size).toBe(5);
       // A well-formed but unlisted action is NOT gate-permitted, even though
       // its format is valid — the runtime policy is the authority, but the
       // gate's client-side guard stays explicit.

--- a/src/canonicalAction.ts
+++ b/src/canonicalAction.ts
@@ -32,6 +32,11 @@ export const ADMIN_PERMISSION_GRANT_ACTION = "admin.permission.grant";
 export const AGENT_TOOL_CALL_ACTION = "agent.tool.call";
 export const SECRET_ROTATION_PRODUCTION_ACTION = "secret.rotation.production";
 
+// GxP — Clinical trial blinding / unblinding (ICH E6(R2) §4.8 / §5.13, 21 CFR Part 11 §11.10/§11.300)
+export const TRIAL_BLINDING_SETUP_ACTION = "trial.blinding.setup";
+export const TRIAL_UNBLINDING_EXECUTE_ACTION = "trial.unblinding.execute";
+export const TRIAL_UNBLINDING_EMERGENCY_ACTION = "trial.unblinding.emergency";
+
 /** Legacy alias — accepted during the V1 alias window, normalized on input. */
 export const LEGACY_PRODUCTION_DEPLOY_ALIAS = "deployment.production";
 
@@ -46,6 +51,9 @@ export const LEGACY_PRODUCTION_DEPLOY_ALIAS = "deployment.production";
 export const GATE_PERMITTED_ACTIONS: ReadonlySet<string> = new Set([
   PRODUCTION_DEPLOY_ACTION,
   PACKAGE_RELEASE_ACTION,
+  TRIAL_BLINDING_SETUP_ACTION,
+  TRIAL_UNBLINDING_EXECUTE_ACTION,
+  TRIAL_UNBLINDING_EMERGENCY_ACTION,
 ]);
 
 // ---------------------------------------------------------------------------
@@ -84,6 +92,10 @@ export const PROTECTED_ACTIONS_CATALOG: ReadonlySet<string> = new Set([
   "database.migration.apply",
   "database.schema.drop",
   "database.table.delete",
+  // GxP — Clinical trial blinding (ICH E6(R2) §4.8 / §5.13, 21 CFR Part 11 §11.10/§11.300)
+  "trial.blinding.setup",
+  "trial.unblinding.execute",
+  "trial.unblinding.emergency",
 ]);
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add three named export constants for GxP clinical trial action types: `TRIAL_BLINDING_SETUP_ACTION`, `TRIAL_UNBLINDING_EXECUTE_ACTION`, `TRIAL_UNBLINDING_EMERGENCY_ACTION`
- Add all three to `GATE_PERMITTED_ACTIONS` (size grows from 2 → 5) so the single-eval path accepts them without a gate error
- Add all three to `PROTECTED_ACTIONS_CATALOG` (size grows from 19 → 22) as informational entries under the GxP section
- Rebuild `dist/index.js` (esbuild, node24 target)

## Regulatory context

These action types correspond to ICH E6(R2) §4.8 / §5.13 and 21 CFR Part 11 §11.10 / §11.300:

| Slug | Risk | Gate flags |
|---|---|---|
| `trial.blinding.setup` | high | `requires_state_snapshot`, `requires_human_approval` |
| `trial.unblinding.execute` | critical | `requires_human_approval`, `requires_verified_actor`, `required_assertion_classes: [identity, approval]` |
| `trial.unblinding.emergency` | critical | `requires_mfa`, `requires_verified_actor`, `required_assertion_classes: [identity, approval]` |

## Test plan

- All 327 existing tests pass (`npm test`)
- New test: "permits the three GxP clinical trial action types" verifies all three slugs are in `GATE_PERMITTED_ACTIONS`
- Updated size assertions: `GATE_PERMITTED_ACTIONS.size === 5`, `PROTECTED_ACTIONS_CATALOG.size === 22`
- `dist/index.js` rebuilt and committed

Co-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>
https://claude.ai/code/session_011fqt8E6Y8q7JWC8YWDUeQd

---
_Generated by [Claude Code](https://claude.ai/code/session_011fqt8E6Y8q7JWC8YWDUeQd)_