### PR TITLE
feat(enforce): artifact-digest binding + execution-boundary re-verification (B3/B4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,74 @@ Push to main → AtlaSent evaluates → permit issued → deploy
     # state_snapshot is injected automatically — no need to include it here
 ```
 
+## Artifact binding & execution-boundary verification
+
+By default the gate step evaluates, verifies the permit, and outputs `verified`;
+your deploy step guards on `if: steps.gate.outputs.verified == 'true'`. That is
+fully supported and unchanged.
+
+For a stronger guarantee — **a workflow must not be able to evaluate one artifact
+and execute another** — bind the artifact digest into the authorization and
+re-verify the permit *at the execution boundary*, immediately before the deploy:
+
+```yaml
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs: { digest: "${{ steps.d.outputs.digest }}" }
+    steps:
+      - uses: actions/checkout@v4
+      - run: ./build.sh out/
+      - id: d
+        run: echo "digest=sha256:$(tar -cf - out | sha256sum | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+
+  gate:
+    needs: build
+    runs-on: ubuntu-latest
+    outputs: { permit: "${{ steps.g.outputs.permit-token }}" }
+    steps:
+      - id: g
+        uses: AtlaSent-Systems-Inc/atlasent-action@v1
+        env: { ATLASENT_API_KEY: "${{ secrets.ATLASENT_API_KEY }}", ATLASENT_BASE_URL: "${{ secrets.ATLASENT_BASE_URL }}" }
+        with:
+          action: production.deploy
+          environment: production
+          artifact-digest: ${{ needs.build.outputs.digest }}   # canonical binding
+
+  deploy:
+    needs: [build, gate]
+    runs-on: ubuntu-latest
+    steps:
+      # THE EXECUTION BOUNDARY — re-verify the permit against the live runtime,
+      # re-binding environment + artifact digest. Fails closed on a missing,
+      # modified, expired, replayed, denied, or context-mismatched permit.
+      - id: verify
+        uses: AtlaSent-Systems-Inc/atlasent-action@v1
+        env: { ATLASENT_API_KEY: "${{ secrets.ATLASENT_API_KEY }}", ATLASENT_BASE_URL: "${{ secrets.ATLASENT_BASE_URL }}" }
+        with:
+          verify-permit: "true"
+          permit-token: ${{ needs.gate.outputs.permit }}
+          action: production.deploy
+          environment: production
+          artifact-digest: ${{ needs.build.outputs.digest }}
+      - if: steps.verify.outputs.verified == 'true'
+        run: ./deploy.sh out/
+```
+
+- **`artifact-digest`** is sent to evaluate as the canonical top-level
+  `execution_payload_hash` (never buried in context) and the runtime binds it into
+  the permit. Presenting a different digest at verify → `PAYLOAD_MISMATCH`.
+- **`verify-permit: "true"`** runs verify-only against the live runtime at the
+  deploy boundary. It fails the step closed and sets `verify-outcome` /
+  `verify-error-code` (e.g. `PAYLOAD_MISMATCH`, `ENVIRONMENT_MISMATCH`,
+  `PERMIT_EXPIRED`, `PERMIT_ALREADY_USED`, `MISSING_PERMIT`).
+
+**Compatibility:** all of this is additive and opt-in. Existing single-step gate
+workflows keep working unchanged; `artifact-digest`, `verify-permit`, the
+`permit-token` input, and the `verify-outcome` / `verify-error-code` outputs are
+new optional surface. Adopt the boundary pattern when you want artifact-substitution
+and cross-step replay protection at the point of execution.
+
 ## Beyond deploys — any protected action
 
 The gate is not deployment-specific. `production.deploy` is just the default

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,16 @@ inputs:
   target-id:
     description: 'Target resource being acted on (service name, artifact id, etc). Threaded into both top-level target_id and context.target_id so policies can gate on what is being deployed, not just who is deploying.'
     required: false
+  artifact-digest:
+    description: 'SHA-256 digest of the artifact being deployed (e.g. sha256:<image-or-plan-hash>). Sent to evaluate as the canonical top-level execution_payload_hash, which the runtime binds into the permit. Re-presented at verify time as payload_hash — a permit issued for one artifact and presented for another fails with PAYLOAD_MISMATCH. Supply the SAME digest to the gate step and to the verify-permit step at the execution boundary so a workflow cannot evaluate one artifact and execute another.'
+    required: false
+  verify-permit:
+    description: 'Set "true" to run VERIFY-ONLY mode: re-verify an existing permit at the execution boundary (immediately before the protected step), independent of the gate that issued it. Requires permit-token; also pass action, actor, environment, and artifact-digest so the runtime re-binds the execution context. Fails closed on any missing / modified / expired / replayed / denied / context-mismatched permit. Outputs verified / verify-outcome / verify-error-code.'
+    required: false
+    default: 'false'
+  permit-token:
+    description: 'The permit token to re-verify (required in verify-permit mode). Typically the permit-token output of an earlier gate step, passed to the deploy step.'
+    required: false
   environment:
     description: 'Environment (defaults to live for main branch, test otherwise)'
     required: false
@@ -284,7 +294,11 @@ outputs:
   risk-score:
     description: 'The numeric risk score from the Decision response. Empty string when the evaluator did not return a risk assessment. Single-eval path only.'
   verified:
-    description: '"true" when evaluate=allow AND verify-permit=true for ALL evaluations; "false" otherwise (fail-closed). Set on both single and batch paths.'
+    description: '"true" when evaluate=allow AND verify-permit=true for ALL evaluations; "false" otherwise (fail-closed). Set on both single and batch paths, and in verify-permit (boundary) mode.'
+  verify-outcome:
+    description: 'Coarse verification outcome from the last permit verification (verified / mismatch / expired / revoked / replay_blocked / invalid). Set on the single-eval and verify-permit (boundary) paths. Empty when verification did not run.'
+  verify-error-code:
+    description: 'Precise runtime verify wire code when verification failed (e.g. PAYLOAD_MISMATCH, ENVIRONMENT_MISMATCH, PERMIT_EXPIRED, PERMIT_ALREADY_USED, MISSING_PERMIT). Empty on success. Lets a workflow distinguish WHY a permit was rejected.'
   decisions:
     description: 'JSON array of per-item decision results for the batch path. Each item: {decision, verified, evaluationId, permitToken, reasons, verifyOutcome}.'
   batch-id:

--- a/dist/index.js
+++ b/dist/index.js
@@ -83,17 +83,26 @@ var require_dist = __commonJS({
     exports2.evaluate = evaluate;
     exports2.verify = verify;
     exports2.verifyPermit = verifyPermit3;
+    exports2.reverifyPermit = reverifyPermit2;
     exports2.enforce = enforce2;
     var transport_1 = require_transport();
     var DEFAULT_API_URL = "https://api.atlasent.io";
     var EnforceError2 = class extends Error {
       phase;
       decision;
-      constructor(message, phase, decision = null) {
+      /** Coarse verify outcome (verified | mismatch | expired | replay_blocked | invalid | …). */
+      outcome;
+      /** Precise verify wire code, when the failure came from verify-permit. */
+      verifyErrorCode;
+      mismatchFields;
+      constructor(message, phase, decision = null, details) {
         super(message);
         this.name = "EnforceError";
         this.phase = phase;
         this.decision = decision;
+        this.outcome = details?.outcome;
+        this.verifyErrorCode = details?.verifyErrorCode;
+        this.mismatchFields = details?.mismatchFields;
       }
     };
     exports2.EnforceError = EnforceError2;
@@ -127,6 +136,9 @@ var require_dist = __commonJS({
       const snap = config.state_snapshot ?? contextSnapshot;
       if (snap != null)
         payload["state_snapshot"] = snap;
+      if (config.executionPayloadHash != null) {
+        payload["execution_payload_hash"] = config.executionPayloadHash;
+      }
       let status;
       let body;
       try {
@@ -170,19 +182,25 @@ var require_dist = __commonJS({
           throw new EnforceError2(`Unknown decision: ${String(decision.decision)}`, "verify", decision);
       }
     }
-    async function verifyPermit3(config, decision) {
-      if (!decision.permitToken) {
-        throw new EnforceError2("evaluate returned allow but no permit_token \u2014 refusing to execute without verifiable permit", "verify-permit", decision);
-      }
+    async function postVerify(config, permitToken, decision) {
       const apiUrl = (config.apiUrl ?? DEFAULT_API_URL).replace(/\/$/, "");
+      const bodyObj = {
+        permit_token: permitToken,
+        action_type: config.action,
+        actor_id: config.actor
+      };
+      if (config.environment != null)
+        bodyObj["environment"] = config.environment;
+      if (config.targetId != null)
+        bodyObj["target_id"] = config.targetId;
+      if (config.executionPayloadHash != null)
+        bodyObj["payload_hash"] = config.executionPayloadHash;
       let status;
       let body;
       try {
-        ({ status, body } = await (0, transport_1.post)(`${apiUrl}/v1-verify-permit`, JSON.stringify({
-          permit_token: decision.permitToken,
-          action_type: config.action,
-          actor_id: config.actor
-        }), { Authorization: `Bearer ${config.apiKey}` }));
+        ({ status, body } = await (0, transport_1.post)(`${apiUrl}/v1-verify-permit`, JSON.stringify(bodyObj), {
+          Authorization: `Bearer ${config.apiKey}`
+        }));
       } catch (err) {
         throw new EnforceError2(`verify-permit unreachable: ${err instanceof Error ? err.message : String(err)}`, "verify-permit", decision);
       }
@@ -198,10 +216,33 @@ var require_dist = __commonJS({
       } catch {
         throw new EnforceError2("Non-JSON response from verify-permit", "verify-permit", decision);
       }
-      if (raw.verified !== true) {
-        throw new EnforceError2(`Permit verification failed (outcome=${raw.outcome ?? "unknown"})`, "verify-permit", decision);
+      const ok = raw.valid ?? raw.verified;
+      return {
+        verified: ok === true,
+        outcome: raw.outcome,
+        verifyErrorCode: raw.verify_error_code,
+        mismatchFields: Array.isArray(raw.mismatch_fields) ? raw.mismatch_fields : void 0
+      };
+    }
+    async function verifyPermit3(config, decision) {
+      if (!decision.permitToken) {
+        throw new EnforceError2("evaluate returned allow but no permit_token \u2014 refusing to execute without verifiable permit", "verify-permit", decision);
       }
-      return { verified: true, outcome: raw.outcome };
+      const r = await postVerify(config, decision.permitToken, decision);
+      if (!r.verified) {
+        throw new EnforceError2(`Permit verification failed (outcome=${r.outcome ?? "unknown"}${r.verifyErrorCode ? `, code=${r.verifyErrorCode}` : ""})`, "verify-permit", decision, { outcome: r.outcome, verifyErrorCode: r.verifyErrorCode, mismatchFields: r.mismatchFields });
+      }
+      return r;
+    }
+    async function reverifyPermit2(config, permitToken) {
+      if (!permitToken || !permitToken.trim()) {
+        throw new EnforceError2("no permit_token presented at execution boundary \u2014 refusing to execute", "verify-permit", null, { outcome: "invalid", verifyErrorCode: "MISSING_PERMIT" });
+      }
+      const r = await postVerify(config, permitToken, null);
+      if (!r.verified) {
+        throw new EnforceError2(`Permit re-verification failed at execution boundary (outcome=${r.outcome ?? "unknown"}${r.verifyErrorCode ? `, code=${r.verifyErrorCode}` : ""})`, "verify-permit", null, { outcome: r.outcome, verifyErrorCode: r.verifyErrorCode, mismatchFields: r.mismatchFields });
+      }
+      return r;
     }
     async function enforce2(config, fn) {
       const decision = await evaluate(config);
@@ -1929,6 +1970,55 @@ var VALID_SEVERITIES = [
   "high",
   "blocker"
 ];
+async function runVerifyPermitStep(apiKey, apiUrl) {
+  const permitToken = getInput("permit-token", true);
+  const rawActionType = getInput("action", true);
+  const actionType = normalizeAndValidateProtectedAction(rawActionType);
+  const actor = getInput("actor") || "unknown";
+  const targetId = getInput("target-id") || void 0;
+  const artifactDigest = getInput("artifact-digest") || void 0;
+  const gh = getGitHubContext();
+  const environment = resolveEnvironment(getInput("environment"), gh.ref, apiKey);
+  maskValue(permitToken);
+  const config = {
+    apiKey,
+    apiUrl,
+    action: actionType,
+    actor: `github:${actor}`,
+    environment,
+    targetId,
+    executionPayloadHash: artifactDigest
+  };
+  info(
+    `AtlaSent boundary re-verification: "${actionType}" for "github:${actor}" in ${environment}` + (artifactDigest ? ` (artifact=${artifactDigest})` : "")
+  );
+  try {
+    const r = await (0, import_enforce3.reverifyPermit)(config, permitToken);
+    setOutput("decision", "allow");
+    setOutput("verified", "true");
+    setOutput("verify-outcome", r.outcome ?? "verified");
+    setOutput("verify-error-code", "");
+    setOutput("permit-token", permitToken);
+    info(
+      `Permit re-verified at the execution boundary (outcome=${r.outcome ?? "verified"}). Deployment may proceed.`
+    );
+  } catch (err) {
+    setOutput("decision", "deny");
+    setOutput("verified", "false");
+    if (err instanceof import_enforce3.EnforceError) {
+      setOutput("verify-outcome", err.outcome ?? "invalid");
+      setOutput("verify-error-code", err.verifyErrorCode ?? "");
+      setFailed(
+        `Deploy blocked at execution boundary (outcome=${err.outcome ?? "unknown"}${err.verifyErrorCode ? `, code=${err.verifyErrorCode}` : ""}): ${err.message}`
+      );
+    }
+    setOutput("verify-outcome", "invalid");
+    setOutput("verify-error-code", "");
+    setFailed(
+      `Deploy blocked at execution boundary: ${err instanceof Error ? err.message : String(err)}`
+    );
+  }
+}
 async function runGovernanceAgentsStep(apiKey, apiUrl) {
   const slugsRaw = getInput("governance-agents", true);
   const agentSlugs = slugsRaw.split(",").map((s) => s.trim()).filter((s) => s.length > 0);
@@ -2290,6 +2380,10 @@ async function run() {
     await runGovernanceAgentsStep(apiKey, apiUrl);
     return;
   }
+  if (getInput("verify-permit").toLowerCase() === "true") {
+    await runVerifyPermitStep(apiKey, apiUrl);
+    return;
+  }
   const evaluationsRaw = getInput("evaluations");
   if (evaluationsRaw) {
     const waitForId = getInput("wait-for-id") || void 0;
@@ -2416,6 +2510,7 @@ async function run() {
       warn: warning
     });
   }
+  const artifactDigest = getInput("artifact-digest") || void 0;
   const config = {
     apiKey,
     apiUrl,
@@ -2423,6 +2518,9 @@ async function run() {
     actor: `github:${actor}`,
     environment,
     targetId,
+    // Canonical artifact binding — the runtime binds this into the permit and
+    // re-checks it at verify time (artifact-substitution defense).
+    executionPayloadHash: artifactDigest,
     // state_snapshot is required for all action classes (requires_state_snapshot=true).
     // Auto-populate from GitHub Actions context; callers can override via the context input.
     state_snapshot: {
@@ -2468,6 +2566,8 @@ async function run() {
         setOutput("audit-hash", "");
       }
       setOutput("verified", "false");
+      setOutput("verify-outcome", err.outcome ?? "");
+      setOutput("verify-error-code", err.verifyErrorCode ?? "");
       setOutput("evidence-receipt", JSON.stringify(null));
       setOutput("evidence-bundle", JSON.stringify(null));
       {
@@ -2624,6 +2724,8 @@ async function run() {
   const { decision: d, verifyOutcome } = enforceResult;
   setDecisionOutputs(d);
   setOutput("verified", "true");
+  setOutput("verify-outcome", verifyOutcome ?? "verified");
+  setOutput("verify-error-code", "");
   await postCommitStatus({
     repository: gh.repository,
     sha: gh.sha,

--- a/packages/enforce/dist/index.d.ts
+++ b/packages/enforce/dist/index.d.ts
@@ -34,6 +34,16 @@ export interface EnforceConfig {
         run_id?: string;
         payload?: unknown;
     };
+    /**
+     * SHA-256 digest of the artifact being authorized (canonical input, NOT
+     * presentation metadata). Sent to evaluate as the top-level
+     * `execution_payload_hash`, which the runtime binds into the permit
+     * (`execution_hash_expected`). Re-presented at verify time as `payload_hash`
+     * — a permit issued for one artifact then presented for another fails with
+     * `PAYLOAD_MISMATCH`. This is what stops a workflow evaluating one artifact
+     * and executing a different one.
+     */
+    executionPayloadHash?: string;
 }
 export interface Decision {
     decision: "allow" | "deny" | "hold" | "escalate";
@@ -77,16 +87,30 @@ export interface Decision {
 export interface VerifyPermitResult {
     verified: boolean;
     outcome?: string;
+    /** Precise runtime wire code (e.g. PAYLOAD_MISMATCH, PERMIT_EXPIRED). */
+    verifyErrorCode?: string;
+    /** Fields that diverged between the presented context and the bound permit. */
+    mismatchFields?: string[];
 }
 export type EnforcePhase = "evaluate" | "verify" | "verify-permit" | "execute";
 export declare class EnforceError extends Error {
     readonly phase: EnforcePhase;
     readonly decision: Decision | null;
-    constructor(message: string, phase: EnforcePhase, decision?: Decision | null);
+    /** Coarse verify outcome (verified | mismatch | expired | replay_blocked | invalid | …). */
+    readonly outcome?: string;
+    /** Precise verify wire code, when the failure came from verify-permit. */
+    readonly verifyErrorCode?: string;
+    readonly mismatchFields?: string[];
+    constructor(message: string, phase: EnforcePhase, decision?: Decision | null, details?: {
+        outcome?: string;
+        verifyErrorCode?: string;
+        mismatchFields?: string[];
+    });
 }
 export declare function evaluate(config: EnforceConfig): Promise<Decision>;
 export declare function verify(decision: Decision): void;
 export declare function verifyPermit(config: EnforceConfig, decision: Decision): Promise<VerifyPermitResult>;
+export declare function reverifyPermit(config: EnforceConfig, permitToken: string): Promise<VerifyPermitResult>;
 export declare function enforce<T>(config: EnforceConfig, fn: () => Promise<T>): Promise<{
     result: T;
     decision: Decision;

--- a/packages/enforce/dist/index.js
+++ b/packages/enforce/dist/index.js
@@ -11,17 +11,26 @@ exports.EnforceError = void 0;
 exports.evaluate = evaluate;
 exports.verify = verify;
 exports.verifyPermit = verifyPermit;
+exports.reverifyPermit = reverifyPermit;
 exports.enforce = enforce;
 const transport_1 = require("./transport");
 const DEFAULT_API_URL = "https://api.atlasent.io";
 class EnforceError extends Error {
     phase;
     decision;
-    constructor(message, phase, decision = null) {
+    /** Coarse verify outcome (verified | mismatch | expired | replay_blocked | invalid | …). */
+    outcome;
+    /** Precise verify wire code, when the failure came from verify-permit. */
+    verifyErrorCode;
+    mismatchFields;
+    constructor(message, phase, decision = null, details) {
         super(message);
         this.name = "EnforceError";
         this.phase = phase;
         this.decision = decision;
+        this.outcome = details?.outcome;
+        this.verifyErrorCode = details?.verifyErrorCode;
+        this.mismatchFields = details?.mismatchFields;
     }
 }
 exports.EnforceError = EnforceError;
@@ -61,6 +70,11 @@ async function evaluate(config) {
     const snap = config.state_snapshot ?? contextSnapshot;
     if (snap != null)
         payload["state_snapshot"] = snap;
+    // Artifact digest is a canonical top-level input — the runtime binds it into
+    // the permit (execution_hash_expected). Never buried in context/presentation.
+    if (config.executionPayloadHash != null) {
+        payload["execution_payload_hash"] = config.executionPayloadHash;
+    }
     let status;
     let body;
     try {
@@ -109,26 +123,32 @@ function verify(decision) {
             throw new EnforceError(`Unknown decision: ${String(decision.decision)}`, "verify", decision);
     }
 }
-// ---------------------------------------------------------------------------
-// Step 3 — verifyPermit (calls /v1-verify-permit, fail-closed)
-//
-// Without this round-trip the enforce wrapper is evaluate-only: a tampered or
-// replayed permit_token would still surface decision=allow. This step consumes
-// the token — downstream re-verify returns outcome=permit_consumed.
-// ---------------------------------------------------------------------------
-async function verifyPermit(config, decision) {
-    if (!decision.permitToken) {
-        throw new EnforceError("evaluate returned allow but no permit_token — refusing to execute without verifiable permit", "verify-permit", decision);
-    }
+/**
+ * Shared HTTP core for permit verification. Sends the permit token AND re-binds
+ * the execution context (environment, target, artifact digest) so verification
+ * checks the caller is executing the SAME artifact/environment the permit was
+ * issued for. Returns a normalized result (does not throw on verified=false —
+ * the caller applies the fail-closed decision).
+ */
+async function postVerify(config, permitToken, decision) {
     const apiUrl = (config.apiUrl ?? DEFAULT_API_URL).replace(/\/$/, "");
+    const bodyObj = {
+        permit_token: permitToken,
+        action_type: config.action,
+        actor_id: config.actor,
+    };
+    if (config.environment != null)
+        bodyObj["environment"] = config.environment;
+    if (config.targetId != null)
+        bodyObj["target_id"] = config.targetId;
+    if (config.executionPayloadHash != null)
+        bodyObj["payload_hash"] = config.executionPayloadHash;
     let status;
     let body;
     try {
-        ({ status, body } = await (0, transport_1.post)(`${apiUrl}/v1-verify-permit`, JSON.stringify({
-            permit_token: decision.permitToken,
-            action_type: config.action,
-            actor_id: config.actor,
-        }), { Authorization: `Bearer ${config.apiKey}` }));
+        ({ status, body } = await (0, transport_1.post)(`${apiUrl}/v1-verify-permit`, JSON.stringify(bodyObj), {
+            Authorization: `Bearer ${config.apiKey}`,
+        }));
     }
     catch (err) {
         throw new EnforceError(`verify-permit unreachable: ${err instanceof Error ? err.message : String(err)}`, "verify-permit", decision);
@@ -146,11 +166,44 @@ async function verifyPermit(config, decision) {
     catch {
         throw new EnforceError("Non-JSON response from verify-permit", "verify-permit", decision);
     }
-    if (raw.verified !== true) {
-        // outcome=permit_consumed (replay), permit_expired, etc.
-        throw new EnforceError(`Permit verification failed (outcome=${raw.outcome ?? "unknown"})`, "verify-permit", decision);
+    // Runtime wire field is `valid`; older responses used `verified`. Accept both.
+    const ok = raw.valid ?? raw.verified;
+    return {
+        verified: ok === true,
+        outcome: raw.outcome,
+        verifyErrorCode: raw.verify_error_code,
+        mismatchFields: Array.isArray(raw.mismatch_fields) ? raw.mismatch_fields : undefined,
+    };
+}
+async function verifyPermit(config, decision) {
+    if (!decision.permitToken) {
+        throw new EnforceError("evaluate returned allow but no permit_token — refusing to execute without verifiable permit", "verify-permit", decision);
     }
-    return { verified: true, outcome: raw.outcome };
+    const r = await postVerify(config, decision.permitToken, decision);
+    if (!r.verified) {
+        // outcome=replay_blocked (replay), expired, mismatch (wrong artifact/env), etc.
+        throw new EnforceError(`Permit verification failed (outcome=${r.outcome ?? "unknown"}${r.verifyErrorCode ? `, code=${r.verifyErrorCode}` : ""})`, "verify-permit", decision, { outcome: r.outcome, verifyErrorCode: r.verifyErrorCode, mismatchFields: r.mismatchFields });
+    }
+    return r;
+}
+// ---------------------------------------------------------------------------
+// Step 3b — reverifyPermit (re-verify at the EXECUTION BOUNDARY)
+//
+// Re-verify an already-issued permit immediately before the protected step,
+// independent of the gate that issued it — so a workflow cannot evaluate one
+// artifact and execute another, and a missing / modified / expired / replayed /
+// context-mismatched permit fails closed AT THE BOUNDARY. Pass the artifact
+// digest via config.executionPayloadHash and the environment via config.environment.
+// ---------------------------------------------------------------------------
+async function reverifyPermit(config, permitToken) {
+    if (!permitToken || !permitToken.trim()) {
+        throw new EnforceError("no permit_token presented at execution boundary — refusing to execute", "verify-permit", null, { outcome: "invalid", verifyErrorCode: "MISSING_PERMIT" });
+    }
+    const r = await postVerify(config, permitToken, null);
+    if (!r.verified) {
+        throw new EnforceError(`Permit re-verification failed at execution boundary (outcome=${r.outcome ?? "unknown"}${r.verifyErrorCode ? `, code=${r.verifyErrorCode}` : ""})`, "verify-permit", null, { outcome: r.outcome, verifyErrorCode: r.verifyErrorCode, mismatchFields: r.mismatchFields });
+    }
+    return r;
 }
 // ---------------------------------------------------------------------------
 // Step 4 — enforce (evaluate → verify → verifyPermit → execute, fail-closed)

--- a/packages/enforce/src/__tests__/reverify.test.ts
+++ b/packages/enforce/src/__tests__/reverify.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { reverifyPermit, verifyPermit, evaluate, EnforceError } from "../index";
+import type { Decision, EnforceConfig } from "../index";
+
+vi.mock("../transport", () => ({ post: vi.fn() }));
+import { post } from "../transport";
+const mockPost = post as ReturnType<typeof vi.fn>;
+
+const CONFIG: EnforceConfig = {
+  apiKey: "ask_test_key",
+  apiUrl: "https://api.test",
+  action: "production.deploy",
+  actor: "github:github-actions[bot]",
+  environment: "production",
+  targetId: "service:hello-safeguard",
+  executionPayloadHash: "sha256:artifact-A",
+};
+
+function resp(status: number, body: unknown) {
+  mockPost.mockResolvedValueOnce({ status, body: JSON.stringify(body) });
+}
+function lastBody(): Record<string, unknown> {
+  const call = mockPost.mock.calls[mockPost.mock.calls.length - 1];
+  return JSON.parse(call[1] as string) as Record<string, unknown>;
+}
+
+describe("execution-boundary verification (B3/B4)", () => {
+  beforeEach(() => mockPost.mockReset());
+  afterEach(() => vi.restoreAllMocks());
+
+  // ── artifact digest is a canonical evaluate input ──────────────────────────
+  it("evaluate sends the artifact digest as top-level execution_payload_hash", async () => {
+    resp(200, { decision: "allow", permit_token: "pt-1" });
+    await evaluate(CONFIG);
+    const body = lastBody();
+    expect(body.execution_payload_hash).toBe("sha256:artifact-A");
+    // never buried in context/presentation
+    expect((body.context as Record<string, unknown>).execution_payload_hash).toBeUndefined();
+  });
+
+  // ── verify re-binds environment + artifact digest at the boundary ──────────
+  it("reverifyPermit re-binds environment + payload_hash + target at verify", async () => {
+    resp(200, { valid: true, outcome: "verified" });
+    await reverifyPermit(CONFIG, "pt-1");
+    const body = lastBody();
+    expect(body.permit_token).toBe("pt-1");
+    expect(body.action_type).toBe("production.deploy");
+    expect(body.environment).toBe("production");
+    expect(body.payload_hash).toBe("sha256:artifact-A");
+    expect(body.target_id).toBe("service:hello-safeguard");
+  });
+
+  // ── reads the runtime `valid` field (not the legacy `verified`) ────────────
+  it("treats runtime {valid:true} as verified", async () => {
+    resp(200, { valid: true, outcome: "verified" });
+    const r = await reverifyPermit(CONFIG, "pt-1");
+    expect(r.verified).toBe(true);
+    expect(r.outcome).toBe("verified");
+  });
+
+  it("still accepts the legacy {verified:true} field", async () => {
+    resp(200, { verified: true, outcome: "ok" });
+    const r = await reverifyPermit(CONFIG, "pt-1");
+    expect(r.verified).toBe(true);
+  });
+
+  // ── THE artifact-substitution attack: evaluate A, execute B → fail closed ──
+  it("blocks an altered artifact (PAYLOAD_MISMATCH) at the boundary", async () => {
+    // runtime rejects because the presented payload_hash != the bound one
+    resp(200, { valid: false, outcome: "mismatch", verify_error_code: "PAYLOAD_MISMATCH", mismatch_fields: ["payload_hash"] });
+    const err = await reverifyPermit({ ...CONFIG, executionPayloadHash: "sha256:artifact-B" }, "pt-1")
+      .catch((e: unknown) => e as EnforceError);
+    expect(err).toBeInstanceOf(EnforceError);
+    expect(err.phase).toBe("verify-permit");
+    expect(err.outcome).toBe("mismatch");
+    expect(err.verifyErrorCode).toBe("PAYLOAD_MISMATCH");
+    expect(err.mismatchFields).toEqual(["payload_hash"]);
+  });
+
+  // ── wrong environment → fail closed ────────────────────────────────────────
+  it("blocks a wrong-environment permit (ENVIRONMENT_MISMATCH)", async () => {
+    resp(200, { valid: false, outcome: "mismatch", verify_error_code: "ENVIRONMENT_MISMATCH", mismatch_fields: ["environment"] });
+    const err = await reverifyPermit({ ...CONFIG, environment: "staging" }, "pt-1").catch((e: unknown) => e as EnforceError);
+    expect(err.verifyErrorCode).toBe("ENVIRONMENT_MISMATCH");
+  });
+
+  // ── missing / expired / replayed → fail closed ─────────────────────────────
+  it("fails closed with MISSING_PERMIT when no token is presented", async () => {
+    const err = await reverifyPermit(CONFIG, "").catch((e: unknown) => e as EnforceError);
+    expect(err.verifyErrorCode).toBe("MISSING_PERMIT");
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+
+  it("blocks an expired permit (PERMIT_EXPIRED)", async () => {
+    resp(200, { valid: false, outcome: "expired", verify_error_code: "PERMIT_EXPIRED" });
+    const err = await reverifyPermit(CONFIG, "pt-1").catch((e: unknown) => e as EnforceError);
+    expect(err.outcome).toBe("expired");
+    expect(err.verifyErrorCode).toBe("PERMIT_EXPIRED");
+  });
+
+  it("blocks a replayed permit (PERMIT_ALREADY_USED / replay_blocked)", async () => {
+    resp(200, { valid: false, outcome: "replay_blocked", verify_error_code: "PERMIT_ALREADY_USED" });
+    const err = await reverifyPermit(CONFIG, "pt-1").catch((e: unknown) => e as EnforceError);
+    expect(err.outcome).toBe("replay_blocked");
+    expect(err.verifyErrorCode).toBe("PERMIT_ALREADY_USED");
+  });
+
+  // ── verifyPermit (gate path) also surfaces the code + reads valid ──────────
+  it("verifyPermit surfaces verify_error_code and reads valid", async () => {
+    resp(200, { valid: false, outcome: "mismatch", verify_error_code: "PAYLOAD_MISMATCH" });
+    const decision: Decision = { decision: "allow", permitToken: "pt-1" };
+    const err = await verifyPermit(CONFIG, decision).catch((e: unknown) => e as EnforceError);
+    expect(err.verifyErrorCode).toBe("PAYLOAD_MISMATCH");
+    expect(err.outcome).toBe("mismatch");
+  });
+});

--- a/packages/enforce/src/index.ts
+++ b/packages/enforce/src/index.ts
@@ -44,6 +44,16 @@ export interface EnforceConfig {
     run_id?: string;
     payload?: unknown;
   };
+  /**
+   * SHA-256 digest of the artifact being authorized (canonical input, NOT
+   * presentation metadata). Sent to evaluate as the top-level
+   * `execution_payload_hash`, which the runtime binds into the permit
+   * (`execution_hash_expected`). Re-presented at verify time as `payload_hash`
+   * — a permit issued for one artifact then presented for another fails with
+   * `PAYLOAD_MISMATCH`. This is what stops a workflow evaluating one artifact
+   * and executing a different one.
+   */
+  executionPayloadHash?: string;
 }
 
 export interface Decision {
@@ -80,6 +90,10 @@ export interface Decision {
 export interface VerifyPermitResult {
   verified: boolean;
   outcome?: string;
+  /** Precise runtime wire code (e.g. PAYLOAD_MISMATCH, PERMIT_EXPIRED). */
+  verifyErrorCode?: string;
+  /** Fields that diverged between the presented context and the bound permit. */
+  mismatchFields?: string[];
 }
 
 export type EnforcePhase = "evaluate" | "verify" | "verify-permit" | "execute";
@@ -87,12 +101,25 @@ export type EnforcePhase = "evaluate" | "verify" | "verify-permit" | "execute";
 export class EnforceError extends Error {
   readonly phase: EnforcePhase;
   readonly decision: Decision | null;
+  /** Coarse verify outcome (verified | mismatch | expired | replay_blocked | invalid | …). */
+  readonly outcome?: string;
+  /** Precise verify wire code, when the failure came from verify-permit. */
+  readonly verifyErrorCode?: string;
+  readonly mismatchFields?: string[];
 
-  constructor(message: string, phase: EnforcePhase, decision: Decision | null = null) {
+  constructor(
+    message: string,
+    phase: EnforcePhase,
+    decision: Decision | null = null,
+    details?: { outcome?: string; verifyErrorCode?: string; mismatchFields?: string[] },
+  ) {
     super(message);
     this.name = "EnforceError";
     this.phase = phase;
     this.decision = decision;
+    this.outcome = details?.outcome;
+    this.verifyErrorCode = details?.verifyErrorCode;
+    this.mismatchFields = details?.mismatchFields;
   }
 }
 
@@ -128,6 +155,11 @@ export async function evaluate(config: EnforceConfig): Promise<Decision> {
   // state_snapshot is a top-level body field (EvaluateBody.state_snapshot), not inside context.
   const snap = config.state_snapshot ?? contextSnapshot;
   if (snap != null) payload["state_snapshot"] = snap;
+  // Artifact digest is a canonical top-level input — the runtime binds it into
+  // the permit (execution_hash_expected). Never buried in context/presentation.
+  if (config.executionPayloadHash != null) {
+    payload["execution_payload_hash"] = config.executionPayloadHash;
+  }
 
   let status: number;
   let body: string;
@@ -204,6 +236,75 @@ export function verify(decision: Decision): void {
 // the token — downstream re-verify returns outcome=permit_consumed.
 // ---------------------------------------------------------------------------
 
+interface RawVerify {
+  valid?: boolean;
+  verified?: boolean; // legacy field name — accepted for backward compat
+  outcome?: string;
+  verify_error_code?: string;
+  mismatch_fields?: string[];
+}
+
+/**
+ * Shared HTTP core for permit verification. Sends the permit token AND re-binds
+ * the execution context (environment, target, artifact digest) so verification
+ * checks the caller is executing the SAME artifact/environment the permit was
+ * issued for. Returns a normalized result (does not throw on verified=false —
+ * the caller applies the fail-closed decision).
+ */
+async function postVerify(
+  config: EnforceConfig,
+  permitToken: string,
+  decision: Decision | null,
+): Promise<VerifyPermitResult> {
+  const apiUrl = (config.apiUrl ?? DEFAULT_API_URL).replace(/\/$/, "");
+
+  const bodyObj: Record<string, unknown> = {
+    permit_token: permitToken,
+    action_type: config.action,
+    actor_id: config.actor,
+  };
+  if (config.environment != null) bodyObj["environment"] = config.environment;
+  if (config.targetId != null) bodyObj["target_id"] = config.targetId;
+  if (config.executionPayloadHash != null) bodyObj["payload_hash"] = config.executionPayloadHash;
+
+  let status: number;
+  let body: string;
+  try {
+    ({ status, body } = await post(`${apiUrl}/v1-verify-permit`, JSON.stringify(bodyObj), {
+      Authorization: `Bearer ${config.apiKey}`,
+    }));
+  } catch (err) {
+    throw new EnforceError(
+      `verify-permit unreachable: ${err instanceof Error ? err.message : String(err)}`,
+      "verify-permit",
+      decision,
+    );
+  }
+
+  if (status >= 500) {
+    throw new EnforceError(`verify-permit infrastructure failure (HTTP ${status})`, "verify-permit", decision);
+  }
+  if (status < 200 || status >= 300) {
+    throw new EnforceError(`verify-permit failed (HTTP ${status})`, "verify-permit", decision);
+  }
+
+  let raw: RawVerify;
+  try {
+    raw = JSON.parse(body) as RawVerify;
+  } catch {
+    throw new EnforceError("Non-JSON response from verify-permit", "verify-permit", decision);
+  }
+
+  // Runtime wire field is `valid`; older responses used `verified`. Accept both.
+  const ok = raw.valid ?? raw.verified;
+  return {
+    verified: ok === true,
+    outcome: raw.outcome,
+    verifyErrorCode: raw.verify_error_code,
+    mismatchFields: Array.isArray(raw.mismatch_fields) ? raw.mismatch_fields : undefined,
+  };
+}
+
 export async function verifyPermit(
   config: EnforceConfig,
   decision: Decision,
@@ -216,64 +317,51 @@ export async function verifyPermit(
     );
   }
 
-  const apiUrl = (config.apiUrl ?? DEFAULT_API_URL).replace(/\/$/, "");
-
-  let status: number;
-  let body: string;
-  try {
-    ({ status, body } = await post(
-      `${apiUrl}/v1-verify-permit`,
-      JSON.stringify({
-        permit_token: decision.permitToken,
-        action_type: config.action,
-        actor_id: config.actor,
-      }),
-      { Authorization: `Bearer ${config.apiKey}` },
-    ));
-  } catch (err) {
+  const r = await postVerify(config, decision.permitToken, decision);
+  if (!r.verified) {
+    // outcome=replay_blocked (replay), expired, mismatch (wrong artifact/env), etc.
     throw new EnforceError(
-      `verify-permit unreachable: ${err instanceof Error ? err.message : String(err)}`,
+      `Permit verification failed (outcome=${r.outcome ?? "unknown"}${r.verifyErrorCode ? `, code=${r.verifyErrorCode}` : ""})`,
       "verify-permit",
       decision,
+      { outcome: r.outcome, verifyErrorCode: r.verifyErrorCode, mismatchFields: r.mismatchFields },
     );
   }
+  return r;
+}
 
-  if (status >= 500) {
-    throw new EnforceError(
-      `verify-permit infrastructure failure (HTTP ${status})`,
-      "verify-permit",
-      decision,
-    );
-  }
-  if (status < 200 || status >= 300) {
-    throw new EnforceError(
-      `verify-permit failed (HTTP ${status})`,
-      "verify-permit",
-      decision,
-    );
-  }
+// ---------------------------------------------------------------------------
+// Step 3b — reverifyPermit (re-verify at the EXECUTION BOUNDARY)
+//
+// Re-verify an already-issued permit immediately before the protected step,
+// independent of the gate that issued it — so a workflow cannot evaluate one
+// artifact and execute another, and a missing / modified / expired / replayed /
+// context-mismatched permit fails closed AT THE BOUNDARY. Pass the artifact
+// digest via config.executionPayloadHash and the environment via config.environment.
+// ---------------------------------------------------------------------------
 
-  let raw: { verified?: boolean; outcome?: string };
-  try {
-    raw = JSON.parse(body) as { verified?: boolean; outcome?: string };
-  } catch {
+export async function reverifyPermit(
+  config: EnforceConfig,
+  permitToken: string,
+): Promise<VerifyPermitResult> {
+  if (!permitToken || !permitToken.trim()) {
     throw new EnforceError(
-      "Non-JSON response from verify-permit",
+      "no permit_token presented at execution boundary — refusing to execute",
       "verify-permit",
-      decision,
+      null,
+      { outcome: "invalid", verifyErrorCode: "MISSING_PERMIT" },
     );
   }
-
-  if (raw.verified !== true) {
-    // outcome=permit_consumed (replay), permit_expired, etc.
+  const r = await postVerify(config, permitToken, null);
+  if (!r.verified) {
     throw new EnforceError(
-      `Permit verification failed (outcome=${raw.outcome ?? "unknown"})`,
+      `Permit re-verification failed at execution boundary (outcome=${r.outcome ?? "unknown"}${r.verifyErrorCode ? `, code=${r.verifyErrorCode}` : ""})`,
       "verify-permit",
-      decision,
+      null,
+      { outcome: r.outcome, verifyErrorCode: r.verifyErrorCode, mismatchFields: r.mismatchFields },
     );
   }
-
-  return { verified: true, outcome: raw.outcome };
+  return r;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@
 // masking secrets, and translating EnforceResult / EnforceError into step
 // outputs and exit codes.
 
-import { enforce, EnforceError } from "@atlasent/enforce";
+import { enforce, reverifyPermit, EnforceError } from "@atlasent/enforce";
 import type { Decision, EnforceConfig } from "@atlasent/enforce";
 import { GateInfraError } from "./gate";
 import { runV21 } from "./v21";
@@ -549,6 +549,68 @@ const VALID_SEVERITIES: readonly AgentSeverity[] = [
   "blocker",
 ];
 
+// ── Verify-permit (execution boundary) step ──────────────────────────────────
+//
+// Re-verifies an existing permit immediately before the protected step. The
+// artifact digest + environment are re-bound at verify time so a permit issued
+// for one artifact/environment cannot authorize another. Fails closed on any
+// missing / modified / expired / replayed / denied / mismatched permit.
+async function runVerifyPermitStep(apiKey: string, apiUrl: string): Promise<void> {
+  const permitToken = getInput("permit-token", true);
+  const rawActionType = getInput("action", true);
+  const actionType = normalizeAndValidateProtectedAction(rawActionType);
+  const actor = getInput("actor") || "unknown";
+  const targetId = getInput("target-id") || undefined;
+  const artifactDigest = getInput("artifact-digest") || undefined;
+  const gh = getGitHubContext();
+  const environment = resolveEnvironment(getInput("environment"), gh.ref, apiKey);
+
+  maskValue(permitToken);
+
+  const config: EnforceConfig = {
+    apiKey,
+    apiUrl,
+    action: actionType,
+    actor: `github:${actor}`,
+    environment,
+    targetId,
+    executionPayloadHash: artifactDigest,
+  };
+
+  info(
+    `AtlaSent boundary re-verification: "${actionType}" for "github:${actor}" in ${environment}` +
+      (artifactDigest ? ` (artifact=${artifactDigest})` : ""),
+  );
+
+  try {
+    const r = await reverifyPermit(config, permitToken);
+    setOutput("decision", "allow");
+    setOutput("verified", "true");
+    setOutput("verify-outcome", r.outcome ?? "verified");
+    setOutput("verify-error-code", "");
+    setOutput("permit-token", permitToken);
+    info(
+      `Permit re-verified at the execution boundary (outcome=${r.outcome ?? "verified"}). Deployment may proceed.`,
+    );
+  } catch (err) {
+    setOutput("decision", "deny");
+    setOutput("verified", "false");
+    if (err instanceof EnforceError) {
+      setOutput("verify-outcome", err.outcome ?? "invalid");
+      setOutput("verify-error-code", err.verifyErrorCode ?? "");
+      setFailed(
+        `Deploy blocked at execution boundary (outcome=${err.outcome ?? "unknown"}` +
+          `${err.verifyErrorCode ? `, code=${err.verifyErrorCode}` : ""}): ${err.message}`,
+      );
+    }
+    setOutput("verify-outcome", "invalid");
+    setOutput("verify-error-code", "");
+    setFailed(
+      `Deploy blocked at execution boundary: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
 async function runGovernanceAgentsStep(apiKey: string, apiUrl: string): Promise<void> {
   const slugsRaw = getInput("governance-agents", true);
   const agentSlugs = slugsRaw
@@ -1010,6 +1072,17 @@ export async function run(): Promise<void> {
     return;
   }
 
+  // ── Verify-permit path (execution boundary) ─────────────────────────────────
+  //
+  // Re-verify an already-issued permit immediately before the protected step,
+  // independent of the gate that issued it. Fails closed on any missing /
+  // modified / expired / replayed / denied / context-mismatched permit — so a
+  // workflow cannot evaluate one artifact and execute another.
+  if (getInput("verify-permit").toLowerCase() === "true") {
+    await runVerifyPermitStep(apiKey, apiUrl);
+    return;
+  }
+
   // ── v2.1 batch path (scope-excluded from this unification) ─────────────────
   const evaluationsRaw = getInput("evaluations");
   if (evaluationsRaw) {
@@ -1173,6 +1246,8 @@ export async function run(): Promise<void> {
     });
   }
 
+  const artifactDigest = getInput("artifact-digest") || undefined;
+
   const config: EnforceConfig = {
     apiKey,
     apiUrl,
@@ -1180,6 +1255,9 @@ export async function run(): Promise<void> {
     actor: `github:${actor}`,
     environment,
     targetId,
+    // Canonical artifact binding — the runtime binds this into the permit and
+    // re-checks it at verify time (artifact-substitution defense).
+    executionPayloadHash: artifactDigest,
     // state_snapshot is required for all action classes (requires_state_snapshot=true).
     // Auto-populate from GitHub Actions context; callers can override via the context input.
     state_snapshot: {
@@ -1227,6 +1305,8 @@ export async function run(): Promise<void> {
         setOutput("audit-hash", "");
       }
       setOutput("verified", "false");
+      setOutput("verify-outcome", err.outcome ?? "");
+      setOutput("verify-error-code", err.verifyErrorCode ?? "");
       setOutput("evidence-receipt", JSON.stringify(null));
       setOutput("evidence-bundle", JSON.stringify(null));
 
@@ -1426,6 +1506,8 @@ export async function run(): Promise<void> {
   const { decision: d, verifyOutcome } = enforceResult;
   setDecisionOutputs(d);
   setOutput("verified", "true");
+  setOutput("verify-outcome", verifyOutcome ?? "verified");
+  setOutput("verify-error-code", "");
 
   // Fallback commit status for orgs without the full GitHub App installation.
   // Best-effort: failure to post never blocks the gate.


### PR DESCRIPTION
## Summary

Completes the **reusable enforcement contract** (READINESS.md **B3/B4**) so the published action makes "verify at the execution boundary" authoritative, not merely demonstrated in the reference workflow. **A workflow can no longer evaluate one artifact and execute another.** Independently reviewable — no dependency on the console work.

### `@atlasent/enforce` (the contract)
- **`EnforceConfig.executionPayloadHash`** — the artifact digest, sent to evaluate as the **canonical top-level `execution_payload_hash`** (never buried in context). The runtime binds it into the permit (`execution_hash_expected`).
- **`verifyPermit` now re-binds the execution context** — sends `environment` + `payload_hash` + `target_id`, not just `action` + `actor` — so a permit for one environment/artifact cannot authorize another.
- **New `reverifyPermit(config, permitToken)`** — the execution-boundary primitive. Re-verifies an already-issued permit immediately before the protected step, independent of the gate that issued it. Fails closed on missing / modified / expired / replayed / denied / context-mismatched permits.
- **Fix:** read the runtime `valid` field. The code was reading `verified`, which the runtime **never emits** — so the published action's permit verification only ever "passed" against mocks. Legacy `verified` still accepted for backward compat.
- Capture `verify_error_code` + `mismatch_fields`; surface via `VerifyPermitResult` and `EnforceError` (`outcome` / `verifyErrorCode` / `mismatchFields`).

### Action surface (additive, opt-in — existing gate workflows unchanged)
- inputs: **`artifact-digest`**, **`verify-permit`** (boundary mode), **`permit-token`**.
- outputs: **`verify-outcome`**, **`verify-error-code`**.
- single-eval threads `artifact-digest → executionPayloadHash` and surfaces the verify outputs.
- new **verify-permit mode**: re-verify at the deploy boundary, fail closed, emit attributable outputs.

### Betty's B3/B4 acceptance gates → where each is met
| Gate | Where |
|---|---|
| digest supplied through a canonical input, not presentation metadata | `evaluate()` sends top-level `execution_payload_hash`; test asserts it's not in context |
| permit bound to that digest + execution context | runtime binds `execution_hash_expected`; verify re-sends `environment`+`payload_hash`+`target_id` |
| re-verify against live runtime immediately before the protected step | `reverifyPermit` + `verify-permit` action mode (deploy job) |
| missing/modified/expired/replayed/denied/context-mismatched fail closed | `reverify.test.ts` covers each → `EnforceError` |
| verification failure prevents execution | mode calls `setFailed` → step fails → `if: verified=='true'` gate |
| attributable evidence linked to evaluation + permit | outputs `verify-outcome`/`verify-error-code` + `permit-token`; permit references the minting evaluation server-side |
| existing consumers have a compatibility/migration path | everything additive & opt-in; README migration note; legacy `verified` field still accepted |
| tests prove happy path AND artifact-substitution attack | `reverify.test.ts` (evaluate A, verify B → `PAYLOAD_MISMATCH` → fail closed) |

## Test plan
- [x] `npm test` — 341 passing (incl. new `reverify.test.ts`, 10 tests)
- [x] `npm run typecheck` — clean (pinned TS 5.4)
- [x] `npm run build` — `dist/index.js` rebuilt and committed; `@atlasent/enforce` dist rebuilt
- [x] Backward-compat: all 66 pre-existing enforce tests still green
- [ ] Live smoke against a seeded reference org (paired with atlasent-examples #113 acceptance suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LFVuah3mkjFEHsXUA3nb6c

---
_Generated by [Claude Code](https://claude.ai/code/session_01LFVuah3mkjFEHsXUA3nb6c)_