### PR TITLE
docs: correct stale input/output counts in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,7 @@ Required secrets (set in repository or org secrets):
 | `ATLASENT_API_KEY` | API key scoped to at least `evaluate:write` + `verify:execute` |
 | `ATLASENT_BASE_URL` | Supabase project URL, e.g. `https://<ref>.supabase.co/functions/v1` |
 
-Key action inputs (see `action.yml` for the full list of ~30 inputs):
+Key action inputs (see `action.yml` for the full list of 53 inputs / 39 outputs):
 
 | Input | Default | Description |
 |---|---|---|
@@ -84,6 +84,8 @@ Key action inputs (see `action.yml` for the full list of ~30 inputs):
 | `governance-agents` | — | Comma-separated advisory governance-agent slugs |
 | `release-mode` | — | Set `"register-and-verify"` for post-deploy release verification |
 | `trajectory-verify` | `"false"` | Set `"true"` to verify a trajectory step |
+
+> The table above is a curated subset. Two further input families in `action.yml` are not represented in the modes table: the `financial-governance` family (`financial-governance`, `financial-action-value`, `financial-action-currency`) and the `insights-*` family (`insights-org-id`, `insights-subject-id`, `insights-session-count`). See `action.yml` for the complete set.
 
 ## Key outputs
 


### PR DESCRIPTION
## Summary

Doc-only fix to the stale input count in `CLAUDE.md`.

- `~30 inputs` → `53 inputs / 39 outputs`. **Counting method:** top-level 2-space-indented keys under the `inputs:` block (lines 6–275) and `outputs:` block (lines 275–367) of `action.yml`.
- Added a note that the Key-inputs table is a curated subset and that two input families in `action.yml` are not represented in the modes table: `financial-governance` (`financial-governance`, `financial-action-value`, `financial-action-currency`) and `insights-*` (`insights-org-id`, `insights-subject-id`, `insights-session-count`).
- Note: `~30 inputs` appeared only **once** in `CLAUDE.md`, not twice.

No code or `dist/` change.

## Test plan
- [x] `CLAUDE.md`-only diff; counts recomputed from `action.yml` on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VqVz8iiJpi4Tc7EzuozDVp)_