### PR TITLE
test(enforce): add Deploy Gate integration contract tests

### DIFF
--- a/packages/enforce/src/__tests__/deploy-gate-integration.test.ts
+++ b/packages/enforce/src/__tests__/deploy-gate-integration.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { enforce, EnforceError } from "../index";
+
+vi.mock("../transport", () => ({ post: vi.fn() }));
+
+import { post } from "../transport";
+const mockPost = post as ReturnType<typeof vi.fn>;
+
+const CONFIG = {
+  apiKey: "ask_test_key",
+  apiUrl: "https://api.test",
+  action: "production.deploy",
+  actor: "github:deploy-bot",
+  environment: "production",
+};
+
+function jsonResponse(status: number, body: unknown) {
+  return { status, body: JSON.stringify(body) };
+}
+
+describe("GitHub Deploy Gate integration contract", () => {
+  beforeEach(() => mockPost.mockReset());
+
+  it("executes one governed deployment only after evaluation and permit verification", async () => {
+    const timeline: string[] = [];
+    mockPost
+      .mockResolvedValueOnce(
+        jsonResponse(200, {
+          decision: "allow",
+          evaluation_id: "eval-deploy-1",
+          permit_token: "permit-deploy-1",
+        }),
+      )
+      .mockResolvedValueOnce(jsonResponse(200, { verified: true, outcome: "ok" }));
+
+    const result = await enforce(CONFIG, async () => {
+      timeline.push("deploy");
+      return "deployed";
+    });
+
+    expect(result.result).toBe("deployed");
+    expect(result.decision.evaluationId).toBe("eval-deploy-1");
+    expect(result.verifyOutcome).toBe("ok");
+    expect(mockPost.mock.calls.map((call) => call[0])).toEqual([
+      "https://api.test/v1-evaluate",
+      "https://api.test/v1-verify-permit",
+    ]);
+    expect(timeline).toEqual(["deploy"]);
+  });
+
+  it("blocks deployment when evaluation denies before permit verification", async () => {
+    const timeline: string[] = [];
+    mockPost.mockResolvedValueOnce(
+      jsonResponse(200, { decision: "deny", deny_reason: "change freeze" }),
+    );
+
+    await expect(
+      enforce(CONFIG, async () => {
+        timeline.push("deploy");
+      }),
+    ).rejects.toMatchObject({ phase: "verify" });
+
+    expect(timeline).toEqual([]);
+    expect(mockPost.mock.calls[0][0]).toBe("https://api.test/v1-evaluate");
+    expect(mockPost).toHaveBeenCalledTimes(1);
+  });
+
+  it("requires an allow decision to include a verifiable permit before deployment", async () => {
+    const timeline: string[] = [];
+    mockPost.mockResolvedValueOnce(
+      jsonResponse(200, { decision: "allow", evaluation_id: "eval-no-permit" }),
+    );
+
+    await expect(
+      enforce(CONFIG, async () => {
+        timeline.push("deploy");
+      }),
+    ).rejects.toSatisfy(
+      (error: EnforceError) =>
+        error instanceof EnforceError &&
+        error.phase === "verify-permit" &&
+        error.message.includes("no permit_token"),
+    );
+
+    expect(timeline).toEqual([]);
+    expect(mockPost).toHaveBeenCalledTimes(1);
+  });
+
+  it("prevents deployment when permit verification fails", async () => {
+    const timeline: string[] = [];
+    mockPost
+      .mockResolvedValueOnce(
+        jsonResponse(200, {
+          decision: "allow",
+          evaluation_id: "eval-replay",
+          permit_token: "permit-replayed",
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse(200, { verified: false, outcome: "permit_consumed" }),
+      );
+
+    await expect(
+      enforce(CONFIG, async () => {
+        timeline.push("deploy");
+      }),
+    ).rejects.toMatchObject({ phase: "verify-permit" });
+
+    expect(timeline).toEqual([]);
+    expect(mockPost).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
### Motivation

- Provide explicit integration-level coverage for the GitHub Deploy Gate contract (evaluate → verify-permit → execute) to validate that the runtime only performs deployments after a verified permit. 
- Capture failure modes that must be fail-closed: policy `deny` blocking before permit verification, missing `permit_token` blocking execution, and permit verification failures blocking execution.

### Description

- Add `packages/enforce/src/__tests__/deploy-gate-integration.test.ts` which mocks the HTTP transport and exercises the end-to-end `enforce()` flow under controlled responses. 
- Implement a happy-path test that asserts the order of operations is `POST /v1-evaluate` → `POST /v1-verify-permit` → deploy callback and that the returned `evaluationId` and `verifyOutcome` are propagated. 
- Add tests that assert a `deny` decision halts execution before any permit verification, that an `allow` without a `permit_token` fails in the `verify-permit` phase, and that a `verified: false` response prevents deployment (replay/expired permit). 
- Use `vi.mock()` for `../transport` and inspect `mockPost.mock.calls` plus a small timeline array to validate sequencing without modifying runtime or policies.

### Testing

- Ran `npm test -- packages/enforce/src/__tests__/deploy-gate-integration.test.ts` and the new test file completed successfully. 
- Ran `npm run typecheck` (`tsc --noEmit`) and it completed successfully. 
- Ran the full test suite with `npm test` and all tests passed. 
- Built the action with `npm run build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a51f0bc6a688320ac9d17770b887da0)