### PR TITLE
docs: frame the gate as domain-independent, not deploy-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,47 @@ Push to main → AtlaSent evaluates → permit issued → deploy
     # state_snapshot is injected automatically — no need to include it here
 ```
 
+## Beyond deploys — any protected action
+
+The gate is not deployment-specific. `production.deploy` is just the default
+`action` value; the same evaluate → permit → verify → fail-closed mechanic
+authorizes **any** provisioned action class. Set `action` (and `target-id`) to
+the class you want to gate — the action, the wire contract, and the fail-closed
+behavior are identical.
+
+For example, a GxP clinical-trial unblinding gate (ICH E6(R2) §4.8 / 21 CFR
+Part 11), where the runtime enforces that class's dual-authorization, verified
+human approval, and per-class MFA at evaluate time:
+
+```yaml
+jobs:
+  unblind:
+    runs-on: ubuntu-latest
+    steps:
+      - name: AtlaSent clinical unblinding gate
+        id: gate
+        uses: AtlaSent-Systems-Inc/atlasent-action@v1
+        env:
+          ATLASENT_API_KEY: ${{ secrets.ATLASENT_API_KEY }}
+          ATLASENT_BASE_URL: ${{ secrets.ATLASENT_BASE_URL }}
+        with:
+          action: trial.unblinding.execute   # or trial.unblinding.emergency, package.release, data.release, …
+          target-id: trial:NCT12345678
+          environment: production
+
+      - name: Perform the unblinding
+        if: steps.gate.outputs.verified == 'true'   # gate on verified, not decision
+        run: ./scripts/unblind.sh
+```
+
+The action does **not** restrict `action` to a fixed allowlist — it validates
+only the format (dot-separated lowercase identifiers, 2–4 segments) and forwards
+the class to the control plane, where the policy is the authority. So any action
+class provisioned in your AtlaSent org works — `package.release`,
+`trial.unblinding.emergency`, `data.release`, your own custom classes — with no
+code change to this action. Recognized clinical/package constants are listed in
+`src/canonicalAction.ts`.
+
 ## Required context: `state_snapshot`
 
 All `production.deploy` evaluations (and all action classes in the AtlaSent system) **require a `state_snapshot`** in the request body. Omitting it results in an immediate `SNAPSHOT_REQUIRED` deny regardless of policy.


### PR DESCRIPTION
## Summary

Documentation-only change that completes the cross-repo "generic authorization gate" framing (companion to the console `authorization-gate.ts` parameterization and the atlasent-docs architecture doc).

Adds a **"Beyond deploys — any protected action"** section to the README that:
- Makes explicit that `production.deploy` is only the *default* `action` value, and the same `evaluate → permit → verify → fail-closed` mechanic authorizes **any** provisioned action class.
- Includes a GxP clinical-trial unblinding worked example (`action: trial.unblinding.execute`, `if: steps.gate.outputs.verified == 'true'`) — the runtime enforces that class's dual-authorization / verified human approval / per-class MFA at evaluate time.
- Clarifies the load-bearing detail that `action` is **format-validated, not allowlisted** — the policy in the control plane is the authority, so any well-formed class (including custom ones) works with no code change to this action. Points to `src/canonicalAction.ts` for the recognized clinical/package constants.

No source, `action.yml`, or `dist/index.js` changes — the action already accepts any well-formed action type (`isValidActionType` / `assertValidActionType` validate format only). This PR just documents the capability.

## Test plan
- [x] Verified the named action constants (`trial.unblinding.execute`, `trial.unblinding.emergency`, `trial.blinding.setup`, `package.release`) exist in `src/canonicalAction.ts`.
- [x] Confirmed `canonicalAction.ts` does not restrict to a fixed allowlist (`isValidActionType` is format-only; "policies are the authority"), so `data.release` / custom classes are accurate examples.
- [x] Docs-only — no build/test impact; `dist/index.js` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WoKZRyBv4cTzJnZrEjnVur

---
_Generated by [Claude Code](https://claude.ai/code/session_01WoKZRyBv4cTzJnZrEjnVur)_